### PR TITLE
Renaming Measure Proxy to Simple

### DIFF
--- a/.changes/unreleased/Features-20230517-104517.yaml
+++ b/.changes/unreleased/Features-20230517-104517.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Renaming measure_proxy to simple
+time: 2023-05-17T10:45:17.611493-05:00
+custom:
+  Author: callum-mcdata
+  Issue: "7"

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -6,7 +6,7 @@ TRANSFORM_OBJECT_NAME_PATTERN = "(?!.*__).*^[a-z][a-z0-9_]*[a-z0-9]$"
 
 
 # Enums
-metric_types_enum_values = ["MEASURE_PROXY", "RATIO", "EXPR", "CUMULATIVE", "DERIVED"]
+metric_types_enum_values = ["SIMPLE", "RATIO", "EXPR", "CUMULATIVE", "DERIVED"]
 metric_types_enum_values += [x.lower() for x in metric_types_enum_values]
 
 entity_type_enum_values = ["PRIMARY", "UNIQUE", "FOREIGN", "NATURAL"]

--- a/dbt_semantic_interfaces/parsing/schemas/metricflow.json
+++ b/dbt_semantic_interfaces/parsing/schemas/metricflow.json
@@ -257,12 +257,12 @@
                 },
                 "type": {
                     "enum": [
-                        "MEASURE_PROXY",
+                        "SIMPLE",
                         "RATIO",
                         "EXPR",
                         "CUMULATIVE",
                         "DERIVED",
-                        "measure_proxy",
+                        "simple",
                         "ratio",
                         "expr",
                         "cumulative",

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -30,7 +30,7 @@ class CreateProxyMeasureRule(ModelTransformRule):
                 add_metric = True
                 for metric in model.metrics:
                     if metric.name == measure.name:
-                        if metric.type != MetricType.MEASURE_PROXY:
+                        if metric.type != MetricType.SIMPLE:
                             raise ModelTransformError(
                                 f"Cannot have metric with the same name as a measure ({measure.name}) that is not a "
                                 f"proxy for that measure"
@@ -45,7 +45,7 @@ class CreateProxyMeasureRule(ModelTransformRule):
                     model.metrics.append(
                         Metric(
                             name=measure.name,
-                            type=MetricType.MEASURE_PROXY,
+                            type=MetricType.SIMPLE,
                             type_params=MetricTypeParams(
                                 measures=[MetricInputMeasure(name=measure.name)],
                                 expr=measure.name,

--- a/dbt_semantic_interfaces/type_enums/metric_type.py
+++ b/dbt_semantic_interfaces/type_enums/metric_type.py
@@ -4,7 +4,7 @@ from dbt_semantic_interfaces.enum_extension import ExtendedEnum
 class MetricType(ExtendedEnum):
     """Currently supported metric types."""
 
-    MEASURE_PROXY = "measure_proxy"
+    SIMPLE = "simple"
     RATIO = "ratio"
     EXPR = "expr"
     CUMULATIVE = "cumulative"

--- a/dbt_semantic_interfaces/validations/non_empty.py
+++ b/dbt_semantic_interfaces/validations/non_empty.py
@@ -30,14 +30,14 @@ class NonEmptyRule(ModelValidationRule):
         issues: List[ValidationIssue] = []
 
         # If we are going to generate measure proxy metrics that is sufficient as well
-        create_measure_proxy_metrics = False
+        create_simple_metrics = False
         for semantic_model in model.semantic_models:
             for measure in semantic_model.measures:
                 if measure.create_metric is True:
-                    create_measure_proxy_metrics = True
+                    create_simple_metrics = True
                     break
 
-        if not model.metrics and not create_measure_proxy_metrics:
+        if not model.metrics and not create_simple_metrics:
             issues.append(
                 ValidationError(
                     message="No metrics present in the model.",

--- a/tests/fixtures/model_yamls/simple_model/metrics.yaml
+++ b/tests/fixtures/model_yamls/simple_model/metrics.yaml
@@ -2,7 +2,7 @@
 metric:
   name: "bookings"
   description: "bookings metric"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - bookings
@@ -10,7 +10,7 @@ metric:
 metric:
   name: "average_booking_value"
   description: "average booking value metric"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - average_booking_value
@@ -18,7 +18,7 @@ metric:
 metric:
   name: "instant_bookings"
   description: "instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - instant_bookings
@@ -26,7 +26,7 @@ metric:
 metric:
   name: "booking_value"
   description: "booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value
@@ -34,7 +34,7 @@ metric:
 metric:
   name: "max_booking_value"
   description: "max booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - max_booking_value
@@ -42,7 +42,7 @@ metric:
 metric:
   name: "min_booking_value"
   description: "min booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - min_booking_value
@@ -50,7 +50,7 @@ metric:
 metric:
   name: "instant_booking_value"
   description: "booking value of instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value
@@ -59,7 +59,7 @@ metric:
 metric:
   name: "average_instant_booking_value"
   description: "average booking value of instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - average_booking_value
@@ -68,7 +68,7 @@ metric:
 metric:
   name: "booking_value_for_non_null_listing_id"
   description: "booking value of instant bookings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value
@@ -77,7 +77,7 @@ metric:
 metric:
   name: "bookers"
   description: "bookers"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - bookers
@@ -85,7 +85,7 @@ metric:
 metric:
   name: "booking_payments"
   description: "Booking payments."
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_payments
@@ -93,7 +93,7 @@ metric:
 metric:
   name: "views"
   description: "views"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - views
@@ -101,7 +101,7 @@ metric:
 metric:
   name: "listings"
   description: "listings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - listings
@@ -109,7 +109,7 @@ metric:
 metric:
   name: "lux_listings"
   description: "lux_listings"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - listings
@@ -118,7 +118,7 @@ metric:
 metric:
   name: "smallest_listing"
   description: "smallest listing"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - smallest_listing
@@ -126,7 +126,7 @@ metric:
 metric:
   name: "largest_listing"
   description: "largest listing"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - largest_listing
@@ -134,7 +134,7 @@ metric:
 metric:
   name: "identity_verifications"
   description: "identity_verifications"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - identity_verifications
@@ -142,7 +142,7 @@ metric:
 metric:
   name: "revenue"
   description: "revenue"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - txn_revenue
@@ -246,7 +246,7 @@ metric:
 metric:
   name: "total_account_balance_first_day"
   description: "total_account_balance_first_day"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - total_account_balance_first_day
@@ -254,7 +254,7 @@ metric:
 metric:
   name: "current_account_balance_by_user"
   description: "current_account_balance_by_user"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - current_account_balance_by_user
@@ -345,7 +345,7 @@ metric:
 metric:
   name: "referred_bookings"
   description: "bookings made through a referral"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - referred_bookings
@@ -431,7 +431,7 @@ metric:
 metric:
   name: "median_booking_value"
   description: "median booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - median_booking_value
@@ -439,7 +439,7 @@ metric:
 metric:
   name: "booking_value_p99"
   description: "p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - booking_value_p99
@@ -447,7 +447,7 @@ metric:
 metric:
   name: "discrete_booking_value_p99"
   description: "discrete p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - discrete_booking_value_p99
@@ -455,7 +455,7 @@ metric:
 metric:
   name: "approximate_continuous_booking_value_p99"
   description: "approximate continuous p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - approximate_continuous_booking_value_p99
@@ -463,7 +463,7 @@ metric:
 metric:
   name: "approximate_discrete_booking_value_p99"
   description: "approximate discrete p99 booking value"
-  type: measure_proxy
+  type: simple
   type_params:
     measures:
       - approximate_discrete_booking_value_p99

--- a/tests/parsing/test_metadata_parsing.py
+++ b/tests/parsing/test_metadata_parsing.py
@@ -42,7 +42,7 @@ def test_metric_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> 
 
 
 @pytest.mark.skip("TODO: Determine what to do with measure proxy metric metadata")
-def test_metric_metadata_parsing_with_measure_proxy(
+def test_metric_metadata_parsing_with_simple(
     simple_semantic_manifest: SemanticManifest,
 ) -> None:
     """Tests internal metadata object parsing from a file into the Metric model object via measure proxy.

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -21,7 +21,7 @@ def test_legacy_measure_metric_parsing() -> None:
         """\
         metric:
           name: legacy_test
-          type: measure_proxy
+          type: simple
           type_params:
             measure: legacy_measure
         """
@@ -33,7 +33,7 @@ def test_legacy_measure_metric_parsing() -> None:
     assert len(build_result.model.metrics) == 1
     metric = build_result.model.metrics[0]
     assert metric.name == "legacy_test"
-    assert metric.type is MetricType.MEASURE_PROXY
+    assert metric.type is MetricType.SIMPLE
     assert metric.type_params.measure == MetricInputMeasure(name="legacy_measure")
     assert metric.type_params.measures is None
 
@@ -44,7 +44,7 @@ def test_legacy_metric_input_measure_object_parsing() -> None:
         """\
         metric:
           name: legacy_test
-          type: measure_proxy
+          type: simple
           type_params:
             measure:
               name: legacy_measure_from_object
@@ -69,7 +69,7 @@ def test_metric_metadata_parsing() -> None:
         """\
         metric:
           name: metadata_test
-          type: measure_proxy
+          type: simple
           type_params:
             measures:
               - metadata_test_measure
@@ -87,7 +87,7 @@ def test_metric_metadata_parsing() -> None:
     expected_metadata_content = textwrap.dedent(
         """\
         name: metadata_test
-        type: measure_proxy
+        type: simple
         type_params:
           measures:
           - metadata_test_measure
@@ -334,7 +334,7 @@ def test_constraint_metric_parsing() -> None:
         """\
         metric:
           name: constraint_test
-          type: measure_proxy
+          type: simple
           type_params:
             measures:
               - input_measure
@@ -348,7 +348,7 @@ def test_constraint_metric_parsing() -> None:
     assert len(build_result.model.metrics) == 1
     metric = build_result.model.metrics[0]
     assert metric.name == "constraint_test"
-    assert metric.type is MetricType.MEASURE_PROXY
+    assert metric.type is MetricType.SIMPLE
     assert metric.filter == WhereFilter(where_sql_template="{{ dimension('some_dimension') }} IN ('value1', 'value2')")
 
 

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -56,7 +56,7 @@ def test_semantic_manifest_protocol() -> None:  # noqa: D
     )
     metric = Metric(
         name="test_metric",
-        type=MetricType.MEASURE_PROXY,
+        type=MetricType.SIMPLE,
         type_params=MetricTypeParams(measure=MetricInputMeasure(name="test_measure")),
     )
     semantic_manifest = SemanticManifest(
@@ -97,7 +97,7 @@ class RuntimeCheckableMetric(MetricProtocol, Protocol):
 def test_metric_protocol() -> None:  # noqa: D
     test_metric = Metric(
         name="test_metric",
-        type=MetricType.MEASURE_PROXY,
+        type=MetricType.SIMPLE,
         type_params=MetricTypeParams(measure=MetricInputMeasure(name="test_measure")),
     )
     assert isinstance(test_metric, RuntimeCheckableMetric)

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -67,7 +67,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                 metrics=[
                     metric_with_guaranteed_meta(
                         name=measure_name,
-                        type=MetricType.MEASURE_PROXY,
+                        type=MetricType.SIMPLE,
                         type_params=MetricTypeParams(measures=[measure_name]),
                     )
                 ],
@@ -115,7 +115,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                 metrics=[
                     metric_with_guaranteed_meta(
                         name=measure_name,
-                        type=MetricType.MEASURE_PROXY,
+                        type=MetricType.SIMPLE,
                         type_params=MetricTypeParams(measures=[measure_name]),
                     )
                 ],
@@ -168,7 +168,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                 metrics=[
                     Metric(
                         name=measure_reference.element_name,
-                        type=MetricType.MEASURE_PROXY,
+                        type=MetricType.SIMPLE,
                         type_params=MetricTypeParams(measures=[measure_reference.element_name]),
                     )
                 ],

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -70,7 +70,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
             metrics=[
                 metric_with_guaranteed_meta(
                     name="metric_with_no_time_dim",
-                    type=MetricType.MEASURE_PROXY,
+                    type=MetricType.SIMPLE,
                     type_params=MetricTypeParams(measures=[measure_name]),
                 )
             ],
@@ -100,7 +100,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                 metrics=[
                     metric_with_guaranteed_meta(
                         name="metric_with_no_time_dim",
-                        type=MetricType.MEASURE_PROXY,
+                        type=MetricType.SIMPLE,
                         type_params=MetricTypeParams(measures=[measure_name]),
                     )
                 ],
@@ -141,7 +141,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                 metrics=[
                     metric_with_guaranteed_meta(
                         name="foo",
-                        type=MetricType.MEASURE_PROXY,
+                        type=MetricType.SIMPLE,
                         type_params=MetricTypeParams(measures=[measure_name]),
                     )
                 ],
@@ -213,12 +213,12 @@ def test_derived_metric() -> None:  # noqa: D
             metrics=[
                 metric_with_guaranteed_meta(
                     name="random_metric",
-                    type=MetricType.MEASURE_PROXY,
+                    type=MetricType.SIMPLE,
                     type_params=MetricTypeParams(measures=[measure_name]),
                 ),
                 metric_with_guaranteed_meta(
                     name="random_metric2",
-                    type=MetricType.MEASURE_PROXY,
+                    type=MetricType.SIMPLE,
                     type_params=MetricTypeParams(measures=[measure_name]),
                 ),
                 metric_with_guaranteed_meta(


### PR DESCRIPTION
resolves #48 

### Description

As part of the `Right Now` set of changes in issue #7, renaming measure proxy to simple.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
