### PR TITLE
Adding semantic manifest version

### DIFF
--- a/.changes/unreleased/Features-20230517-103947.yaml
+++ b/.changes/unreleased/Features-20230517-103947.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Adding DSI version number to semantic manifest
+time: 2023-05-17T10:39:47.542969-05:00
+custom:
+  Author: callum-mcdata
+  Issue: "30"

--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -1,5 +1,7 @@
 from typing import List
 
+from importlib_metadata import PackageNotFoundError, version
+
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 from dbt_semantic_interfaces.implementations.metric import Metric
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
@@ -10,3 +12,11 @@ class SemanticManifest(HashableBaseModel):
 
     semantic_models: List[SemanticModel]
     metrics: List[Metric]
+
+    @property
+    def interfaces_version(self) -> str:
+        """Returns the version of the dbt_semantic_interfaces package that generated this manifest."""
+        try:
+            return version("dbt_semantic_interfaces")
+        except PackageNotFoundError:
+            return "dbt_semantic_interfaces is not installed"

--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -1,6 +1,7 @@
 from typing import List
 
-from importlib_metadata import PackageNotFoundError, version
+from importlib_metadata import version
+from pydantic import validator
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 from dbt_semantic_interfaces.implementations.metric import Metric
@@ -12,11 +13,12 @@ class SemanticManifest(HashableBaseModel):
 
     semantic_models: List[SemanticModel]
     metrics: List[Metric]
+    interfaces_version: str = ""
 
-    @property
-    def interfaces_version(self) -> str:
+    @validator("interfaces_version", always=True)
+    @classmethod
+    def __create_default_interfaces_version(cls, value: str) -> str:  # type: ignore[misc]
         """Returns the version of the dbt_semantic_interfaces package that generated this manifest."""
-        try:
-            return version("dbt_semantic_interfaces")
-        except PackageNotFoundError:
-            return "dbt_semantic_interfaces is not installed"
+        if value:
+            return value
+        return version("dbt_semantic_interfaces")

--- a/dbt_semantic_interfaces/protocols/semantic_manifest.py
+++ b/dbt_semantic_interfaces/protocols/semantic_manifest.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import List, Protocol
 
 from dbt_semantic_interfaces.protocols.metric import Metric
@@ -9,3 +10,9 @@ class SemanticManifest(Protocol):
 
     semantic_models: List[SemanticModel]
     metrics: List[Metric]
+
+    @property
+    @abstractmethod
+    def interfaces_version(self) -> str:
+        """Returns the version of the dbt_semantic_interfaces package that generated this manifest."""
+        ...

--- a/dbt_semantic_interfaces/protocols/semantic_manifest.py
+++ b/dbt_semantic_interfaces/protocols/semantic_manifest.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 from typing import List, Protocol
 
 from dbt_semantic_interfaces.protocols.metric import Metric
@@ -10,9 +9,4 @@ class SemanticManifest(Protocol):
 
     semantic_models: List[SemanticModel]
     metrics: List[Metric]
-
-    @property
-    @abstractmethod
-    def interfaces_version(self) -> str:
-        """Returns the version of the dbt_semantic_interfaces package that generated this manifest."""
-        ...
+    interfaces_version: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "Jinja2==3.1.2",
   "click>=7.1.2",
   "python-dateutil==2.8.2",
+  "importlib_metadata==6.6.0"
 ]
 
 [build-system]

--- a/tests/implementations/test_semantic_manifest.py
+++ b/tests/implementations/test_semantic_manifest.py
@@ -1,9 +1,9 @@
 from importlib_metadata import version
 
-from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 
 
-def test_interfaces_version() -> None:
+def test_interfaces_version_matches() -> None:
     """Test that the interfaces_version property returns the installed version of dbt_semantic_interfaces."""
     semantic_manifest = SemanticManifest(
         semantic_models=[],

--- a/tests/parsing/test_semantic_manifest_parsing.py
+++ b/tests/parsing/test_semantic_manifest_parsing.py
@@ -1,0 +1,15 @@
+from importlib_metadata import version
+
+from dbt_semantic_interfaces.objects.semantic_manifest import SemanticManifest
+
+
+def test_interfaces_version() -> None:
+    """Test that the interfaces_version property returns the installed version of dbt_semantic_interfaces."""
+    semantic_manifest = SemanticManifest(
+        semantic_models=[],
+        metrics=[],
+    )
+
+    # get the actual installed version
+    installed_version = version("dbt_semantic_interfaces")
+    assert semantic_manifest.interfaces_version == installed_version


### PR DESCRIPTION
resolves #30


### Description
This is a duplicate PR intentionally. The prior PR, #46, we had targeted at a separate branch `protocolization-branch` which was closed in favor of `clean-protocolization-branch`. Thus we merged it into the wrong branch. This PR does what #46 did, just with a target of main

> Adds a interfaces_version to the SemanticManifest protocol. Additionally the default implementation of SemanticManifest has been updated to have this attribute, and a way of setting it on instantiation.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
