### PR TITLE
Revert to using WhereFilter.call_parameter_sets

### DIFF
--- a/dbt_semantic_interfaces/implementations/filters/call_parameter_sets.py
+++ b/dbt_semantic_interfaces/implementations/filters/call_parameter_sets.py
@@ -1,14 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Sequence, Tuple
+from typing import Tuple
 
-import jinja2
-
-from dbt_semantic_interfaces.implementations.filters.where_filter import (
-    WhereFilter,
-    WhereFilterTransform,
-)
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     EntityReference,
@@ -53,84 +47,3 @@ class FilterCallParameterSets:
 
 class ParseWhereFilterException(Exception):  # noqa: D
     pass
-
-
-class ParseToCallParameterSets(WhereFilterTransform[FilterCallParameterSets]):
-    """Parses the where filter and returns the calls used in the template.
-
-    An abbreviated example:
-
-    WhereFilter("{{ dimension('home_state_latest', entity_path=['user']) }} IN ('CA', 'HI', 'WA')")
-
-    ->
-
-    FilterCallParameterSets(
-        dimension_call_parameter_sets=(
-            DimensionCallParameterSet(
-                entity_path=("user",),
-                dimension_reference="home_state_latest",
-            ),
-        )
-        ...
-    )
-
-    """
-
-    # To extract the parameters to the calls, we use a function to record the parameters while rendering the Jinja
-    # template. The rendered result is not used, but since Jinja has to render something, using this as a placeholder.
-    _DUMMY_PLACEHOLDER = "DUMMY_PLACEHOLDER"
-
-    def transform(self, where_filter: WhereFilter) -> FilterCallParameterSets:  # noqa: D
-        dimension_call_parameter_sets: List[DimensionCallParameterSet] = []
-        time_dimension_call_parameter_sets: List[TimeDimensionCallParameterSet] = []
-        entity_call_parameter_sets: List[EntityCallParameterSet] = []
-
-        def _dimension_call(dimension_name: str, entity_path: Sequence[str] = ()) -> str:
-            """Gets called by Jinja when rendering {{ dimension(...) }}."""
-            dimension_call_parameter_sets.append(
-                DimensionCallParameterSet(
-                    dimension_reference=DimensionReference(element_name=dimension_name),
-                    entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),
-                )
-            )
-            return ParseToCallParameterSets._DUMMY_PLACEHOLDER
-
-        def _time_dimension_call(
-            time_dimension_name: str, time_granularity_name: str, entity_path: Sequence[str] = ()
-        ) -> str:
-            """Gets called by Jinja when rendering {{ time_dimension(...) }}."""
-            time_dimension_call_parameter_sets.append(
-                TimeDimensionCallParameterSet(
-                    time_dimension_reference=TimeDimensionReference(element_name=time_dimension_name),
-                    entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),
-                    time_granularity=TimeGranularity(time_granularity_name),
-                )
-            )
-            return ParseToCallParameterSets._DUMMY_PLACEHOLDER
-
-        def _entity_call(entity_name: str, entity_path: Sequence[str] = ()) -> str:
-            """Gets called by Jinja when rendering {{ entity(...) }}."""
-            entity_call_parameter_sets.append(
-                EntityCallParameterSet(
-                    entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),
-                    entity_reference=EntityReference(element_name=entity_name),
-                )
-            )
-            return ParseToCallParameterSets._DUMMY_PLACEHOLDER
-
-        try:
-            jinja2.Template(where_filter.where_sql_template, undefined=jinja2.StrictUndefined).render(
-                dimension=_dimension_call,
-                time_dimension=_time_dimension_call,
-                entity=_entity_call,
-            )
-        except (jinja2.exceptions.UndefinedError, jinja2.exceptions.TemplateSyntaxError) as e:
-            raise ParseWhereFilterException(
-                f"Error while parsing Jinja template:\n{where_filter.where_sql_template}"
-            ) from e
-
-        return FilterCallParameterSets(
-            dimension_call_parameter_sets=tuple(dimension_call_parameter_sets),
-            time_dimension_call_parameter_sets=tuple(time_dimension_call_parameter_sets),
-            entity_call_parameter_sets=tuple(entity_call_parameter_sets),
-        )

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -1,23 +1,27 @@
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import List, Sequence
+
+import jinja2
 
 from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
     PydanticCustomInputParser,
     PydanticParseableValueType,
 )
-
-TransformOutputT = TypeVar("TransformOutputT")
-
-
-class WhereFilterTransform(Generic[TransformOutputT], ABC):
-    """Function to use for transforming WhereFilters."""
-
-    @abstractmethod
-    def transform(self, where_filter: WhereFilter) -> TransformOutputT:  # noqa: D
-        raise NotImplementedError
+from dbt_semantic_interfaces.implementations.filters.call_parameter_sets import (
+    DimensionCallParameterSet,
+    EntityCallParameterSet,
+    FilterCallParameterSets,
+    ParseWhereFilterException,
+    TimeDimensionCallParameterSet,
+)
+from dbt_semantic_interfaces.references import (
+    DimensionReference,
+    EntityReference,
+    TimeDimensionReference,
+)
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 
 class WhereFilter(PydanticCustomInputParser, HashableBaseModel):
@@ -46,5 +50,62 @@ class WhereFilter(PydanticCustomInputParser, HashableBaseModel):
         else:
             raise ValueError(f"Expected input to be of type string, but got type {type(input)} with value: {input}")
 
-    def transform(self, where_filter_transform: WhereFilterTransform[TransformOutputT]) -> TransformOutputT:  # noqa: D
-        return where_filter_transform.transform(self)
+    @property
+    def call_parameter_sets(self) -> FilterCallParameterSets:
+        """Return the result of extracting the semantic objects referenced in the where SQL template string."""
+        # To extract the parameters to the calls, we use a function to record the parameters while rendering the Jinja
+        # template. The rendered result is not used, but since Jinja has to render something, using this as a
+        # placeholder. An alternative approach would have been to use the Jinja AST API, but this seemed simpler.
+        _DUMMY_PLACEHOLDER = "DUMMY_PLACEHOLDER"
+
+        dimension_call_parameter_sets: List[DimensionCallParameterSet] = []
+        time_dimension_call_parameter_sets: List[TimeDimensionCallParameterSet] = []
+        entity_call_parameter_sets: List[EntityCallParameterSet] = []
+
+        def _dimension_call(dimension_name: str, entity_path: Sequence[str] = ()) -> str:
+            """Gets called by Jinja when rendering {{ dimension(...) }}."""
+            dimension_call_parameter_sets.append(
+                DimensionCallParameterSet(
+                    dimension_reference=DimensionReference(element_name=dimension_name),
+                    entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),
+                )
+            )
+            return _DUMMY_PLACEHOLDER
+
+        def _time_dimension_call(
+            time_dimension_name: str, time_granularity_name: str, entity_path: Sequence[str] = ()
+        ) -> str:
+            """Gets called by Jinja when rendering {{ time_dimension(...) }}."""
+            time_dimension_call_parameter_sets.append(
+                TimeDimensionCallParameterSet(
+                    time_dimension_reference=TimeDimensionReference(element_name=time_dimension_name),
+                    entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),
+                    time_granularity=TimeGranularity(time_granularity_name),
+                )
+            )
+            return _DUMMY_PLACEHOLDER
+
+        def _entity_call(entity_name: str, entity_path: Sequence[str] = ()) -> str:
+            """Gets called by Jinja when rendering {{ entity(...) }}."""
+            entity_call_parameter_sets.append(
+                EntityCallParameterSet(
+                    entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),
+                    entity_reference=EntityReference(element_name=entity_name),
+                )
+            )
+            return _DUMMY_PLACEHOLDER
+
+        try:
+            jinja2.Template(self.where_sql_template, undefined=jinja2.StrictUndefined).render(
+                dimension=_dimension_call,
+                time_dimension=_time_dimension_call,
+                entity=_entity_call,
+            )
+        except (jinja2.exceptions.UndefinedError, jinja2.exceptions.TemplateSyntaxError) as e:
+            raise ParseWhereFilterException(f"Error while parsing Jinja template:\n{self.where_sql_template}") from e
+
+        return FilterCallParameterSets(
+            dimension_call_parameter_sets=tuple(dimension_call_parameter_sets),
+            time_dimension_call_parameter_sets=tuple(time_dimension_call_parameter_sets),
+            entity_call_parameter_sets=tuple(entity_call_parameter_sets),
+        )

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -4,7 +4,6 @@ from dbt_semantic_interfaces.implementations.filters.call_parameter_sets import 
     DimensionCallParameterSet,
     EntityCallParameterSet,
     FilterCallParameterSets,
-    ParseToCallParameterSets,
     TimeDimensionCallParameterSet,
 )
 from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
@@ -23,7 +22,7 @@ def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
         where_sql_template=(
             """{{ dimension('is_instant') }} AND {{ dimension('country', entity_path=['listing']) }} == 'US'"""
         )
-    ).transform(ParseToCallParameterSets())
+    ).call_parameter_sets
 
     assert parse_result == FilterCallParameterSets(
         dimension_call_parameter_sets=(
@@ -43,7 +42,7 @@ def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
 def test_extract_time_dimension_call_parameter_sets() -> None:  # noqa: D
     parse_result = WhereFilter(
         where_sql_template="""{{ time_dimension('created_at', 'month', entity_path=['listing']) }} = '2020-01-01'"""
-    ).transform(ParseToCallParameterSets())
+    ).call_parameter_sets
 
     assert parse_result == FilterCallParameterSets(
         time_dimension_call_parameter_sets=(
@@ -61,7 +60,7 @@ def test_extract_entity_call_parameter_sets() -> None:  # noqa: D
         where_sql_template=(
             """{{ entity('listing') }} AND {{ entity('user', entity_path=['listing']) }} == 'TEST_USER_ID'"""
         )
-    ).transform(ParseToCallParameterSets())
+    ).call_parameter_sets
 
     assert parse_result == FilterCallParameterSets(
         dimension_call_parameter_sets=(),


### PR DESCRIPTION
### Description

This PR removes the generic `WhereFilter.transform()` interface in favor of the initial proposed interface in 

https://github.com/dbt-labs/metricflow/pull/506/commits/4f811feb4dfe61fa52aaa005e3934292ef8762be#diff-03b7dba8898dd11fd7368e91f503907b988d5475b5bd43b51f54361f1ba54eedR38

to constrain the API.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
