### PR TITLE
Use Common Hatch Environment for Testing & Linting + Parallelize Tests

### DIFF
--- a/.github/workflows/ci-pre-commit.yaml
+++ b/.github/workflows/ci-pre-commit.yaml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python-env
       - name: Run Pre-commit Hooks
-        run: hatch run pre-commit:pre-commit run --show-diff-on-failure --color=always --all-files
+        run: hatch run dev-env:pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python-env
       - name: Run Python Tests
-        run: hatch run pytest:pytest tests
+        run: hatch run dev-env:pytest tests

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.9"
 
       - name: Generate JSON Schema
-        run: hatch run pytest:python dbt_semantic_interfaces/parsing/explicit_schema.py
+        run: hatch run dev-env:python dbt_semantic_interfaces/parsing/explicit_schema.py
 
       - name: Schema Consistency Check
         run: |

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,13 @@ install-hatch:
 
 # This edits your local pre-commit hook file to use Hatch when executing.
 overwrite-pre-commit:
-	hatch run pre-commit:pre-commit install
-	hatch run pre-commit:sed -i -e "s/exec /exec hatch run pre-commit:/g" .git/hooks/pre-commit
+	hatch run dev-env:pre-commit install
+	hatch run dev-env:sed -i -e "s/exec /exec hatch run dev-env:/g" .git/hooks/pre-commit
 
 install: install-hatch overwrite-pre-commit
 
 test:
-	export FORMAT_JSON_LOGS="1" && hatch run pytest:pytest tests
+	export FORMAT_JSON_LOGS="1" && hatch run dev-env:pytest tests
 
 lint:
-	hatch run pre-commit:pre-commit run --show-diff-on-failure --color=always --all-files
+	hatch run dev-env:pre-commit run --show-diff-on-failure --color=always --all-files

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ overwrite-pre-commit:
 install: install-hatch overwrite-pre-commit
 
 test:
-	export FORMAT_JSON_LOGS="1" && hatch run dev-env:pytest tests
+	export FORMAT_JSON_LOGS="1" && hatch -v run dev-env:pytest -n auto tests
 
 lint:
 	hatch run dev-env:pre-commit run --show-diff-on-failure --color=always --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ all = ["pre-commit run --all-files"]
 description = "Env for running development commands like pytest / pre-commit"
 dependencies = [
   "pytest~=7.3.0",
+  "pytest-xdist~=3.2.1",
   "httpx~=0.24.0",
   "pre-commit~=3.2.2",
   "isort~=5.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,14 @@ exclude = [
   "/tests",
 ]
 
-[tool.hatch.envs.pre-commit]
-description = "Env for running pre-commit hooks."
+[tool.hatch.envs.dev-env.scripts]
+all = ["pre-commit run --all-files"]
+
+[tool.hatch.envs.dev-env]
+description = "Env for running development commands like pytest / pre-commit"
 dependencies = [
+  "pytest~=7.3.0",
+  "httpx~=0.24.0",
   "pre-commit~=3.2.2",
   "isort~=5.12.0",
   "black~=23.3.0",
@@ -59,16 +64,6 @@ dependencies = [
   "types-jsonschema~=4.17",
   "types-python-dateutil~=2.8.19",
   "types-PyYAML~=6.0.12",
-]
-
-[tool.hatch.envs.pre-commit.scripts]
-all = ["pre-commit run --all-files"]
-
-[tool.hatch.envs.pytest]
-description = "Env for running pytest."
-dependencies = [
-  "pytest~=7.3.0",
-  "httpx~=0.24.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
### Description

This PR updates `pyproject.toml` so that it uses a single `hatch` environment (called `dev-env`) for testing and linting. The benefit of using a single environment is that it simplifies the setup, and there doesn't seem to be much of a benefit for having separate dependencies for those tasks.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
