### PR TITLE
Change Definition Protocols to Use An Abstract Property

### DIFF
--- a/dbt_semantic_interfaces/implementations/elements/dimension.py
+++ b/dbt_semantic_interfaces/implementations/elements/dimension.py
@@ -17,7 +17,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 ISO8601_FMT = "YYYY-MM-DD"
 
 
-class DimensionValidityParams(HashableBaseModel):
+class PydanticDimensionValidityParams(HashableBaseModel):
     """Parameters identifying a given dimension as an entity for validity state.
 
     This construct is used for supporting SCD Type II tables, such as might be
@@ -31,22 +31,22 @@ class DimensionValidityParams(HashableBaseModel):
     is_end: bool = False
 
 
-class DimensionTypeParams(HashableBaseModel):
-    """Dimension type params add additional context to some types (time) of dimensions."""
+class PydanticDimensionTypeParams(HashableBaseModel):
+    """PydanticDimension type params add additional context to some types (time) of dimensions."""
 
     is_primary: bool = False
     time_granularity: TimeGranularity
-    validity_params: Optional[DimensionValidityParams] = None
+    validity_params: Optional[PydanticDimensionValidityParams] = None
 
 
-class Dimension(HashableBaseModel, ModelWithMetadataParsing):
+class PydanticDimension(HashableBaseModel, ModelWithMetadataParsing):
     """Describes a dimension."""
 
     name: str
     description: Optional[str]
     type: DimensionType
     is_partition: bool = False
-    type_params: Optional[DimensionTypeParams]
+    type_params: Optional[PydanticDimensionTypeParams]
     expr: Optional[str] = None
     metadata: Optional[Metadata]
 
@@ -67,8 +67,8 @@ class Dimension(HashableBaseModel, ModelWithMetadataParsing):
         return TimeDimensionReference(element_name=self.name)
 
     @property
-    def validity_params(self) -> Optional[DimensionValidityParams]:
-        """Returns the DimensionValidityParams property, if it exists.
+    def validity_params(self) -> Optional[PydanticDimensionValidityParams]:
+        """Returns the PydanticDimensionValidityParams property, if it exists.
 
         This is to avoid repeatedly checking that type params is not None before doing anything with ValidityParams
         """

--- a/dbt_semantic_interfaces/implementations/elements/dimension.py
+++ b/dbt_semantic_interfaces/implementations/elements/dimension.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
     ModelWithMetadataParsing,
 )
-from dbt_semantic_interfaces.implementations.metadata import Metadata
+from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     TimeDimensionReference,
@@ -48,7 +48,7 @@ class PydanticDimension(HashableBaseModel, ModelWithMetadataParsing):
     is_partition: bool = False
     type_params: Optional[PydanticDimensionTypeParams]
     expr: Optional[str] = None
-    metadata: Optional[Metadata]
+    metadata: Optional[PydanticMetadata]
 
     @property
     def is_primary_time(self) -> bool:  # noqa: D

--- a/dbt_semantic_interfaces/implementations/elements/entity.py
+++ b/dbt_semantic_interfaces/implementations/elements/entity.py
@@ -11,7 +11,7 @@ from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 
 
-class Entity(HashableBaseModel, ModelWithMetadataParsing):
+class PydanticEntity(HashableBaseModel, ModelWithMetadataParsing):
     """Describes a entity."""
 
     name: str

--- a/dbt_semantic_interfaces/implementations/elements/entity.py
+++ b/dbt_semantic_interfaces/implementations/elements/entity.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
     ModelWithMetadataParsing,
 )
-from dbt_semantic_interfaces.implementations.metadata import Metadata
+from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.references import EntityReference
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 
@@ -19,7 +19,7 @@ class PydanticEntity(HashableBaseModel, ModelWithMetadataParsing):
     type: EntityType
     role: Optional[str]
     expr: Optional[str] = None
-    metadata: Optional[Metadata] = None
+    metadata: Optional[PydanticMetadata] = None
 
     @property
     def reference(self) -> EntityReference:  # noqa: D

--- a/dbt_semantic_interfaces/implementations/elements/measure.py
+++ b/dbt_semantic_interfaces/implementations/elements/measure.py
@@ -11,7 +11,7 @@ from dbt_semantic_interfaces.references import MeasureReference, TimeDimensionRe
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
 
-class NonAdditiveDimensionParameters(HashableBaseModel):
+class PydanticNonAdditiveDimensionParameters(HashableBaseModel):
     """Describes the params for specifying non-additive dimensions in a measure.
 
     NOTE: Currently, only TimeDimensions are supported for this filter
@@ -24,7 +24,7 @@ class NonAdditiveDimensionParameters(HashableBaseModel):
     window_groupings: List[str] = []
 
 
-class MeasureAggregationParameters(HashableBaseModel):
+class PydanticMeasureAggregationParameters(HashableBaseModel):
     """Describes parameters for aggregations."""
 
     percentile: Optional[float] = None
@@ -32,7 +32,7 @@ class MeasureAggregationParameters(HashableBaseModel):
     use_approximate_percentile: bool = False
 
 
-class Measure(HashableBaseModel, ModelWithMetadataParsing):
+class PydanticMeasure(HashableBaseModel, ModelWithMetadataParsing):
     """Describes a measure."""
 
     name: str
@@ -40,9 +40,9 @@ class Measure(HashableBaseModel, ModelWithMetadataParsing):
     description: Optional[str]
     create_metric: Optional[bool]
     expr: Optional[str] = None
-    agg_params: Optional[MeasureAggregationParameters]
+    agg_params: Optional[PydanticMeasureAggregationParameters]
     metadata: Optional[Metadata]
-    non_additive_dimension: Optional[NonAdditiveDimensionParameters] = None
+    non_additive_dimension: Optional[PydanticNonAdditiveDimensionParameters] = None
     agg_time_dimension: Optional[str] = None
 
     @property

--- a/dbt_semantic_interfaces/implementations/elements/measure.py
+++ b/dbt_semantic_interfaces/implementations/elements/measure.py
@@ -6,7 +6,7 @@ from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
     ModelWithMetadataParsing,
 )
-from dbt_semantic_interfaces.implementations.metadata import Metadata
+from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.references import MeasureReference, TimeDimensionReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
@@ -41,7 +41,7 @@ class PydanticMeasure(HashableBaseModel, ModelWithMetadataParsing):
     create_metric: Optional[bool]
     expr: Optional[str] = None
     agg_params: Optional[PydanticMeasureAggregationParameters]
-    metadata: Optional[Metadata]
+    metadata: Optional[PydanticMetadata]
     non_additive_dimension: Optional[PydanticNonAdditiveDimensionParameters] = None
     agg_time_dimension: Optional[str] = None
 

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -24,7 +24,7 @@ from dbt_semantic_interfaces.references import (
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 
-class WhereFilter(PydanticCustomInputParser, HashableBaseModel):
+class PydanticWhereFilter(PydanticCustomInputParser, HashableBaseModel):
     """A filter applied to the data set containing measures, dimensions, identifiers relevant to the query.
 
     TODO: Clarify whether the filter applies to aggregated or un-aggregated data sets.
@@ -39,14 +39,14 @@ class WhereFilter(PydanticCustomInputParser, HashableBaseModel):
     def _from_yaml_value(
         cls,
         input: PydanticParseableValueType,
-    ) -> WhereFilter:
+    ) -> PydanticWhereFilter:
         """Parses a WhereFilter from a string found in a user-provided model specification.
 
         User-provided constraint strings are SQL snippets conforming to the expectations of SQL WHERE clauses,
         and as such we parse them using our standard parse method below.
         """
         if isinstance(input, str):
-            return WhereFilter(where_sql_template=input)
+            return PydanticWhereFilter(where_sql_template=input)
         else:
             raise ValueError(f"Expected input to be of type string, but got type {type(input)} with value: {input}")
 

--- a/dbt_semantic_interfaces/implementations/metadata.py
+++ b/dbt_semantic_interfaces/implementations/metadata.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 
 
-class FileSlice(HashableBaseModel):  # noqa: D
+class PydanticFileSlice(HashableBaseModel):  # noqa: D
     filename: str
     content: str
     start_line_number: int
     end_line_number: int
 
 
-class Metadata(HashableBaseModel):  # noqa: D
+class PydanticMetadata(HashableBaseModel):  # noqa: D
     repo_file_path: str
-    file_slice: FileSlice
+    file_slice: PydanticFileSlice

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -9,7 +9,9 @@ from dbt_semantic_interfaces.implementations.base import (
     PydanticCustomInputParser,
     PydanticParseableValueType,
 )
-from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+)
 from dbt_semantic_interfaces.implementations.metadata import Metadata
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
@@ -27,7 +29,7 @@ class MetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
     """
 
     name: str
-    filter: Optional[WhereFilter]
+    filter: Optional[PydanticWhereFilter]
     alias: Optional[str]
 
     @classmethod
@@ -118,7 +120,7 @@ class MetricInput(HashableBaseModel):
     """Provides a pointer to a metric along with the additional properties used on that metric."""
 
     name: str
-    filter: Optional[WhereFilter]
+    filter: Optional[PydanticWhereFilter]
     alias: Optional[str]
     offset_window: Optional[MetricTimeWindow]
     offset_to_grain: Optional[TimeGranularity]
@@ -159,7 +161,7 @@ class Metric(HashableBaseModel, ModelWithMetadataParsing):
     description: Optional[str]
     type: MetricType
     type_params: MetricTypeParams
-    filter: Optional[WhereFilter]
+    filter: Optional[PydanticWhereFilter]
     metadata: Optional[Metadata]
 
     @property

--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -5,13 +5,13 @@ from pydantic import validator
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 from dbt_semantic_interfaces.implementations.metric import PydanticMetric
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 
 
 class PydanticSemanticManifest(HashableBaseModel):
     """Model holds all the information the SemanticLayer needs to render a query."""
 
-    semantic_models: List[SemanticModel]
+    semantic_models: List[PydanticSemanticModel]
     metrics: List[PydanticMetric]
     interfaces_version: str = ""
 

--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -4,7 +4,7 @@ from importlib_metadata import version
 from pydantic import validator
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
-from dbt_semantic_interfaces.implementations.metric import Metric
+from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 
 
@@ -12,7 +12,7 @@ class SemanticManifest(HashableBaseModel):
     """Model holds all the information the SemanticLayer needs to render a query."""
 
     semantic_models: List[SemanticModel]
-    metrics: List[Metric]
+    metrics: List[PydanticMetric]
     interfaces_version: str = ""
 
     @validator("interfaces_version", always=True)

--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 
 
-class SemanticManifest(HashableBaseModel):
+class PydanticSemanticManifest(HashableBaseModel):
     """Model holds all the information the SemanticLayer needs to render a query."""
 
     semantic_models: List[SemanticModel]

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -11,7 +11,7 @@ from dbt_semantic_interfaces.implementations.base import (
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
-from dbt_semantic_interfaces.implementations.metadata import Metadata
+from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.references import (
     LinkableElementReference,
     MeasureReference,
@@ -71,7 +71,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
     measures: Sequence[PydanticMeasure] = []
     dimensions: Sequence[PydanticDimension] = []
 
-    metadata: Optional[Metadata]
+    metadata: Optional[PydanticMetadata]
 
     @property
     def entity_references(self) -> List[LinkableElementReference]:  # noqa: D

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
     ModelWithMetadataParsing,
 )
-from dbt_semantic_interfaces.implementations.elements.dimension import Dimension
+from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.implementations.elements.entity import Entity
 from dbt_semantic_interfaces.implementations.elements.measure import Measure
 from dbt_semantic_interfaces.implementations.metadata import Metadata
@@ -69,7 +69,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
 
     entities: Sequence[Entity] = []
     measures: Sequence[Measure] = []
-    dimensions: Sequence[Dimension] = []
+    dimensions: Sequence[PydanticDimension] = []
 
     metadata: Optional[Metadata]
 
@@ -90,7 +90,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
         return any([dim.validity_params is not None for dim in self.dimensions])
 
     @property
-    def validity_start_dimension(self) -> Optional[Dimension]:  # noqa: D
+    def validity_start_dimension(self) -> Optional[PydanticDimension]:  # noqa: D
         validity_start_dims = [dim for dim in self.dimensions if dim.validity_params and dim.validity_params.is_start]
         if not validity_start_dims:
             return None
@@ -100,7 +100,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
         return validity_start_dims[0]
 
     @property
-    def validity_end_dimension(self) -> Optional[Dimension]:  # noqa: D
+    def validity_end_dimension(self) -> Optional[PydanticDimension]:  # noqa: D
         validity_end_dims = [dim for dim in self.dimensions if dim.validity_params and dim.validity_params.is_end]
         if not validity_end_dims:
             return None
@@ -110,11 +110,11 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
         return validity_end_dims[0]
 
     @property
-    def partitions(self) -> List[Dimension]:  # noqa: D
+    def partitions(self) -> List[PydanticDimension]:  # noqa: D
         return [dim for dim in self.dimensions or [] if dim.is_partition]
 
     @property
-    def partition(self) -> Optional[Dimension]:  # noqa: D
+    def partition(self) -> Optional[PydanticDimension]:  # noqa: D
         partitions = self.partitions
         if not partitions:
             return None
@@ -135,7 +135,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
             f"No dimension with name ({measure_reference.element_name}) in semantic_model with name ({self.name})"
         )
 
-    def get_dimension(self, dimension_reference: LinkableElementReference) -> Dimension:  # noqa: D
+    def get_dimension(self, dimension_reference: LinkableElementReference) -> PydanticDimension:  # noqa: D
         for dim in self.dimensions:
             if dim.reference == dimension_reference:
                 return dim

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -60,7 +60,7 @@ class NodeRelation(HashableBaseModel):
         )
 
 
-class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
+class PydanticSemanticModel(HashableBaseModel, ModelWithMetadataParsing):
     """Describes a semantic model."""
 
     name: str

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -9,8 +9,8 @@ from dbt_semantic_interfaces.implementations.base import (
     ModelWithMetadataParsing,
 )
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
-from dbt_semantic_interfaces.implementations.elements.entity import Entity
-from dbt_semantic_interfaces.implementations.elements.measure import Measure
+from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metadata import Metadata
 from dbt_semantic_interfaces.references import (
     LinkableElementReference,
@@ -67,8 +67,8 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
     description: Optional[str]
     node_relation: NodeRelation
 
-    entities: Sequence[Entity] = []
-    measures: Sequence[Measure] = []
+    entities: Sequence[PydanticEntity] = []
+    measures: Sequence[PydanticMeasure] = []
     dimensions: Sequence[PydanticDimension] = []
 
     metadata: Optional[Metadata]
@@ -126,7 +126,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
     def reference(self) -> SemanticModelReference:  # noqa: D
         return SemanticModelReference(semantic_model_name=self.name)
 
-    def get_measure(self, measure_reference: MeasureReference) -> Measure:  # noqa: D
+    def get_measure(self, measure_reference: MeasureReference) -> PydanticMeasure:  # noqa: D
         for measure in self.measures:
             if measure.reference == measure_reference:
                 return measure
@@ -142,7 +142,7 @@ class SemanticModel(HashableBaseModel, ModelWithMetadataParsing):
 
         raise ValueError(f"No dimension with name ({dimension_reference}) in semantic_model with name ({self.name})")
 
-    def get_entity(self, entity_reference: LinkableElementReference) -> Entity:  # noqa: D
+    def get_entity(self, entity_reference: LinkableElementReference) -> PydanticEntity:  # noqa: D
         for entity in self.entities:
             if entity.reference == entity_reference:
                 return entity

--- a/dbt_semantic_interfaces/model_transformer.py
+++ b/dbt_semantic_interfaces/model_transformer.py
@@ -2,7 +2,9 @@ import copy
 import logging
 from typing import Sequence, Tuple
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.add_input_metric_measures import (
     AddInputMetricMeasuresRule,
 )
@@ -49,9 +51,9 @@ class ModelTransformer:
 
     @staticmethod
     def transform(
-        model: SemanticManifest,
+        model: PydanticSemanticManifest,
         ordered_rule_sequences: Tuple[Sequence[ModelTransformRule], ...] = DEFAULT_RULES,
-    ) -> SemanticManifest:
+    ) -> PydanticSemanticManifest:
         """Copies the passed in model, applies the rules to the new model, and then returns that model.
 
         It's important to note that some rules need to happen before or after other rules. Thus rules
@@ -69,8 +71,8 @@ class ModelTransformer:
 
     @staticmethod
     def pre_validation_transform_model(
-        model: SemanticManifest, rules: Sequence[ModelTransformRule] = PRIMARY_RULES
-    ) -> SemanticManifest:
+        model: PydanticSemanticManifest, rules: Sequence[ModelTransformRule] = PRIMARY_RULES
+    ) -> PydanticSemanticManifest:
         """Transform a model according to configured rules before validations are run."""
         logger.warning(
             "DEPRECATION: `ModelTransformer.pre_validation_transform_model` is deprecated.",
@@ -81,9 +83,9 @@ class ModelTransformer:
 
     @staticmethod
     def post_validation_transform_model(
-        model: SemanticManifest,
+        model: PydanticSemanticManifest,
         rules: Sequence[ModelTransformRule] = SECONDARY_RULES,
-    ) -> SemanticManifest:
+    ) -> PydanticSemanticManifest:
         """Transform a model according to configured rules after validations are run."""
         logger.warning(
             "DEPRECATION: `ModelTransformer.post_validation_transform_model` is deprecated.",

--- a/dbt_semantic_interfaces/model_validator.py
+++ b/dbt_semantic_interfaces/model_validator.py
@@ -3,7 +3,9 @@ import logging
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.validations.agg_time_dimension import (
     AggregationTimeDimensionRule,
 )
@@ -79,7 +81,7 @@ class ModelValidator:
         self._rules = rules
         self._executor = ProcessPoolExecutor(max_workers=max_workers)
 
-    def validate_model(self, model: SemanticManifest) -> ModelValidationResults:
+    def validate_model(self, model: PydanticSemanticManifest) -> ModelValidationResults:
         """Validate a model according to configured rules."""
         serialized_model = model.json()
 
@@ -96,7 +98,7 @@ class ModelValidator:
 
         return ModelValidationResults.merge(results)
 
-    def checked_validations(self, model: SemanticManifest) -> None:
+    def checked_validations(self, model: PydanticSemanticManifest) -> None:
         """Similar to validate(), but throws an exception if validation fails."""
         model_copy = copy.deepcopy(model)
         model_issues = self.validate_model(model_copy)

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -9,7 +9,9 @@ from jsonschema import exceptions
 
 from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.implementations.metric import PydanticMetric
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
 from dbt_semantic_interfaces.parsing.objects import Version, YamlConfigFile
@@ -40,7 +42,7 @@ DOCUMENT_TYPES = [METRIC_TYPE, SEMANTIC_MODEL_TYPE]
 
 @dataclass(frozen=True)
 class ModelBuildResult:  # noqa: D
-    model: SemanticManifest
+    model: PydanticSemanticManifest
     # Issues found in the model.
     issues: ModelValidationResults = ModelValidationResults()
 
@@ -215,7 +217,7 @@ def parse_yaml_files_to_model(
         issues += file_issues
 
     return ModelBuildResult(
-        model=SemanticManifest(
+        model=PydanticSemanticManifest(
             semantic_models=semantic_models,
             metrics=metrics,
         ),

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Type, Union
 from jsonschema import exceptions
 
 from dbt_semantic_interfaces.errors import ParsingException
-from dbt_semantic_interfaces.implementations.metric import Metric
+from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
@@ -54,7 +54,7 @@ class FileParsingResult:
         issues: Issues found when trying to parse the file
     """
 
-    elements: List[Union[SemanticModel, Metric]]
+    elements: List[Union[SemanticModel, PydanticMetric]]
     issues: List[ValidationIssue]
 
 
@@ -178,7 +178,7 @@ def parse_yaml_files_to_validation_ready_model(
 def parse_yaml_files_to_model(
     files: List[YamlConfigFile],
     semantic_model_class: Type[SemanticModel] = SemanticModel,
-    metric_class: Type[Metric] = Metric,
+    metric_class: Type[PydanticMetric] = PydanticMetric,
 ) -> ModelBuildResult:
     """Builds SemanticManifest from list of config files (as strings).
 
@@ -226,10 +226,10 @@ def parse_yaml_files_to_model(
 def parse_config_yaml(
     config_yaml: YamlConfigFile,
     semantic_model_class: Type[SemanticModel] = SemanticModel,
-    metric_class: Type[Metric] = Metric,
+    metric_class: Type[PydanticMetric] = PydanticMetric,
 ) -> FileParsingResult:
     """Parses transform config file passed as string - Returns list of model objects."""
-    results: List[Union[SemanticModel, Metric]] = []
+    results: List[Union[SemanticModel, PydanticMetric]] = []
     ctx: Optional[ParsingContext] = None
     issues: List[ValidationIssue] = []
     try:

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
 from dbt_semantic_interfaces.parsing.objects import Version, YamlConfigFile
 from dbt_semantic_interfaces.parsing.schemas import (
@@ -56,7 +56,7 @@ class FileParsingResult:
         issues: Issues found when trying to parse the file
     """
 
-    elements: List[Union[SemanticModel, PydanticMetric]]
+    elements: List[Union[PydanticSemanticModel, PydanticMetric]]
     issues: List[ValidationIssue]
 
 
@@ -179,7 +179,7 @@ def parse_yaml_files_to_validation_ready_model(
 
 def parse_yaml_files_to_model(
     files: List[YamlConfigFile],
-    semantic_model_class: Type[SemanticModel] = SemanticModel,
+    semantic_model_class: Type[PydanticSemanticModel] = PydanticSemanticModel,
     metric_class: Type[PydanticMetric] = PydanticMetric,
 ) -> ModelBuildResult:
     """Builds SemanticManifest from list of config files (as strings).
@@ -227,11 +227,11 @@ def parse_yaml_files_to_model(
 
 def parse_config_yaml(
     config_yaml: YamlConfigFile,
-    semantic_model_class: Type[SemanticModel] = SemanticModel,
+    semantic_model_class: Type[PydanticSemanticModel] = PydanticSemanticModel,
     metric_class: Type[PydanticMetric] = PydanticMetric,
 ) -> FileParsingResult:
     """Parses transform config file passed as string - Returns list of model objects."""
-    results: List[Union[SemanticModel, PydanticMetric]] = []
+    results: List[Union[PydanticSemanticModel, PydanticMetric]] = []
     ctx: Optional[ParsingContext] = None
     issues: List[ValidationIssue] = []
     try:

--- a/dbt_semantic_interfaces/protocols/dimension.py
+++ b/dbt_semantic_interfaces/protocols/dimension.py
@@ -22,28 +22,73 @@ class DimensionValidityParams(Protocol):
     validity window, where the dimension value is valid for any time within that range.
     """
 
-    is_start: bool
-    is_end: bool
+    @property
+    @abstractmethod
+    def is_start(self) -> bool:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def is_end(self) -> bool:  # noqa: D
+        pass
 
 
 class DimensionTypeParams(Protocol):
     """Dimension type params add context to some types of dimensions (like time)."""
 
-    is_primary: bool
-    time_granularity: TimeGranularity
-    validity_params: Optional[DimensionValidityParams]
+    @property
+    @abstractmethod
+    def is_primary(self) -> bool:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def time_granularity(self) -> TimeGranularity:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def validity_params(self) -> Optional[DimensionValidityParams]:  # noqa: D
+        pass
 
 
 class Dimension(Protocol):
     """Describes a dimension."""
 
-    name: str
-    description: Optional[str]
-    type: DimensionType
-    is_partition: bool
-    type_params: Optional[DimensionTypeParams]
-    expr: Optional[str]
-    metadata: Optional[Metadata]
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def type(self) -> DimensionType:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def is_partition(self) -> bool:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def type_params(self) -> Optional[DimensionTypeParams]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def expr(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def metadata(self) -> Optional[Metadata]:  # noqa: D
+        pass
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/dimension.py
+++ b/dbt_semantic_interfaces/protocols/dimension.py
@@ -34,7 +34,7 @@ class DimensionValidityParams(Protocol):
 
 
 class DimensionTypeParams(Protocol):
-    """Dimension type params add context to some types of dimensions (like time)."""
+    """PydanticDimension type params add context to some types of dimensions (like time)."""
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/entity.py
+++ b/dbt_semantic_interfaces/protocols/entity.py
@@ -10,11 +10,30 @@ from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 class Entity(Protocol):
     """Describes a entity."""
 
-    name: str
-    description: Optional[str]
-    type: EntityType
-    role: Optional[str]
-    expr: Optional[str] = None
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def type(self) -> EntityType:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def role(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def expr(self) -> Optional[str]:  # noqa: D
+        pass
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/measure.py
+++ b/dbt_semantic_interfaces/protocols/measure.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import List, Optional, Protocol
+from typing import Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.references import MeasureReference, TimeDimensionReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
@@ -10,17 +10,39 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 class NonAdditiveDimensionParameters(Protocol):
     """Describes the params for specifying non-additive dimensions in a measure."""
 
-    name: str
-    window_choice: AggregationType
-    window_groupings: List[str]
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def window_choice(self) -> AggregationType:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def window_groupings(self) -> Sequence[str]:  # noqa: D
+        pass
 
 
 class MeasureAggregationParameters(Protocol):
     """Describes parameters for aggregations."""
 
-    percentile: Optional[float]
-    use_discrete_percentile: bool
-    use_approximate_percentile: bool
+    @property
+    @abstractmethod
+    def percentile(self) -> Optional[float]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def use_discrete_percentile(self) -> bool:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def use_approximate_percentile(self) -> bool:  # noqa: D
+        pass
 
 
 class Measure(Protocol):
@@ -30,14 +52,45 @@ class Measure(Protocol):
     in a specific way.
     """
 
-    name: str
-    agg: AggregationType
-    description: Optional[str]
-    create_metric: Optional[bool]
-    expr: Optional[str]
-    agg_params: Optional[MeasureAggregationParameters]
-    non_additive_dimension: Optional[NonAdditiveDimensionParameters]
-    agg_time_dimension: Optional[str]
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def agg(self) -> AggregationType:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def create_metric(self) -> Optional[bool]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def expr(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def agg_params(self) -> Optional[MeasureAggregationParameters]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def non_additive_dimension(self) -> Optional[NonAdditiveDimensionParameters]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def agg_time_dimension(self) -> Optional[str]:  # noqa: D
+        pass
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/metadata.py
+++ b/dbt_semantic_interfaces/protocols/metadata.py
@@ -1,19 +1,42 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from typing import Protocol
 
 
 class FileSlice(Protocol):
     """Provides file slice level context about what something was created from."""
 
-    filename: str
-    content: str
-    start_line_number: int
-    end_line_number: int
+    @property
+    @abstractmethod
+    def filename(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def content(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def start_line_number(self) -> int:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def end_line_number(self) -> int:  # noqa: D
+        pass
 
 
 class Metadata(Protocol):
     """Provides file context about what something was created from."""
 
-    repo_file_path: str
-    file_slice: FileSlice
+    @property
+    @abstractmethod
+    def repo_file_path(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def file_slice(self) -> FileSlice:  # noqa: D
+        pass

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import List, Optional, Protocol, Sequence
 
-from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
+from dbt_semantic_interfaces.protocols.where_filter import WhereFilter
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import List, Optional, Protocol
+from typing import List, Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
@@ -16,9 +16,20 @@ class MetricInputMeasure(Protocol):
     phase in the SQL plan.
     """
 
-    name: str
-    filter: Optional[WhereFilter]
-    alias: Optional[str]
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def filter(self) -> Optional[WhereFilter]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def alias(self) -> Optional[str]:  # noqa: D
+        pass
 
     @property
     @abstractmethod
@@ -36,18 +47,44 @@ class MetricInputMeasure(Protocol):
 class MetricTimeWindow(Protocol):
     """Describes the window of time the metric should be accumulated over, e.g., '1 day', '2 weeks', etc."""
 
-    count: int
-    granularity: TimeGranularity
+    @property
+    @abstractmethod
+    def count(self) -> int:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def granularity(self) -> TimeGranularity:  # noqa: D
+        pass
 
 
 class MetricInput(Protocol):
     """Provides a pointer to a metric along with the additional properties used on that metric."""
 
-    name: str
-    filter: Optional[WhereFilter]
-    alias: Optional[str]
-    offset_window: Optional[MetricTimeWindow]
-    offset_to_grain: Optional[TimeGranularity]
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def filter(self) -> Optional[WhereFilter]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def alias(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def offset_window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def offset_to_grain(self) -> Optional[TimeGranularity]:  # noqa: D
+        pass
 
     @property
     @abstractmethod
@@ -59,14 +96,45 @@ class MetricInput(Protocol):
 class MetricTypeParams(Protocol):
     """Type params add additional context to certain metric types (the context depends on the metric type)."""
 
-    measure: Optional[MetricInputMeasure]
-    measures: Optional[List[MetricInputMeasure]]
-    numerator: Optional[MetricInputMeasure]
-    denominator: Optional[MetricInputMeasure]
-    expr: Optional[str]
-    window: Optional[MetricTimeWindow]
-    grain_to_date: Optional[TimeGranularity]
-    metrics: Optional[List[MetricInput]]
+    @property
+    @abstractmethod
+    def measure(self) -> Optional[MetricInputMeasure]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def measures(self) -> Optional[Sequence[MetricInputMeasure]]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def numerator(self) -> Optional[MetricInputMeasure]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def denominator(self) -> Optional[MetricInputMeasure]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def expr(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def grain_to_date(self) -> Optional[TimeGranularity]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def metrics(self) -> Optional[Sequence[MetricInput]]:  # noqa: D
+        pass
 
     @property
     @abstractmethod
@@ -84,11 +152,30 @@ class MetricTypeParams(Protocol):
 class Metric(Protocol):
     """Describes a metric."""
 
-    name: str
-    description: Optional[str]
-    type: MetricType
-    type_params: MetricTypeParams
-    filter: Optional[WhereFilter]
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def type(self) -> MetricType:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def type_params(self) -> MetricTypeParams:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def filter(self) -> Optional[WhereFilter]:  # noqa: D
+        pass
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import List, Optional, Protocol, Sequence
 
+from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.protocols.where_filter import WhereFilter
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType
@@ -194,3 +195,8 @@ class Metric(Protocol):
     def input_metrics(self) -> List[MetricInput]:
         """Return the associated input metrics for this metric."""
         ...
+
+    @property
+    @abstractmethod
+    def metadata(self) -> Optional[Metadata]:  # noqa: D
+        pass

--- a/dbt_semantic_interfaces/protocols/semantic_manifest.py
+++ b/dbt_semantic_interfaces/protocols/semantic_manifest.py
@@ -1,4 +1,5 @@
-from typing import List, Protocol
+from abc import abstractmethod
+from typing import Protocol, Sequence
 
 from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
@@ -7,6 +8,17 @@ from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 class SemanticManifest(Protocol):
     """Semantic Manifest holds all the information a SemanticLayer needs to render a query."""
 
-    semantic_models: List[SemanticModel]
-    metrics: List[Metric]
-    interfaces_version: str
+    @property
+    @abstractmethod
+    def semantic_models(self) -> Sequence[SemanticModel]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def metrics(self) -> Sequence[Metric]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def interfaces_version(self) -> str:  # noqa: D
+        pass

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 from typing import List, Optional, Protocol, Sequence
 
-from dbt_semantic_interfaces.implementations.elements.dimension import Dimension
+from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
 from dbt_semantic_interfaces.protocols.measure import Measure
 from dbt_semantic_interfaces.protocols.metadata import Metadata

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -16,22 +16,59 @@ from dbt_semantic_interfaces.references import (
 class NodeRelation(Protocol):
     """Path object to where the data should be."""
 
-    alias: str
-    schema_name: str
-    database: Optional[str]
-    relation_name: str
+    @property
+    @abstractmethod
+    def alias(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def schema_name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def database(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def relation_name(self) -> str:  # noqa: D
+        pass
 
 
 class SemanticModel(Protocol):
     """Describes a semantic model."""
 
-    name: str
-    description: Optional[str]
-    node_relation: NodeRelation
+    @property
+    @abstractmethod
+    def name(self) -> str:  # noqa: D
+        pass
 
-    entities: Sequence[Entity]
-    measures: Sequence[Measure]
-    dimensions: Sequence[Dimension]
+    @property
+    @abstractmethod
+    def description(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def node_relation(self) -> NodeRelation:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def entities(self) -> Sequence[Entity]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def measures(self) -> Sequence[Measure]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def dimensions(self) -> Sequence[Dimension]:  # noqa: D
+        pass
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Protocol, Sequence
 from dbt_semantic_interfaces.implementations.elements.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
 from dbt_semantic_interfaces.protocols.measure import Measure
+from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.references import (
     LinkableElementReference,
     MeasureReference,
@@ -123,3 +124,8 @@ class SemanticModel(Protocol):
     def reference(self) -> SemanticModelReference:
         """Returns a reference to this semantic model."""
         ...
+
+    @property
+    @abstractmethod
+    def metadata(self) -> Optional[Metadata]:  # noqa: D
+        pass

--- a/dbt_semantic_interfaces/protocols/where_filter.py
+++ b/dbt_semantic_interfaces/protocols/where_filter.py
@@ -1,0 +1,12 @@
+from abc import abstractmethod
+from typing import Protocol
+
+
+class WhereFilter(Protocol):
+    """A filter that is applied using a WHERE filter in the generated SQL."""
+
+    @property
+    @abstractmethod
+    def where_sql_template(self) -> str:
+        """A template that describes how to render the SQL for a WHERE clause."""
+        pass

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -11,11 +11,14 @@ from dbt_semantic_interfaces.implementations.elements.measure import PydanticMea
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilter,
 )
-from dbt_semantic_interfaces.implementations.metadata import FileSlice, Metadata
+from dbt_semantic_interfaces.implementations.metadata import (
+    PydanticFileSlice,
+    PydanticMetadata,
+)
 from dbt_semantic_interfaces.implementations.metric import (
-    Metric,
     MetricType,
-    MetricTypeParams,
+    PydanticMetric,
+    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import (
@@ -50,7 +53,7 @@ def find_semantic_model_with(
     raise Exception("Unable to find a semantic_model matching function criteria")
 
 
-def find_metric_with(model: SemanticManifest, function: Callable[[Metric], bool]) -> Tuple[Metric, int]:
+def find_metric_with(model: SemanticManifest, function: Callable[[PydanticMetric], bool]) -> Tuple[PydanticMetric, int]:
     """Returns a metric from the model which matches the criteria defined by the passed in function'.
 
     This is useful because the order of metrics in the list is non-determinant, thus it's impossible to
@@ -100,11 +103,11 @@ def base_semantic_manifest_file() -> YamlConfigFile:
     return YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
 
 
-def default_meta() -> Metadata:
+def default_meta() -> PydanticMetadata:
     """Returns a Metadata object with the required information."""
-    return Metadata(
+    return PydanticMetadata(
         repo_file_path="/not/from/a/repo",
-        file_slice=FileSlice(
+        file_slice=PydanticFileSlice(
             filename="not_from_file.py",
             content="N/A",
             start_line_number=0,
@@ -116,16 +119,16 @@ def default_meta() -> Metadata:
 def metric_with_guaranteed_meta(
     name: str,
     type: MetricType,
-    type_params: MetricTypeParams,
+    type_params: PydanticMetricTypeParams,
     where_filter: Optional[PydanticWhereFilter] = None,
-    metadata: Metadata = default_meta(),
+    metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
-) -> Metric:
+) -> PydanticMetric:
     """Creates a metric with the given input.
 
     If a metadata object is not supplied, a default metadata object is used.
     """
-    return Metric(
+    return PydanticMetric(
         name=name,
         description=description,
         type=type,
@@ -139,7 +142,7 @@ def semantic_model_with_guaranteed_meta(
     name: str,
     description: Optional[str] = None,
     node_relation: Optional[NodeRelation] = None,
-    metadata: Metadata = default_meta(),
+    metadata: PydanticMetadata = default_meta(),
     entities: Sequence[PydanticEntity] = (),
     measures: Sequence[PydanticMeasure] = (),
     dimensions: Sequence[PydanticDimension] = (),

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -25,7 +25,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 )
 from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
-    SemanticModel,
+    PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
 
@@ -38,8 +38,8 @@ def as_datetime(date_string: str) -> datetime.datetime:
 
 
 def find_semantic_model_with(
-    model: PydanticSemanticManifest, function: Callable[[SemanticModel], bool]
-) -> Tuple[SemanticModel, int]:
+    model: PydanticSemanticManifest, function: Callable[[PydanticSemanticModel], bool]
+) -> Tuple[PydanticSemanticModel, int]:
     """Returns a semantic model from the model which matches the criteria defined by the passed in function'.
 
     This is useful because the order of semantic models in the list is non determinant, thus it's impossible to
@@ -150,7 +150,7 @@ def semantic_model_with_guaranteed_meta(
     entities: Sequence[PydanticEntity] = (),
     measures: Sequence[PydanticMeasure] = (),
     dimensions: Sequence[PydanticDimension] = (),
-) -> SemanticModel:
+) -> PydanticSemanticModel:
     """Creates a semantic model with the given input.
 
     If a metadata object is not supplied, a default metadata object is used.
@@ -162,7 +162,7 @@ def semantic_model_with_guaranteed_meta(
             alias="table",
         )
 
-    return SemanticModel(
+    return PydanticSemanticModel(
         name=name,
         description=description,
         node_relation=created_node_relation,

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -20,7 +20,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
     PydanticMetricTypeParams,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
     SemanticModel,
@@ -36,7 +38,7 @@ def as_datetime(date_string: str) -> datetime.datetime:
 
 
 def find_semantic_model_with(
-    model: SemanticManifest, function: Callable[[SemanticModel], bool]
+    model: PydanticSemanticManifest, function: Callable[[SemanticModel], bool]
 ) -> Tuple[SemanticModel, int]:
     """Returns a semantic model from the model which matches the criteria defined by the passed in function'.
 
@@ -53,7 +55,9 @@ def find_semantic_model_with(
     raise Exception("Unable to find a semantic_model matching function criteria")
 
 
-def find_metric_with(model: SemanticManifest, function: Callable[[PydanticMetric], bool]) -> Tuple[PydanticMetric, int]:
+def find_metric_with(
+    model: PydanticSemanticManifest, function: Callable[[PydanticMetric], bool]
+) -> Tuple[PydanticMetric, int]:
     """Returns a metric from the model which matches the criteria defined by the passed in function'.
 
     This is useful because the order of metrics in the list is non-determinant, thus it's impossible to

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -6,9 +6,11 @@ from typing import Callable, Optional, Sequence, Tuple
 import dateutil.parser
 
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
-from dbt_semantic_interfaces.implementations.elements.entity import Entity
-from dbt_semantic_interfaces.implementations.elements.measure import Measure
-from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
+from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+)
 from dbt_semantic_interfaces.implementations.metadata import FileSlice, Metadata
 from dbt_semantic_interfaces.implementations.metric import (
     Metric,
@@ -115,7 +117,7 @@ def metric_with_guaranteed_meta(
     name: str,
     type: MetricType,
     type_params: MetricTypeParams,
-    where_filter: Optional[WhereFilter] = None,
+    where_filter: Optional[PydanticWhereFilter] = None,
     metadata: Metadata = default_meta(),
     description: str = "adhoc metric",
 ) -> Metric:
@@ -138,8 +140,8 @@ def semantic_model_with_guaranteed_meta(
     description: Optional[str] = None,
     node_relation: Optional[NodeRelation] = None,
     metadata: Metadata = default_meta(),
-    entities: Sequence[Entity] = (),
-    measures: Sequence[Measure] = (),
+    entities: Sequence[PydanticEntity] = (),
+    measures: Sequence[PydanticMeasure] = (),
     dimensions: Sequence[PydanticDimension] = (),
 ) -> SemanticModel:
     """Creates a semantic model with the given input.

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional, Sequence, Tuple
 
 import dateutil.parser
 
-from dbt_semantic_interfaces.implementations.elements.dimension import Dimension
+from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.implementations.elements.entity import Entity
 from dbt_semantic_interfaces.implementations.elements.measure import Measure
 from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
@@ -140,7 +140,7 @@ def semantic_model_with_guaranteed_meta(
     metadata: Metadata = default_meta(),
     entities: Sequence[Entity] = (),
     measures: Sequence[Measure] = (),
-    dimensions: Sequence[Dimension] = (),
+    dimensions: Sequence[PydanticDimension] = (),
 ) -> SemanticModel:
     """Creates a semantic model with the given input.
 

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -2,8 +2,8 @@ from typing import Set
 
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.metric import (
-    MetricInputMeasure,
     MetricType,
+    PydanticMetricInputMeasure,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
@@ -13,7 +13,7 @@ class AddInputMetricMeasuresRule(ModelTransformRule):
     """Add all measures corresponding to the input metrics of the derived metric."""
 
     @staticmethod
-    def _get_measures_for_metric(model: SemanticManifest, metric_name: str) -> Set[MetricInputMeasure]:
+    def _get_measures_for_metric(model: SemanticManifest, metric_name: str) -> Set[PydanticMetricInputMeasure]:
         """Returns a unique set of input measures for a given metric."""
         measures = set()
         matched_metric = next(iter((metric for metric in model.metrics if metric.name == metric_name)), None)

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -5,7 +5,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
     PydanticMetricInputMeasure,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 
 
@@ -13,7 +15,7 @@ class AddInputMetricMeasuresRule(ModelTransformRule):
     """Add all measures corresponding to the input metrics of the derived metric."""
 
     @staticmethod
-    def _get_measures_for_metric(model: SemanticManifest, metric_name: str) -> Set[PydanticMetricInputMeasure]:
+    def _get_measures_for_metric(model: PydanticSemanticManifest, metric_name: str) -> Set[PydanticMetricInputMeasure]:
         """Returns a unique set of input measures for a given metric."""
         measures = set()
         matched_metric = next(iter((metric for metric in model.metrics if metric.name == metric_name)), None)
@@ -28,7 +30,7 @@ class AddInputMetricMeasuresRule(ModelTransformRule):
         return measures
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for metric in model.metrics:
             if metric.type == MetricType.DERIVED:
                 measures = AddInputMetricMeasuresRule._get_measures_for_metric(model, metric.name)

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -28,7 +28,7 @@ class SetMeasureAggregationTimeDimensionRule(ModelTransformRule):
             )
 
             if not primary_time_dimension_reference:
-                # Dimension semantic models won't have a primary time dimension.
+                # PydanticDimension semantic models won't have a primary time dimension.
                 continue
 
             for measure in semantic_model.measures:

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -1,7 +1,9 @@
 import logging
 from typing import Optional
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import TimeDimensionReference
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
@@ -21,7 +23,7 @@ class SetMeasureAggregationTimeDimensionRule(ModelTransformRule):
         return None
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for semantic_model in model.semantic_models:
             primary_time_dimension_reference = SetMeasureAggregationTimeDimensionRule._find_primary_time_dimension(
                 semantic_model

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -4,7 +4,7 @@ from typing import Optional
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.references import TimeDimensionReference
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -16,7 +16,7 @@ class SetMeasureAggregationTimeDimensionRule(ModelTransformRule):
     """Sets the aggregation time dimension for measures to the primary time dimension if not defined."""
 
     @staticmethod
-    def _find_primary_time_dimension(semantic_model: SemanticModel) -> Optional[TimeDimensionReference]:
+    def _find_primary_time_dimension(semantic_model: PydanticSemanticModel) -> Optional[TimeDimensionReference]:
         for dimension in semantic_model.dimensions:
             if dimension.type == DimensionType.TIME and dimension.type_params and dimension.type_params.is_primary:
                 return dimension.time_dimension_reference

--- a/dbt_semantic_interfaces/transformations/boolean_measure.py
+++ b/dbt_semantic_interfaces/transformations/boolean_measure.py
@@ -1,6 +1,8 @@
 import logging
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
@@ -11,7 +13,7 @@ class BooleanMeasureAggregationRule(ModelTransformRule):
     """Converts the expression used in boolean measures so that it can be aggregated."""
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for semantic_model in model.semantic_models:
             for measure in semantic_model.measures:
                 if measure.agg == AggregationType.SUM_BOOLEAN:

--- a/dbt_semantic_interfaces/transformations/convert_count.py
+++ b/dbt_semantic_interfaces/transformations/convert_count.py
@@ -1,5 +1,7 @@
 from dbt_semantic_interfaces.errors import ModelTransformError
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
@@ -10,7 +12,7 @@ class ConvertCountToSumRule(ModelTransformRule):
     """Converts any COUNT measures to SUM equivalent."""
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for semantic_model in model.semantic_models:
             for measure in semantic_model.measures:
                 if measure.agg == AggregationType.COUNT:

--- a/dbt_semantic_interfaces/transformations/convert_median.py
+++ b/dbt_semantic_interfaces/transformations/convert_median.py
@@ -1,6 +1,6 @@
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.elements.measure import (
-    MeasureAggregationParameters,
+    PydanticMeasureAggregationParameters,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
@@ -20,7 +20,7 @@ class ConvertMedianToPercentileRule(ModelTransformRule):
                     measure.agg = AggregationType.PERCENTILE
 
                     if not measure.agg_params:
-                        measure.agg_params = MeasureAggregationParameters()
+                        measure.agg_params = PydanticMeasureAggregationParameters()
                     else:
                         if measure.agg_params.percentile is not None and measure.agg_params.percentile != 0.5:
                             raise ModelTransformError(

--- a/dbt_semantic_interfaces/transformations/convert_median.py
+++ b/dbt_semantic_interfaces/transformations/convert_median.py
@@ -2,7 +2,9 @@ from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.elements.measure import (
     PydanticMeasureAggregationParameters,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
@@ -13,7 +15,7 @@ class ConvertMedianToPercentileRule(ModelTransformRule):
     """Converts any MEDIAN measures to percentile equivalent."""
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for semantic_model in model.semantic_models:
             for measure in semantic_model.measures:
                 if measure.agg == AggregationType.MEDIAN:

--- a/dbt_semantic_interfaces/transformations/names.py
+++ b/dbt_semantic_interfaces/transformations/names.py
@@ -1,6 +1,8 @@
 import logging
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 
@@ -11,7 +13,7 @@ class LowerCaseNamesRule(ModelTransformRule):
     """Lowercases the names of both top level objects and semantic model elements in a model."""
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         LowerCaseNamesRule._lowercase_top_level_objects(model)
         for semantic_model in model.semantic_models:
             LowerCaseNamesRule._lowercase_semantic_model_elements(semantic_model)
@@ -32,7 +34,7 @@ class LowerCaseNamesRule(ModelTransformRule):
                 dimension.name = dimension.name.lower()
 
     @staticmethod
-    def _lowercase_top_level_objects(model: SemanticManifest) -> None:
+    def _lowercase_top_level_objects(model: PydanticSemanticManifest) -> None:
         """Lowercases the names of model objects."""
         if model.semantic_models:
             for semantic_model in model.semantic_models:

--- a/dbt_semantic_interfaces/transformations/names.py
+++ b/dbt_semantic_interfaces/transformations/names.py
@@ -3,7 +3,7 @@ import logging
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ class LowerCaseNamesRule(ModelTransformRule):
         return model
 
     @staticmethod
-    def _lowercase_semantic_model_elements(semantic_model: SemanticModel) -> None:
+    def _lowercase_semantic_model_elements(semantic_model: PydanticSemanticModel) -> None:
         """Lowercases the names of semantic model elements."""
         if semantic_model.measures:
             for measure in semantic_model.measures:

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -7,7 +7,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInputMeasure,
     PydanticMetricTypeParams,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 
 logger = logging.getLogger(__name__)
@@ -20,7 +22,7 @@ class CreateProxyMeasureRule(ModelTransformRule):
     """
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:
         """Creates measure proxy metrics for measures with `create_metric==True`."""
         for semantic_model in model.semantic_models:
             for measure in semantic_model.measures:

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -2,10 +2,10 @@ import logging
 
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.metric import (
-    Metric,
-    MetricInputMeasure,
     MetricType,
-    MetricTypeParams,
+    PydanticMetric,
+    PydanticMetricInputMeasure,
+    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
@@ -43,11 +43,11 @@ class CreateProxyMeasureRule(ModelTransformRule):
 
                 if add_metric is True:
                     model.metrics.append(
-                        Metric(
+                        PydanticMetric(
                             name=measure.name,
                             type=MetricType.MEASURE_PROXY,
-                            type_params=MetricTypeParams(
-                                measures=[MetricInputMeasure(name=measure.name)],
+                            type_params=PydanticMetricTypeParams(
+                                measures=[PydanticMetricInputMeasure(name=measure.name)],
                                 expr=measure.name,
                             ),
                         )

--- a/dbt_semantic_interfaces/transformations/transform_rule.py
+++ b/dbt_semantic_interfaces/transformations/transform_rule.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 
 
 class ModelTransformRule(ABC):
@@ -8,6 +10,6 @@ class ModelTransformRule(ABC):
 
     @staticmethod
     @abstractmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:
         """Copy and transform the given model into a new model."""
         pass

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -1,9 +1,7 @@
 from typing import List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     SemanticModelElementReference,
     TimeDimensionReference,
@@ -25,7 +23,7 @@ class AggregationTimeDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for semantic models in the model")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         for semantic_model in model.semantic_models:
             issues.extend(AggregationTimeDimensionRule._validate_semantic_model(semantic_model))

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -1,6 +1,8 @@
 from typing import List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     SemanticModelElementReference,
@@ -23,7 +25,7 @@ class AggregationTimeDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for semantic models in the model")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         for semantic_model in model.semantic_models:
             issues.extend(AggregationTimeDimensionRule._validate_semantic_model(semantic_model))

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -1,7 +1,9 @@
 from typing import Dict, List, Sequence, Set
 
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     EntityReference,
@@ -65,7 +67,7 @@ class CommonEntitysRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation warning if entities are only one one semantic model")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         """Issues a warning for any entity that is associated with only one semantic_model."""
         issues = []
 

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -1,10 +1,8 @@
 from typing import Dict, List, Sequence, Set
 
-from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.entity import Entity
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     EntityReference,
     SemanticModelElementReference,
@@ -24,7 +22,7 @@ class CommonEntitysRule(ModelValidationRule):
     """Checks that entities exist on more than one semantic model."""
 
     @staticmethod
-    def _map_semantic_model_entities(semantic_models: List[SemanticModel]) -> Dict[EntityReference, Set[str]]:
+    def _map_semantic_model_entities(semantic_models: Sequence[SemanticModel]) -> Dict[EntityReference, Set[str]]:
         """Generate mapping of entity names to the set of semantic_models where it is defined."""
         entities_to_semantic_models: Dict[EntityReference, Set[str]] = {}
         for semantic_model in semantic_models or []:
@@ -38,7 +36,7 @@ class CommonEntitysRule(ModelValidationRule):
     @staticmethod
     @validate_safely(whats_being_done="checking entity exists on more than one semantic model")
     def _check_entity(
-        entity: PydanticEntity,
+        entity: Entity,
         semantic_model: SemanticModel,
         entities_to_semantic_models: Dict[EntityReference, Set[str]],
     ) -> List[ValidationIssue]:
@@ -67,7 +65,7 @@ class CommonEntitysRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation warning if entities are only one one semantic model")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
         """Issues a warning for any entity that is associated with only one semantic_model."""
         issues = []
 

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Sequence, Set
 
-from dbt_semantic_interfaces.implementations.elements.entity import Entity
+from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
@@ -36,7 +36,7 @@ class CommonEntitysRule(ModelValidationRule):
     @staticmethod
     @validate_safely(whats_being_done="checking entity exists on more than one semantic model")
     def _check_entity(
-        entity: Entity,
+        entity: PydanticEntity,
         semantic_model: SemanticModel,
         entities_to_semantic_models: Dict[EntityReference, Set[str]],
     ) -> List[ValidationIssue]:

--- a/dbt_semantic_interfaces/validations/dimension_const.py
+++ b/dbt_semantic_interfaces/validations/dimension_const.py
@@ -1,8 +1,8 @@
 from typing import Dict, List, Sequence
 
-from dbt_semantic_interfaces.implementations.elements.dimension import Dimension
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.dimension import Dimension
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     SemanticModelElementReference,

--- a/dbt_semantic_interfaces/validations/element_const.py
+++ b/dbt_semantic_interfaces/validations/element_const.py
@@ -1,7 +1,9 @@
 from collections import defaultdict
 from typing import DefaultDict, List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
@@ -25,7 +27,7 @@ class ElementConsistencyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring model wide element consistency")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
         element_name_to_types = ElementConsistencyRule._get_element_name_to_types(model=model)
         invalid_elements = {
@@ -51,7 +53,7 @@ class ElementConsistencyRule(ModelValidationRule):
 
     @staticmethod
     def _get_element_name_to_types(
-        model: SemanticManifest,
+        model: PydanticSemanticManifest,
     ) -> DefaultDict[str, DefaultDict[SemanticModelElementType, List[SemanticModelContext]]]:
         """Create a mapping of element names in the semantic manifest to types with a list of associated contexts."""
         element_types: DefaultDict[

--- a/dbt_semantic_interfaces/validations/entities.py
+++ b/dbt_semantic_interfaces/validations/entities.py
@@ -2,10 +2,8 @@ import logging
 from datetime import date
 from typing import List, MutableSet, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -63,7 +61,7 @@ class NaturalEntityConfigurationRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that entities marked as EntityType.NATURAL are properly configured")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
         """Validate entities marked as EntityType.NATURAL."""
         issues: List[ValidationIssue] = []
         for semantic_model in model.semantic_models:
@@ -103,7 +101,7 @@ class OnePrimaryEntityPerSemanticModelRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring each semantic model has only one primary entity"
     )
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
 
         for semantic_model in model.semantic_models:

--- a/dbt_semantic_interfaces/validations/entities.py
+++ b/dbt_semantic_interfaces/validations/entities.py
@@ -2,7 +2,9 @@ import logging
 from datetime import date
 from typing import List, MutableSet, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
@@ -61,7 +63,7 @@ class NaturalEntityConfigurationRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that entities marked as EntityType.NATURAL are properly configured")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         """Validate entities marked as EntityType.NATURAL."""
         issues: List[ValidationIssue] = []
         for semantic_model in model.semantic_models:
@@ -101,7 +103,7 @@ class OnePrimaryEntityPerSemanticModelRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring each semantic model has only one primary entity"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
 
         for semantic_model in model.semantic_models:

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -3,8 +3,8 @@ from typing import DefaultDict, Dict, List, Sequence, Set
 
 from more_itertools import bucket
 
-from dbt_semantic_interfaces.implementations.metric import Metric
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.references import MeasureReference, MetricModelReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -58,7 +58,7 @@ class SemanticModelMeasuresUniqueRule(ModelValidationRule):
 class MeasureConstraintAliasesRule(ModelValidationRule):
     """Checks that aliases are configured correctly for constrained measure references.
 
-    These are, currently, only applicable for Metric types, since the MetricInputMeasure is only
+    These are, currently, only applicable for PydanticMetric types, since the MetricInputMeasure is only
     """
 
     @staticmethod
@@ -96,8 +96,8 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
                     ValidationWarning(
                         context=metric_context,
                         message=(
-                            f"Metric {metric.name} has multiple identical input measures specifications for measure "
-                            f"{name}. This might be hiding a semantic error. Input measure specification: "
+                            f"PydanticMetric {metric.name} has multiple identical input measures specifications for "
+                            f"measure {name}. This might be hiding a semantic error. Input measure specification: "
                             f"{input_measures[0]}."
                         ),
                     )
@@ -112,9 +112,10 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
                     ValidationError(
                         context=metric_context,
                         message=(
-                            f"Metric {metric.name} depends on multiple different constrained versions of measure "
-                            f"{name}. In such cases, aliases must be provided, but the following input measures have "
-                            f"constraints specified without an alias: {constrained_measures_without_aliases}."
+                            f"PydanticMetric {metric.name} depends on multiple different constrained versions of "
+                            f"measure {name}. In such cases, aliases must be provided, but the following input "
+                            f"measures have constraints specified without an alias: "
+                            f"{constrained_measures_without_aliases}."
                         ),
                     )
                 )

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -3,7 +3,9 @@ from typing import DefaultDict, Dict, List, Sequence, Set
 
 from more_itertools import bucket
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.references import MeasureReference, MetricModelReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
@@ -30,7 +32,7 @@ class SemanticModelMeasuresUniqueRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring measures exist in only one configured semantic model"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         measure_references_to_semantic_models: Dict[MeasureReference, List] = defaultdict(list)
@@ -124,7 +126,7 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking constrained measures are aliased properly")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         """Ensures measures that might need an alias have one set, and that the alias is distinct.
 
         We do not allow aliases to collide with other alias or measure names, since that could create
@@ -207,7 +209,7 @@ class MetricMeasuresRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         valid_measure_names = _get_measure_names_from_model(model)
 
@@ -223,7 +225,7 @@ class MeasuresNonAdditiveDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring that a measure's non_additive_dimensions is valid")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         for semantic_model in model.semantic_models or []:
             for measure in semantic_model.measures:
@@ -380,7 +382,7 @@ class CountAggregationExprRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring expr exist for measures with count aggregation"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in model.semantic_models:
@@ -432,7 +434,7 @@ class PercentileAggregationRule(ModelValidationRule):
         whats_being_done="running model validation ensuring the agg_params.percentile value exist for measures with "
         "percentile aggregation"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in model.semantic_models:
@@ -515,7 +517,7 @@ class PercentileAggregationRule(ModelValidationRule):
         return issues
 
 
-def _get_measure_names_from_model(model: SemanticManifest) -> Set[str]:
+def _get_measure_names_from_model(model: PydanticSemanticManifest) -> Set[str]:
     """Return every distinct measure name specified in the model."""
     measure_names = set()
     for semantic_model in model.semantic_models:

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -6,7 +6,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
     PydanticMetricTimeWindow,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.references import MetricModelReference
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
@@ -60,7 +62,7 @@ class CumulativeMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring cumulative sum metrics are valid")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for metric in model.metrics or []:
@@ -99,7 +101,7 @@ class DerivedMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the input metrics exist")
-    def _validate_input_metrics_exist(model: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_input_metrics_exist(model: PydanticSemanticManifest) -> List[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         all_metrics = {m.name for m in model.metrics}
@@ -143,7 +145,7 @@ class DerivedMetricRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring derived metrics properties are configured properly"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         issues += DerivedMetricRule._validate_input_metrics_exist(model=model)

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -3,11 +3,11 @@ from typing import List, Sequence
 
 from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.implementations.metric import (
-    Metric,
-    MetricTimeWindow,
     MetricType,
+    PydanticMetricTimeWindow,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.references import MetricModelReference
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -42,7 +42,8 @@ class CumulativeMetricRule(ModelValidationRule):
 
             if metric.type_params.window:
                 try:
-                    MetricTimeWindow.parse(metric.type_params.window.to_string())
+                    window_str = f"{metric.type_params.window.count} {metric.type_params.window.granularity.value}"
+                    PydanticMetricTimeWindow.parse(window_str)
                 except ParsingException as e:
                     issues.append(
                         ValidationError(

--- a/dbt_semantic_interfaces/validations/non_empty.py
+++ b/dbt_semantic_interfaces/validations/non_empty.py
@@ -1,6 +1,8 @@
 from typing import List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.validations.validator_helpers import (
     ModelValidationRule,
     ValidationError,
@@ -14,7 +16,7 @@ class NonEmptyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the model has semantic models")
-    def _check_model_has_semantic_models(model: SemanticManifest) -> List[ValidationIssue]:
+    def _check_model_has_semantic_models(model: PydanticSemanticManifest) -> List[ValidationIssue]:
         issues: List[ValidationIssue] = []
         if not model.semantic_models:
             issues.append(
@@ -26,7 +28,7 @@ class NonEmptyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the model has metrics")
-    def _check_model_has_metrics(model: SemanticManifest) -> List[ValidationIssue]:
+    def _check_model_has_metrics(model: PydanticSemanticManifest) -> List[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         # If we are going to generate measure proxy metrics that is sufficient as well
@@ -47,7 +49,7 @@ class NonEmptyRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely("running model validation rule ensuring metrics and semantic models are defined")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         issues += NonEmptyRule._check_model_has_semantic_models(model=model)
         issues += NonEmptyRule._check_model_has_metrics(model=model)

--- a/dbt_semantic_interfaces/validations/reserved_keywords.py
+++ b/dbt_semantic_interfaces/validations/reserved_keywords.py
@@ -1,9 +1,7 @@
 from typing import List
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelElementReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
@@ -124,7 +122,7 @@ class ReservedKeywordsRule(ModelValidationRule):
 
     @classmethod
     @validate_safely(whats_being_done="checking that semantic_model node_relations are not sql reserved keywords")
-    def _validate_semantic_models(cls, model: PydanticSemanticManifest) -> List[ValidationIssue]:
+    def _validate_semantic_models(cls, model: SemanticManifest) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
         issues: List[ValidationIssue] = []
         set_keywords = set(RESERVED_KEYWORDS)
@@ -155,5 +153,5 @@ class ReservedKeywordsRule(ModelValidationRule):
         whats_being_done="running model validation ensuring elements that aren't selected via a defined expr don't "
         "contain reserved keywords"
     )
-    def validate_model(cls, model: PydanticSemanticManifest) -> List[ValidationIssue]:  # noqa: D
+    def validate_model(cls, model: SemanticManifest) -> List[ValidationIssue]:  # noqa: D
         return cls._validate_semantic_models(model=model)

--- a/dbt_semantic_interfaces/validations/reserved_keywords.py
+++ b/dbt_semantic_interfaces/validations/reserved_keywords.py
@@ -1,6 +1,8 @@
 from typing import List
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelElementReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -122,7 +124,7 @@ class ReservedKeywordsRule(ModelValidationRule):
 
     @classmethod
     @validate_safely(whats_being_done="checking that semantic_model node_relations are not sql reserved keywords")
-    def _validate_semantic_models(cls, model: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_semantic_models(cls, model: PydanticSemanticManifest) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
         issues: List[ValidationIssue] = []
         set_keywords = set(RESERVED_KEYWORDS)
@@ -153,5 +155,5 @@ class ReservedKeywordsRule(ModelValidationRule):
         whats_being_done="running model validation ensuring elements that aren't selected via a defined expr don't "
         "contain reserved keywords"
     )
-    def validate_model(cls, model: SemanticManifest) -> List[ValidationIssue]:  # noqa: D
+    def validate_model(cls, model: PydanticSemanticManifest) -> List[ValidationIssue]:  # noqa: D
         return cls._validate_semantic_models(model=model)

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -1,10 +1,8 @@
 import logging
 from typing import List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
@@ -25,7 +23,7 @@ class SemanticModelTimeDimensionWarningsRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring time dimensions are defined properly")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in model.semantic_models:
@@ -85,7 +83,7 @@ class SemanticModelValidityWindowRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking correctness of the time dimension validity parameters in the model")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
         """Checks the validity param definitions in every semantic model in the model."""
         issues: List[ValidationIssue] = []
 

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -1,7 +1,9 @@
 import logging
 from typing import List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -23,7 +25,7 @@ class SemanticModelTimeDimensionWarningsRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring time dimensions are defined properly")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in model.semantic_models:
@@ -83,7 +85,7 @@ class SemanticModelValidityWindowRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking correctness of the time dimension validity parameters in the model")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         """Checks the validity param definitions in every semantic model in the model."""
         issues: List[ValidationIssue] = []
 

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -5,10 +5,8 @@ import re
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     ElementReference,
     MetricModelReference,
@@ -163,7 +161,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking model top level element names are sufficiently unique")
-    def _validate_top_level_objects(model: PydanticSemanticManifest) -> List[ValidationIssue]:
+    def _validate_top_level_objects(model: SemanticManifest) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
         object_info_tuples = []
         if model.semantic_models:
@@ -219,7 +217,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
         issues += UniqueAndValidNameRule._validate_top_level_objects(model=model)
 

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -5,7 +5,9 @@ import re
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     ElementReference,
@@ -161,7 +163,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking model top level element names are sufficiently unique")
-    def _validate_top_level_objects(model: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_top_level_objects(model: PydanticSemanticManifest) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
         object_info_tuples = []
         if model.semantic_models:
@@ -217,7 +219,7 @@ class UniqueAndValidNameRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
         issues += UniqueAndValidNameRule._validate_top_level_objects(model=model)
 

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -12,8 +12,8 @@ import click
 from pydantic import BaseModel, Extra
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
-from dbt_semantic_interfaces.implementations.metadata import Metadata
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.references import (
     MetricModelReference,
     SemanticModelElementReference,

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -12,7 +12,9 @@ import click
 from pydantic import BaseModel, Extra
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.references import (
     MetricModelReference,
@@ -381,7 +383,7 @@ class ModelValidationRule(ABC):
 
     @classmethod
     @abstractmethod
-    def validate_model(cls, model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(cls, model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         """Check the given model and return a list of validation issues."""
         pass
 
@@ -394,7 +396,7 @@ class ModelValidationRule(ABC):
         idiosyncratic behavior and inscrutable errors due to interactions between pickling and pydantic objects.
         """
         return ModelValidationResults.from_issues_sequence(
-            cls.validate_model(SemanticManifest.parse_raw(serialized_model))
+            cls.validate_model(PydanticSemanticManifest.parse_raw(serialized_model))
         ).json()
 
 

--- a/tests/fixtures/semantic_manifest_fixtures.py
+++ b/tests/fixtures/semantic_manifest_fixtures.py
@@ -8,7 +8,9 @@ from typing import Dict
 
 import pytest
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_directory_of_yaml_files_to_model,
@@ -27,7 +29,7 @@ def template_mapping() -> Dict[str, str]:
 
 
 @pytest.fixture(scope="session")
-def simple_semantic_manifest(template_mapping: Dict[str, str]) -> SemanticManifest:
+def simple_semantic_manifest(template_mapping: Dict[str, str]) -> PydanticSemanticManifest:
     """Semantic Manifest used for many tests."""
     model_build_result = parse_directory_of_yaml_files_to_model(
         os.path.join(os.path.dirname(__file__), "semantic_manifest_yamls/simple_semantic_manifest"),
@@ -37,7 +39,7 @@ def simple_semantic_manifest(template_mapping: Dict[str, str]) -> SemanticManife
 
 
 @pytest.fixture(scope="session")
-def simple_semantic_manifest__with_primary_transforms(template_mapping: Dict[str, str]) -> SemanticManifest:
+def simple_semantic_manifest__with_primary_transforms(template_mapping: Dict[str, str]) -> PydanticSemanticManifest:
     """Semantic Manifest used for tests pre-transformations."""
     model_build_result = parse_directory_of_yaml_files_to_model(
         os.path.join(os.path.dirname(__file__), "semantic_manifest_yamls/simple_semantic_manifest"),

--- a/tests/implementations/test_semantic_manifest.py
+++ b/tests/implementations/test_semantic_manifest.py
@@ -1,11 +1,13 @@
 from importlib_metadata import version
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 
 
 def test_interfaces_version_matches() -> None:
     """Test that the interfaces_version property returns the installed version of dbt_semantic_interfaces."""
-    semantic_manifest = SemanticManifest(
+    semantic_manifest = PydanticSemanticManifest(
         semantic_models=[],
         metrics=[],
     )

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -6,7 +6,9 @@ from dbt_semantic_interfaces.implementations.filters.call_parameter_sets import 
     FilterCallParameterSets,
     TimeDimensionCallParameterSet,
 )
-from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+)
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     EntityReference,
@@ -18,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
-    parse_result = WhereFilter(
+    parse_result = PydanticWhereFilter(
         where_sql_template=(
             """{{ dimension('is_instant') }} AND {{ dimension('country', entity_path=['listing']) }} == 'US'"""
         )
@@ -40,7 +42,7 @@ def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
 
 
 def test_extract_time_dimension_call_parameter_sets() -> None:  # noqa: D
-    parse_result = WhereFilter(
+    parse_result = PydanticWhereFilter(
         where_sql_template="""{{ time_dimension('created_at', 'month', entity_path=['listing']) }} = '2020-01-01'"""
     ).call_parameter_sets
 
@@ -56,7 +58,7 @@ def test_extract_time_dimension_call_parameter_sets() -> None:  # noqa: D
 
 
 def test_extract_entity_call_parameter_sets() -> None:  # noqa: D
-    parse_result = WhereFilter(
+    parse_result = PydanticWhereFilter(
         where_sql_template=(
             """{{ entity('listing') }} AND {{ entity('user', entity_path=['listing']) }} == 'TEST_USER_ID'"""
         )

--- a/tests/parsing/test_metadata_parsing.py
+++ b/tests/parsing/test_metadata_parsing.py
@@ -5,7 +5,7 @@ from typing import Sequence
 
 import pytest
 
-from dbt_semantic_interfaces.implementations.elements.measure import Measure
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metadata import Metadata
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.parsing.yaml_loader import YamlConfigLoader
@@ -90,7 +90,7 @@ def _assert_metadata_filename_is_valid(metadata: Metadata) -> None:
     ), f"Expected repo file path to be fully resolved, but it is filename only. Metadata: {metadata}"
 
 
-def _assert_measure_metadata_is_valid(measures: Sequence[Measure]) -> None:
+def _assert_measure_metadata_is_valid(measures: Sequence[PydanticMeasure]) -> None:
     """Sequence of assertion steps to show that we are parsing metadata consistently for measures.
 
     The assertions check that:

--- a/tests/parsing/test_metadata_parsing.py
+++ b/tests/parsing/test_metadata_parsing.py
@@ -6,7 +6,7 @@ from typing import Sequence
 import pytest
 
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
-from dbt_semantic_interfaces.implementations.metadata import Metadata
+from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.parsing.yaml_loader import YamlConfigLoader
 
@@ -27,7 +27,7 @@ def test_semantic_model_metadata_parsing(simple_semantic_manifest: SemanticManif
 
 
 def test_metric_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> None:
-    """Tests internal metadata object parsing from a file into the Metric model object.
+    """Tests internal metadata object parsing from a file into the PydanticMetric model object.
 
     This only tests some basic file name parsing for each metric since they are not guaranteed
     to be collected in the same file in the simple model, and the output here has been transformed
@@ -45,7 +45,7 @@ def test_metric_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> 
 def test_metric_metadata_parsing_with_measure_proxy(
     simple_semantic_manifest: SemanticManifest,
 ) -> None:
-    """Tests internal metadata object parsing from a file into the Metric model object via measure proxy.
+    """Tests internal metadata object parsing from a file into the PydanticMetric model object via measure proxy.
 
     The simple model has a broader array of metric definitions, but it does not appear to have a measure proxy
     added via transformation. This test includes such a metric.
@@ -75,7 +75,7 @@ def test_measure_metadata_parsing(simple_semantic_manifest: SemanticManifest) ->
         _assert_measure_metadata_is_valid(semantic_model.measures)
 
 
-def _assert_metadata_filename_is_valid(metadata: Metadata) -> None:
+def _assert_metadata_filename_is_valid(metadata: PydanticMetadata) -> None:
     """Sequence of assertion steps to ensure the metadata object has consistent file name parsing."""
     assert YamlConfigLoader.is_valid_yaml_file_ending(metadata.repo_file_path), (
         f"Expected repo file path in measure metadata to be a yaml file with an appropriate ending. "

--- a/tests/parsing/test_metadata_parsing.py
+++ b/tests/parsing/test_metadata_parsing.py
@@ -7,11 +7,13 @@ import pytest
 
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.parsing.yaml_loader import YamlConfigLoader
 
 
-def test_semantic_model_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> None:
+def test_semantic_model_metadata_parsing(simple_semantic_manifest: PydanticSemanticManifest) -> None:
     """Tests internal metadata object parsing from a file into the Semantic Model model object.
 
     This only tests some basic file name parsing for each semantic model since they are not guaranteed
@@ -26,7 +28,7 @@ def test_semantic_model_metadata_parsing(simple_semantic_manifest: SemanticManif
         _assert_metadata_filename_is_valid(semantic_model.metadata)
 
 
-def test_metric_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> None:
+def test_metric_metadata_parsing(simple_semantic_manifest: PydanticSemanticManifest) -> None:
     """Tests internal metadata object parsing from a file into the PydanticMetric model object.
 
     This only tests some basic file name parsing for each metric since they are not guaranteed
@@ -43,7 +45,7 @@ def test_metric_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> 
 
 @pytest.mark.skip("TODO: Determine what to do with measure proxy metric metadata")
 def test_metric_metadata_parsing_with_measure_proxy(
-    simple_semantic_manifest: SemanticManifest,
+    simple_semantic_manifest: PydanticSemanticManifest,
 ) -> None:
     """Tests internal metadata object parsing from a file into the PydanticMetric model object via measure proxy.
 
@@ -62,7 +64,7 @@ def test_metric_metadata_parsing_with_measure_proxy(
         _assert_metadata_filename_is_valid(metric.metadata)
 
 
-def test_measure_metadata_parsing(simple_semantic_manifest: SemanticManifest) -> None:
+def test_measure_metadata_parsing(simple_semantic_manifest: PydanticSemanticManifest) -> None:
     """Tests internal metadata object parsing from a file into the Measure model object.
 
     This tests the complete parsing process for Measure object metadata, including some baseline testing of things

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -4,10 +4,10 @@ from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilter,
 )
 from dbt_semantic_interfaces.implementations.metric import (
-    MetricInput,
-    MetricInputMeasure,
-    MetricTimeWindow,
     MetricType,
+    PydanticMetricInput,
+    PydanticMetricInputMeasure,
+    PydanticMetricTimeWindow,
 )
 from dbt_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_model
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
@@ -36,7 +36,7 @@ def test_legacy_measure_metric_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.name == "legacy_test"
     assert metric.type is MetricType.MEASURE_PROXY
-    assert metric.type_params.measure == MetricInputMeasure(name="legacy_measure")
+    assert metric.type_params.measure == PydanticMetricInputMeasure(name="legacy_measure")
     assert metric.type_params.measures is None
 
 
@@ -59,14 +59,14 @@ def test_legacy_metric_input_measure_object_parsing() -> None:
 
     assert len(build_result.model.metrics) == 1
     metric = build_result.model.metrics[0]
-    assert metric.type_params.measure == MetricInputMeasure(
+    assert metric.type_params.measure == PydanticMetricInputMeasure(
         name="legacy_measure_from_object",
         filter=PydanticWhereFilter(where_sql_template="""{{ dimension('some_bool') }}"""),
     )
 
 
 def test_metric_metadata_parsing() -> None:
-    """Test for asserting that internal metadata is parsed into the Metric object."""
+    """Test for asserting that internal metadata is parsed into the PydanticMetric object."""
     yaml_contents = textwrap.dedent(
         """\
         metric:
@@ -118,8 +118,8 @@ def test_ratio_metric_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.name == "ratio_test"
     assert metric.type is MetricType.RATIO
-    assert metric.type_params.numerator == MetricInputMeasure(name="numerator_measure")
-    assert metric.type_params.denominator == MetricInputMeasure(name="denominator_measure")
+    assert metric.type_params.numerator == PydanticMetricInputMeasure(name="numerator_measure")
+    assert metric.type_params.denominator == PydanticMetricInputMeasure(name="denominator_measure")
     assert metric.type_params.measures is None
 
 
@@ -144,13 +144,13 @@ def test_ratio_metric_input_measure_object_parsing() -> None:
 
     assert len(build_result.model.metrics) == 1
     metric = build_result.model.metrics[0]
-    assert metric.type_params.numerator == MetricInputMeasure(
+    assert metric.type_params.numerator == PydanticMetricInputMeasure(
         name="numerator_measure_from_object",
         filter=PydanticWhereFilter(
             where_sql_template="some_number > 5",
         ),
     )
-    assert metric.type_params.denominator == MetricInputMeasure(name="denominator_measure_from_object")
+    assert metric.type_params.denominator == PydanticMetricInputMeasure(name="denominator_measure_from_object")
 
 
 def test_expr_metric_parsing() -> None:
@@ -175,8 +175,8 @@ def test_expr_metric_parsing() -> None:
     assert metric.name == "expr_test"
     assert metric.type is MetricType.EXPR
     assert metric.type_params.measures == [
-        MetricInputMeasure(name="measure_one"),
-        MetricInputMeasure(name="measure_two"),
+        PydanticMetricInputMeasure(name="measure_one"),
+        PydanticMetricInputMeasure(name="measure_two"),
     ]
 
 
@@ -203,11 +203,11 @@ def test_expr_metric_input_measure_object_parsing() -> None:
     assert metric.name == "expr_test"
     assert metric.type is MetricType.EXPR
     assert metric.type_params.measures == [
-        MetricInputMeasure(
+        PydanticMetricInputMeasure(
             name="measure_one_from_object",
             filter=PydanticWhereFilter(where_sql_template="some_bool"),
         ),
-        MetricInputMeasure(name="measure_two_from_object"),
+        PydanticMetricInputMeasure(name="measure_two_from_object"),
     ]
 
 
@@ -232,8 +232,8 @@ def test_cumulative_window_metric_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.name == "cumulative_test"
     assert metric.type is MetricType.CUMULATIVE
-    assert metric.type_params.measures == [MetricInputMeasure(name="cumulative_measure")]
-    assert metric.type_params.window == MetricTimeWindow(count=7, granularity=TimeGranularity.DAY)
+    assert metric.type_params.measures == [PydanticMetricInputMeasure(name="cumulative_measure")]
+    assert metric.type_params.window == PydanticMetricTimeWindow(count=7, granularity=TimeGranularity.DAY)
 
 
 def test_grain_to_date_metric_parsing() -> None:
@@ -257,7 +257,7 @@ def test_grain_to_date_metric_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.name == "grain_to_date_test"
     assert metric.type is MetricType.CUMULATIVE
-    assert metric.type_params.measures == [MetricInputMeasure(name="cumulative_measure")]
+    assert metric.type_params.measures == [PydanticMetricInputMeasure(name="cumulative_measure")]
     assert metric.type_params.window is None
     assert metric.type_params.grain_to_date is TimeGranularity.WEEK
 
@@ -290,7 +290,7 @@ def test_derived_metric_offset_window_parsing() -> None:
     assert metric.type_params.metrics and len(metric.type_params.metrics) == 2
     metric1, metric2 = metric.type_params.metrics
     assert metric1.offset_window is None
-    assert metric2.offset_window == MetricTimeWindow(count=14, granularity=TimeGranularity.DAY)
+    assert metric2.offset_window == PydanticMetricTimeWindow(count=14, granularity=TimeGranularity.DAY)
     assert metric1.alias is None
     assert metric2.alias == "bookings_2_weeks_ago"
     assert metric.type_params.expr == "bookings / bookings_2_weeks_ago"
@@ -383,8 +383,8 @@ def test_derived_metric_input_parsing() -> None:
     assert metric.type_params
     assert metric.type_params.metrics
     assert len(metric.type_params.metrics) == 2
-    assert metric.type_params.metrics[0] == MetricInput(name="input_metric")
-    assert metric.type_params.metrics[1] == MetricInput(
+    assert metric.type_params.metrics[0] == PydanticMetricInput(name="input_metric")
+    assert metric.type_params.metrics[1] == PydanticMetricInput(
         name="input_metric",
         alias="constrained_input_metric",
         filter=PydanticWhereFilter(where_sql_template="input_metric < 10"),

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -1,6 +1,8 @@
 import textwrap
 
-from dbt_semantic_interfaces.implementations.filters.where_filter import WhereFilter
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+)
 from dbt_semantic_interfaces.implementations.metric import (
     MetricInput,
     MetricInputMeasure,
@@ -59,7 +61,7 @@ def test_legacy_metric_input_measure_object_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.type_params.measure == MetricInputMeasure(
         name="legacy_measure_from_object",
-        filter=WhereFilter(where_sql_template="""{{ dimension('some_bool') }}"""),
+        filter=PydanticWhereFilter(where_sql_template="""{{ dimension('some_bool') }}"""),
     )
 
 
@@ -144,7 +146,7 @@ def test_ratio_metric_input_measure_object_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.type_params.numerator == MetricInputMeasure(
         name="numerator_measure_from_object",
-        filter=WhereFilter(
+        filter=PydanticWhereFilter(
             where_sql_template="some_number > 5",
         ),
     )
@@ -203,7 +205,7 @@ def test_expr_metric_input_measure_object_parsing() -> None:
     assert metric.type_params.measures == [
         MetricInputMeasure(
             name="measure_one_from_object",
-            filter=WhereFilter(where_sql_template="some_bool"),
+            filter=PydanticWhereFilter(where_sql_template="some_bool"),
         ),
         MetricInputMeasure(name="measure_two_from_object"),
     ]
@@ -349,7 +351,9 @@ def test_constraint_metric_parsing() -> None:
     metric = build_result.model.metrics[0]
     assert metric.name == "constraint_test"
     assert metric.type is MetricType.MEASURE_PROXY
-    assert metric.filter == WhereFilter(where_sql_template="{{ dimension('some_dimension') }} IN ('value1', 'value2')")
+    assert metric.filter == PydanticWhereFilter(
+        where_sql_template="{{ dimension('some_dimension') }} IN ('value1', 'value2')"
+    )
 
 
 def test_derived_metric_input_parsing() -> None:
@@ -383,7 +387,7 @@ def test_derived_metric_input_parsing() -> None:
     assert metric.type_params.metrics[1] == MetricInput(
         name="input_metric",
         alias="constrained_input_metric",
-        filter=WhereFilter(where_sql_template="input_metric < 10"),
+        filter=PydanticWhereFilter(where_sql_template="input_metric < 10"),
     )
 
 

--- a/tests/parsing/test_model_deserialization.py
+++ b/tests/parsing/test_model_deserialization.py
@@ -1,7 +1,9 @@
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 
 
-def test_model_serialization_deserialization(simple_semantic_manifest: SemanticManifest) -> None:
+def test_model_serialization_deserialization(simple_semantic_manifest: PydanticSemanticManifest) -> None:
     """Tests Pydantic serialization and deserialization of a SemanticManifest.
 
     This ensures any custom parsing operations internal to our Pydantic models are properly applied to not only

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -16,7 +16,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInputMeasure,
     PydanticMetricTypeParams,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
     SemanticModel,
@@ -62,7 +64,7 @@ def test_semantic_manifest_protocol() -> None:  # noqa: D
         type=MetricType.MEASURE_PROXY,
         type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name="test_measure")),
     )
-    semantic_manifest = SemanticManifest(
+    semantic_manifest = PydanticSemanticManifest(
         semantic_models=[semantic_model],
         metrics=[metric],
     )

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -7,11 +7,14 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
 )
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
-from dbt_semantic_interfaces.implementations.metadata import FileSlice, Metadata
+from dbt_semantic_interfaces.implementations.metadata import (
+    PydanticFileSlice,
+    PydanticMetadata,
+)
 from dbt_semantic_interfaces.implementations.metric import (
-    Metric,
-    MetricInputMeasure,
-    MetricTypeParams,
+    PydanticMetric,
+    PydanticMetricInputMeasure,
+    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import (
@@ -54,10 +57,10 @@ def test_semantic_manifest_protocol() -> None:  # noqa: D
         measures=[],
         dimensions=[],
     )
-    metric = Metric(
+    metric = PydanticMetric(
         name="test_metric",
         type=MetricType.MEASURE_PROXY,
-        type_params=MetricTypeParams(measure=MetricInputMeasure(name="test_measure")),
+        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name="test_measure")),
     )
     semantic_manifest = SemanticManifest(
         semantic_models=[semantic_model],
@@ -95,10 +98,10 @@ class RuntimeCheckableMetric(MetricProtocol, Protocol):
 
 
 def test_metric_protocol() -> None:  # noqa: D
-    test_metric = Metric(
+    test_metric = PydanticMetric(
         name="test_metric",
         type=MetricType.MEASURE_PROXY,
-        type_params=MetricTypeParams(measure=MetricInputMeasure(name="test_measure")),
+        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name="test_measure")),
     )
     assert isinstance(test_metric, RuntimeCheckableMetric)
 
@@ -171,9 +174,9 @@ class RuntimeCheckableMetadata(MetadataProtocol, Protocol):
 
 
 def test_metadata_protocol() -> None:  # noqa: D
-    metadata = Metadata(
+    metadata = PydanticMetadata(
         repo_file_path="/path/to/cats.txt",
-        file_slice=FileSlice(
+        file_slice=PydanticFileSlice(
             filename="cats.txt",
             content="I like cats",
             start_line_number=0,

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -21,7 +21,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 )
 from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
-    SemanticModel,
+    PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.protocols.dimension import Dimension as DimensionProtocol
 from dbt_semantic_interfaces.protocols.entity import Entity as EntityProtocol
@@ -49,7 +49,7 @@ class RuntimeCheckableSemanticManifest(SemanticManifestProtocol, Protocol):
 
 
 def test_semantic_manifest_protocol() -> None:  # noqa: D
-    semantic_model = SemanticModel(
+    semantic_model = PydanticSemanticModel(
         name="test_semantic_model",
         node_relation=NodeRelation(
             alias="test_alias",
@@ -79,7 +79,7 @@ class RuntimeCheckableSemanticModel(SemanticModelProtocol, Protocol):
 
 
 def test_semantic_model_protocol() -> None:  # noqa: D
-    test_semantic_model = SemanticModel(
+    test_semantic_model = PydanticSemanticModel(
         name="test_semantic_model",
         node_relation=NodeRelation(
             alias="test_alias",

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -1,9 +1,9 @@
 from typing import Protocol, runtime_checkable
 
 from dbt_semantic_interfaces.implementations.elements.dimension import (
-    Dimension,
-    DimensionTypeParams,
-    DimensionValidityParams,
+    PydanticDimension,
+    PydanticDimensionTypeParams,
+    PydanticDimensionValidityParams,
 )
 from dbt_semantic_interfaces.implementations.elements.entity import Entity
 from dbt_semantic_interfaces.implementations.elements.measure import Measure
@@ -142,12 +142,12 @@ class RuntimeCheckableDimension(DimensionProtocol, Protocol):
 
 
 def test_dimension_protocol() -> None:  # noqa: D
-    time_dim = Dimension(
+    time_dim = PydanticDimension(
         name="test_time_dim",
         type=DimensionType.TIME,
-        type_params=DimensionTypeParams(
+        type_params=PydanticDimensionTypeParams(
             time_granularity=TimeGranularity.DAY,
-            validity_params=DimensionValidityParams(),
+            validity_params=PydanticDimensionValidityParams(),
         ),
     )
     assert isinstance(time_dim, RuntimeCheckableDimension)
@@ -156,7 +156,7 @@ def test_dimension_protocol() -> None:  # noqa: D
     # exception if DimensionType != TIME. The isinstance check seems to actually run the function thus
     # raising an exception during the assertion.
     # of
-    # categorical_dim = Dimension(
+    # categorical_dim = PydanticDimension(
     #     name="test_categorical_dim",
     #     type=DimensionType.CATEGORICAL,
     # )

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -5,8 +5,8 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
     PydanticDimensionTypeParams,
     PydanticDimensionValidityParams,
 )
-from dbt_semantic_interfaces.implementations.elements.entity import Entity
-from dbt_semantic_interfaces.implementations.elements.measure import Measure
+from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metadata import FileSlice, Metadata
 from dbt_semantic_interfaces.implementations.metric import (
     Metric,
@@ -111,7 +111,7 @@ class RuntimeCheckableEntity(EntityProtocol, Protocol):
 
 
 def test_entity_protocol() -> None:  # noqa: D
-    test_entity = Entity(
+    test_entity = PydanticEntity(
         name="test_name",
         type=EntityType.PRIMARY,
     )
@@ -126,7 +126,7 @@ class RuntimeCheckableMeasure(MeasureProtocol, Protocol):
 
 
 def test_measure_protocol() -> None:  # noqa: D
-    test_measure = Measure(
+    test_measure = PydanticMeasure(
         name="test_measure",
         agg=AggregationType.SUM,
         agg_time_dimension="some_time_dimension",

--- a/tests/test_pretty_print.py
+++ b/tests/test_pretty_print.py
@@ -21,7 +21,7 @@ def test_pformat_big_objects() -> None:  # noqa: D
     assert pformat_big_objects(meta) == (
         textwrap.dedent(
             """\
-                {'class': 'Metadata',
+                {'class': 'PydanticMetadata',
                  'repo_file_path': '/not/from/a/repo',
                  'file_slice': {'filename': 'not_from_file.py',
                                 'content': 'N/A',
@@ -35,7 +35,7 @@ def test_pformat_big_objects() -> None:  # noqa: D
         textwrap.dedent(
             """\
                 meta:
-                    {'class': 'Metadata',
+                    {'class': 'PydanticMetadata',
                      'repo_file_path': '/not/from/a/repo',
                      'file_slice': {'filename': 'not_from_file.py',
                                     'content': 'N/A',

--- a/tests/transformations/test_configurable_transform_rules.py
+++ b/tests/transformations/test_configurable_transform_rules.py
@@ -1,4 +1,6 @@
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
 from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
 
@@ -10,14 +12,14 @@ class SliceNamesRule(ModelTransformRule):
     """
 
     @staticmethod
-    def transform_model(model: SemanticManifest) -> SemanticManifest:  # noqa: D
+    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for semantic_model in model.semantic_models:
             semantic_model.name = semantic_model.name[:3]
         return model
 
 
 def test_can_configure_model_transform_rules(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     pre_model = simple_semantic_manifest__with_primary_transforms
     assert not all(len(x.name) == 3 for x in pre_model.semantic_models)

--- a/tests/validations/test_agg_time_dimension.py
+++ b/tests/validations/test_agg_time_dimension.py
@@ -2,7 +2,9 @@ from copy import deepcopy
 
 import pytest
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -14,7 +16,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-def test_invalid_aggregation_time_dimension(simple_semantic_manifest: SemanticManifest) -> None:  # noqa:D
+def test_invalid_aggregation_time_dimension(simple_semantic_manifest: PydanticSemanticManifest) -> None:  # noqa:D
     model = deepcopy(simple_semantic_manifest)
     semantic_model_with_measures, _ = find_semantic_model_with(
         model,
@@ -34,7 +36,7 @@ def test_invalid_aggregation_time_dimension(simple_semantic_manifest: SemanticMa
         model_validator.checked_validations(model)
 
 
-def test_unset_aggregation_time_dimension(simple_semantic_manifest: SemanticManifest) -> None:  # noqa:D
+def test_unset_aggregation_time_dimension(simple_semantic_manifest: PydanticSemanticManifest) -> None:  # noqa:D
     model = deepcopy(simple_semantic_manifest)
     semantic_model_with_measures, _ = find_semantic_model_with(
         model,
@@ -52,7 +54,7 @@ def test_unset_aggregation_time_dimension(simple_semantic_manifest: SemanticMani
 
 
 def test_missing_primary_time_ok_if_all_measures_have_agg_time_dim(  # noqa:D
-    simple_semantic_manifest: SemanticManifest,
+    simple_semantic_manifest: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest)
     semantic_model_with_measures, _ = find_semantic_model_with(

--- a/tests/validations/test_common_entities.py
+++ b/tests/validations/test_common_entities.py
@@ -4,7 +4,7 @@ import re
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.validations.common_entities import CommonEntitysRule
@@ -16,7 +16,7 @@ def test_lonely_entity_raises_issue(  # noqa: D
     model = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
     lonely_entity_name = "hi_im_lonely"
 
-    def func(semantic_model: SemanticModel) -> bool:
+    def func(semantic_model: PydanticSemanticModel) -> bool:
         return len(semantic_model.entities) > 0
 
     semantic_model_with_entities, _ = find_semantic_model_with(model, func)

--- a/tests/validations/test_common_entities.py
+++ b/tests/validations/test_common_entities.py
@@ -1,7 +1,9 @@
 import copy
 import re
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
@@ -9,7 +11,7 @@ from dbt_semantic_interfaces.validations.common_entities import CommonEntitysRul
 
 
 def test_lonely_entity_raises_issue(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
     lonely_entity_name = "hi_im_lonely"

--- a/tests/validations/test_configurable_rules.py
+++ b/tests/validations/test_configurable_rules.py
@@ -7,14 +7,16 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInput,
     PydanticMetricTypeParams,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import metric_with_guaranteed_meta
 from dbt_semantic_interfaces.validations.metrics import DerivedMetricRule
 
 
 def test_can_configure_model_validator_rules(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
     model.metrics.append(

--- a/tests/validations/test_configurable_rules.py
+++ b/tests/validations/test_configurable_rules.py
@@ -3,9 +3,9 @@ import copy
 import pytest
 
 from dbt_semantic_interfaces.implementations.metric import (
-    MetricInput,
     MetricType,
-    MetricTypeParams,
+    PydanticMetricInput,
+    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.model_validator import ModelValidator
@@ -21,8 +21,9 @@ def test_can_configure_model_validator_rules(  # noqa: D
         metric_with_guaranteed_meta(
             name="metric_doesnt_exist_squared",
             type=MetricType.DERIVED,
-            type_params=MetricTypeParams(
-                expr="metric_doesnt_exist * metric_doesnt_exist", metrics=[MetricInput(name="metric_doesnt_exist")]
+            type_params=PydanticMetricTypeParams(
+                expr="metric_doesnt_exist * metric_doesnt_exist",
+                metrics=[PydanticMetricInput(name="metric_doesnt_exist")],
             ),
         )
     )

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -1,8 +1,8 @@
 import pytest
 
 from dbt_semantic_interfaces.implementations.elements.dimension import (
-    Dimension,
-    DimensionTypeParams,
+    PydanticDimension,
+    PydanticDimensionTypeParams,
 )
 from dbt_semantic_interfaces.implementations.elements.measure import Measure
 from dbt_semantic_interfaces.implementations.metric import (
@@ -49,10 +49,10 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                         name="dim1",
                         measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
-                            Dimension(
+                            PydanticDimension(
                                 name=dim_name,
                                 type=DimensionType.TIME,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     is_primary=True,
                                     time_granularity=TimeGranularity.DAY,
                                 ),
@@ -61,7 +61,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     ),
                     semantic_model_with_guaranteed_meta(
                         name="categoricaldim",
-                        dimensions=[Dimension(name=dim_name, type=DimensionType.CATEGORICAL)],
+                        dimensions=[PydanticDimension(name=dim_name, type=DimensionType.CATEGORICAL)],
                     ),
                 ],
                 metrics=[
@@ -87,11 +87,11 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                         name="dim1",
                         measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
-                            Dimension(
+                            PydanticDimension(
                                 name=dim_name,
                                 type=DimensionType.TIME,
                                 is_partition=True,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     is_primary=True,
                                     time_granularity=TimeGranularity.DAY,
                                 ),
@@ -101,11 +101,11 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                     semantic_model_with_guaranteed_meta(
                         name="dim2",
                         dimensions=[
-                            Dimension(
+                            PydanticDimension(
                                 name=dim_name,
                                 type=DimensionType.TIME,
                                 is_partition=False,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -146,18 +146,18 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                             )
                         ],
                         dimensions=[
-                            Dimension(
+                            PydanticDimension(
                                 name=dimension_reference.element_name,
                                 type=DimensionType.TIME,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     is_primary=True,
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             ),
-                            Dimension(
+                            PydanticDimension(
                                 name=dimension_reference2.element_name,
                                 type=DimensionType.TIME,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     is_primary=True,
                                     time_granularity=TimeGranularity.DAY,
                                 ),

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -10,7 +10,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
     PydanticMetricTypeParams,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
     SemanticModel,
@@ -43,7 +45,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
         measure_name = "measure"
         model_validator = ModelValidator([DimensionConsistencyRule()])
         model_validator.checked_validations(
-            SemanticManifest(
+            PydanticSemanticManifest(
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="dim1",
@@ -81,7 +83,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
         measure_name = "measure"
         model_validator = ModelValidator([DimensionConsistencyRule()])
         model_validator.checked_validations(
-            SemanticManifest(
+            PydanticSemanticManifest(
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="dim1",
@@ -130,7 +132,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
         measure_reference = MeasureReference(element_name="measure")
         model_validator = ModelValidator([SemanticModelTimeDimensionWarningsRule()])
         model_validator.checked_validations(
-            model=SemanticManifest(
+            model=PydanticSemanticManifest(
                 semantic_models=[
                     SemanticModel(
                         name="dim1",

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -4,7 +4,7 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
     PydanticDimension,
     PydanticDimensionTypeParams,
 )
-from dbt_semantic_interfaces.implementations.elements.measure import Measure
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metric import (
     Metric,
     MetricType,
@@ -47,7 +47,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="dim1",
-                        measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
+                        measures=[PydanticMeasure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
                             PydanticDimension(
                                 name=dim_name,
@@ -85,7 +85,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="dim1",
-                        measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
+                        measures=[PydanticMeasure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
                             PydanticDimension(
                                 name=dim_name,
@@ -139,7 +139,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                             schema_name="schema",
                         ),
                         measures=[
-                            Measure(
+                            PydanticMeasure(
                                 name=measure_reference.element_name,
                                 agg=AggregationType.SUM,
                                 agg_time_dimension=dimension_reference.element_name,

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -6,9 +6,9 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
 )
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metric import (
-    Metric,
     MetricType,
-    MetricTypeParams,
+    PydanticMetric,
+    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import (
@@ -68,7 +68,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name=measure_name,
                         type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
                     )
                 ],
             )
@@ -116,7 +116,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name=measure_name,
                         type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
                     )
                 ],
             )
@@ -166,10 +166,10 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                     ),
                 ],
                 metrics=[
-                    Metric(
+                    PydanticMetric(
                         name=measure_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure_reference.element_name]),
+                        type_params=PydanticMetricTypeParams(measures=[measure_reference.element_name]),
                     )
                 ],
             )

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -15,7 +15,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 )
 from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
-    SemanticModel,
+    PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.references import (
@@ -134,7 +134,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
         model_validator.checked_validations(
             model=PydanticSemanticManifest(
                 semantic_models=[
-                    SemanticModel(
+                    PydanticSemanticModel(
                         name="dim1",
                         node_relation=NodeRelation(
                             alias="table",

--- a/tests/validations/test_element_const.py
+++ b/tests/validations/test_element_const.py
@@ -3,7 +3,7 @@ from typing import Tuple
 
 import pytest
 
-from dbt_semantic_interfaces.implementations.elements.dimension import Dimension
+from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
@@ -16,7 +16,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-def _categorical_dimensions(semantic_model: SemanticModel) -> Tuple[Dimension, ...]:
+def _categorical_dimensions(semantic_model: SemanticModel) -> Tuple[PydanticDimension, ...]:
     return tuple(dim for dim in semantic_model.dimensions if dim.type == DimensionType.CATEGORICAL)
 
 

--- a/tests/validations/test_element_const.py
+++ b/tests/validations/test_element_const.py
@@ -7,7 +7,7 @@ from dbt_semantic_interfaces.implementations.elements.dimension import PydanticD
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -18,7 +18,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-def _categorical_dimensions(semantic_model: SemanticModel) -> Tuple[PydanticDimension, ...]:
+def _categorical_dimensions(semantic_model: PydanticSemanticModel) -> Tuple[PydanticDimension, ...]:
     return tuple(dim for dim in semantic_model.dimensions if dim.type == DimensionType.CATEGORICAL)
 
 

--- a/tests/validations/test_element_const.py
+++ b/tests/validations/test_element_const.py
@@ -4,7 +4,9 @@ from typing import Tuple
 import pytest
 
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
@@ -20,7 +22,9 @@ def _categorical_dimensions(semantic_model: SemanticModel) -> Tuple[PydanticDime
     return tuple(dim for dim in semantic_model.dimensions if dim.type == DimensionType.CATEGORICAL)
 
 
-def test_cross_element_names(simple_semantic_manifest__with_primary_transforms: SemanticManifest) -> None:  # noqa:D
+def test_cross_element_names(  # noqa:D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
     model = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
 
     # ensure we have a usable semantic model for the test

--- a/tests/validations/test_entities.py
+++ b/tests/validations/test_entities.py
@@ -7,7 +7,7 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
@@ -33,7 +33,7 @@ def test_semantic_model_cant_have_more_than_one_primary_entity(
     """Add an additional primary entity to a semantic model and assert that it cannot have two."""
     model = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
 
-    def func(semantic_model: SemanticModel) -> bool:
+    def func(semantic_model: PydanticSemanticModel) -> bool:
         return len(semantic_model.entities) > 1
 
     multiple_entity_semantic_model, _ = find_semantic_model_with(model, func)

--- a/tests/validations/test_entities.py
+++ b/tests/validations/test_entities.py
@@ -4,7 +4,9 @@ import textwrap
 
 import pytest
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import SemanticModel
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
@@ -26,7 +28,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 
 
 def test_semantic_model_cant_have_more_than_one_primary_entity(
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:  # noqa: D
     """Add an additional primary entity to a semantic model and assert that it cannot have two."""
     model = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -4,8 +4,8 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
     PydanticDimension,
     PydanticDimensionTypeParams,
 )
-from dbt_semantic_interfaces.implementations.elements.entity import Entity
-from dbt_semantic_interfaces.implementations.elements.measure import Measure
+from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metric import (
     MetricInput,
     MetricType,
@@ -48,7 +48,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                 semantic_model_with_guaranteed_meta(
                     name="sum_measure2",
                     measures=[
-                        Measure(
+                        PydanticMeasure(
                             name=measure_name,
                             agg=AggregationType.SUM,
                             agg_time_dimension=dim2_name,
@@ -88,7 +88,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="sum_measure",
-                        measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
+                        measures=[PydanticMeasure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
                             PydanticDimension(
                                 name=dim_name,
@@ -119,7 +119,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="sum_measure",
-                        measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
+                        measures=[PydanticMeasure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
                             PydanticDimension(
                                 name=dim_name,
@@ -157,7 +157,9 @@ def test_generated_metrics_only() -> None:  # noqa:D
     entity_reference = EntityReference(element_name="primary")
     semantic_model = semantic_model_with_guaranteed_meta(
         name="dim1",
-        measures=[Measure(name=measure_name, agg=AggregationType.SUM, agg_time_dimension=dim2_reference.element_name)],
+        measures=[
+            PydanticMeasure(name=measure_name, agg=AggregationType.SUM, agg_time_dimension=dim2_reference.element_name)
+        ],
         dimensions=[
             PydanticDimension(name=dim_reference.element_name, type=DimensionType.CATEGORICAL),
             PydanticDimension(
@@ -170,7 +172,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
             ),
         ],
         entities=[
-            Entity(name=entity_reference.element_name, type=EntityType.PRIMARY),
+            PydanticEntity(name=entity_reference.element_name, type=EntityType.PRIMARY),
         ],
     )
     semantic_model.measures[0].create_metric = True
@@ -192,7 +194,7 @@ def test_derived_metric() -> None:  # noqa: D
                 semantic_model_with_guaranteed_meta(
                     name="sum_measure",
                     measures=[
-                        Measure(
+                        PydanticMeasure(
                             name=measure_name,
                             agg=AggregationType.SUM,
                             agg_time_dimension="ds",

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -1,8 +1,8 @@
 import pytest
 
 from dbt_semantic_interfaces.implementations.elements.dimension import (
-    Dimension,
-    DimensionTypeParams,
+    PydanticDimension,
+    PydanticDimensionTypeParams,
 )
 from dbt_semantic_interfaces.implementations.elements.entity import Entity
 from dbt_semantic_interfaces.implementations.elements.measure import Measure
@@ -43,7 +43,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                 semantic_model_with_guaranteed_meta(
                     name="sum_measure",
                     measures=[],
-                    dimensions=[Dimension(name=dim_name, type=DimensionType.CATEGORICAL)],
+                    dimensions=[PydanticDimension(name=dim_name, type=DimensionType.CATEGORICAL)],
                 ),
                 semantic_model_with_guaranteed_meta(
                     name="sum_measure2",
@@ -55,11 +55,11 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                         )
                     ],
                     dimensions=[
-                        Dimension(name=dim_name, type=DimensionType.CATEGORICAL),
-                        Dimension(
+                        PydanticDimension(name=dim_name, type=DimensionType.CATEGORICAL),
+                        PydanticDimension(
                             name=dim2_name,
                             type=DimensionType.TIME,
-                            type_params=DimensionTypeParams(
+                            type_params=PydanticDimensionTypeParams(
                                 is_primary=True,
                                 time_granularity=TimeGranularity.DAY,
                             ),
@@ -90,7 +90,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                         name="sum_measure",
                         measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
-                            Dimension(
+                            PydanticDimension(
                                 name=dim_name,
                                 type=DimensionType.CATEGORICAL,
                             )
@@ -121,17 +121,17 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                         name="sum_measure",
                         measures=[Measure(name=measure_name, agg=AggregationType.SUM)],
                         dimensions=[
-                            Dimension(
+                            PydanticDimension(
                                 name=dim_name,
                                 type=DimensionType.TIME,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             ),
-                            Dimension(
+                            PydanticDimension(
                                 name=dim2_name,
                                 type=DimensionType.TIME,
-                                type_params=DimensionTypeParams(
+                                type_params=PydanticDimensionTypeParams(
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             ),
@@ -159,11 +159,11 @@ def test_generated_metrics_only() -> None:  # noqa:D
         name="dim1",
         measures=[Measure(name=measure_name, agg=AggregationType.SUM, agg_time_dimension=dim2_reference.element_name)],
         dimensions=[
-            Dimension(name=dim_reference.element_name, type=DimensionType.CATEGORICAL),
-            Dimension(
+            PydanticDimension(name=dim_reference.element_name, type=DimensionType.CATEGORICAL),
+            PydanticDimension(
                 name=dim2_reference.element_name,
                 type=DimensionType.TIME,
-                type_params=DimensionTypeParams(
+                type_params=PydanticDimensionTypeParams(
                     is_primary=True,
                     time_granularity=TimeGranularity.DAY,
                 ),
@@ -199,10 +199,10 @@ def test_derived_metric() -> None:  # noqa: D
                         )
                     ],
                     dimensions=[
-                        Dimension(
+                        PydanticDimension(
                             name="ds",
                             type=DimensionType.TIME,
-                            type_params=DimensionTypeParams(
+                            type_params=PydanticDimensionTypeParams(
                                 is_primary=True,
                                 time_granularity=TimeGranularity.DAY,
                             ),

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -7,9 +7,9 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metric import (
-    MetricInput,
     MetricType,
-    MetricTypeParams,
+    PydanticMetricInput,
+    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.model_validator import ModelValidator
@@ -71,7 +71,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                 metric_with_guaranteed_meta(
                     name="metric_with_no_time_dim",
                     type=MetricType.MEASURE_PROXY,
-                    type_params=MetricTypeParams(measures=[measure_name]),
+                    type_params=PydanticMetricTypeParams(measures=[measure_name]),
                 )
             ],
         )
@@ -101,7 +101,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name="metric_with_no_time_dim",
                         type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
                     )
                 ],
             )
@@ -142,7 +142,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name="foo",
                         type=MetricType.MEASURE_PROXY,
-                        type_params=MetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
                     )
                 ],
             )
@@ -216,46 +216,50 @@ def test_derived_metric() -> None:  # noqa: D
                 metric_with_guaranteed_meta(
                     name="random_metric",
                     type=MetricType.MEASURE_PROXY,
-                    type_params=MetricTypeParams(measures=[measure_name]),
+                    type_params=PydanticMetricTypeParams(measures=[measure_name]),
                 ),
                 metric_with_guaranteed_meta(
                     name="random_metric2",
                     type=MetricType.MEASURE_PROXY,
-                    type_params=MetricTypeParams(measures=[measure_name]),
+                    type_params=PydanticMetricTypeParams(measures=[measure_name]),
                 ),
                 metric_with_guaranteed_meta(
                     name="alias_collision",
                     type=MetricType.DERIVED,
-                    type_params=MetricTypeParams(
+                    type_params=PydanticMetricTypeParams(
                         expr="random_metric2 * 2",
                         metrics=[
-                            MetricInput(name="random_metric", alias="random_metric2"),
-                            MetricInput(name="random_metric2"),
+                            PydanticMetricInput(name="random_metric", alias="random_metric2"),
+                            PydanticMetricInput(name="random_metric2"),
                         ],
                     ),
                 ),
                 metric_with_guaranteed_meta(
                     name="doesntexist",
                     type=MetricType.DERIVED,
-                    type_params=MetricTypeParams(expr="notexist * 2", metrics=[MetricInput(name="notexist")]),
+                    type_params=PydanticMetricTypeParams(
+                        expr="notexist * 2", metrics=[PydanticMetricInput(name="notexist")]
+                    ),
                 ),
                 metric_with_guaranteed_meta(
                     name="has_valid_time_window_params",
                     type=MetricType.DERIVED,
-                    type_params=MetricTypeParams(
+                    type_params=PydanticMetricTypeParams(
                         expr="random_metric / random_metric3",
                         metrics=[
-                            MetricInput(name="random_metric", offset_window="3 weeks"),
-                            MetricInput(name="random_metric", offset_to_grain="month", alias="random_metric3"),
+                            PydanticMetricInput(name="random_metric", offset_window="3 weeks"),
+                            PydanticMetricInput(name="random_metric", offset_to_grain="month", alias="random_metric3"),
                         ],
                     ),
                 ),
                 metric_with_guaranteed_meta(
                     name="has_both_time_offset_params_on_same_input_metric",
                     type=MetricType.DERIVED,
-                    type_params=MetricTypeParams(
+                    type_params=PydanticMetricTypeParams(
                         expr="random_metric * 2",
-                        metrics=[MetricInput(name="random_metric", offset_window="3 weeks", offset_to_grain="month")],
+                        metrics=[
+                            PydanticMetricInput(name="random_metric", offset_window="3 weeks", offset_to_grain="month")
+                        ],
                     ),
                 ),
             ],

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -11,7 +11,9 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInput,
     PydanticMetricTypeParams,
 )
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.references import (
     DimensionReference,
@@ -38,7 +40,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
     measure_name = "foo"
     model_validator = ModelValidator()
     model_validator.checked_validations(
-        SemanticManifest(
+        PydanticSemanticManifest(
             semantic_models=[
                 semantic_model_with_guaranteed_meta(
                     name="sum_measure",
@@ -84,7 +86,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
         measure_name = "foo"
         model_validator = ModelValidator()
         model_validator.checked_validations(
-            SemanticManifest(
+            PydanticSemanticManifest(
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="sum_measure",
@@ -115,7 +117,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
         measure_name = "foo"
         model_validator = ModelValidator()
         model_validator.checked_validations(
-            SemanticManifest(
+            PydanticSemanticManifest(
                 semantic_models=[
                     semantic_model_with_guaranteed_meta(
                         name="sum_measure",
@@ -178,7 +180,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
     semantic_model.measures[0].create_metric = True
 
     ModelValidator().checked_validations(
-        SemanticManifest(
+        PydanticSemanticManifest(
             semantic_models=[semantic_model],
             metrics=[],
         )
@@ -189,7 +191,7 @@ def test_derived_metric() -> None:  # noqa: D
     measure_name = "foo"
     model_validator = ModelValidator([DerivedMetricRule()])
     model_issues = model_validator.validate_model(
-        SemanticManifest(
+        PydanticSemanticManifest(
             semantic_models=[
                 semantic_model_with_guaranteed_meta(
                     name="sum_measure",

--- a/tests/validations/test_reserved_keywords.py
+++ b/tests/validations/test_reserved_keywords.py
@@ -1,7 +1,9 @@
 import random
 from copy import deepcopy
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.implementations.semantic_model import NodeRelation
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.validations.reserved_keywords import (
@@ -15,13 +17,15 @@ def random_keyword() -> str:  # noqa: D
     return random.choice(RESERVED_KEYWORDS)
 
 
-def test_no_reserved_keywords(simple_semantic_manifest__with_primary_transforms: SemanticManifest) -> None:  # noqa: D
+def test_no_reserved_keywords(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
     issues = ReservedKeywordsRule.validate_model(simple_semantic_manifest__with_primary_transforms)
     assert len(issues) == 0
 
 
 def test_reserved_keywords_in_dimensions(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
     (semantic_model, _index) = find_semantic_model_with(
@@ -36,7 +40,7 @@ def test_reserved_keywords_in_dimensions(  # noqa: D
 
 
 def test_reserved_keywords_in_measures(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
     (semantic_model, _index) = find_semantic_model_with(
@@ -51,7 +55,7 @@ def test_reserved_keywords_in_measures(  # noqa: D
 
 
 def test_reserved_keywords_in_entities(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
     (semantic_model, _index) = find_semantic_model_with(
@@ -66,7 +70,7 @@ def test_reserved_keywords_in_entities(  # noqa: D
 
 
 def test_reserved_keywords_in_node_relation(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
     (semantic_model_with_node_relation, _index) = find_semantic_model_with(

--- a/tests/validations/test_semantic_models.py
+++ b/tests/validations/test_semantic_models.py
@@ -1,8 +1,8 @@
 import pytest
 
 from dbt_semantic_interfaces.implementations.elements.dimension import (
-    Dimension,
-    DimensionTypeParams,
+    PydanticDimension,
+    PydanticDimensionTypeParams,
 )
 from dbt_semantic_interfaces.test_utils import semantic_model_with_guaranteed_meta
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -18,10 +18,10 @@ def test_semantic_model_invalid_sql() -> None:  # noqa:D
         semantic_model_with_guaranteed_meta(
             name="invalid_sql_source",
             dimensions=[
-                Dimension(
+                PydanticDimension(
                     name="ds",
                     type=DimensionType.TIME,
-                    type_params=DimensionTypeParams(
+                    type_params=PydanticDimensionTypeParams(
                         time_granularity=TimeGranularity.DAY,
                     ),
                 )

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -3,7 +3,9 @@ from copy import deepcopy
 import more_itertools
 import pytest
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_validator import ModelValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.validations.unique_valid_name import (
@@ -29,7 +31,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 
 
 def test_duplicate_semantic_model_name(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
     duplicated_semantic_model = model.semantic_models[0]
@@ -42,7 +44,9 @@ def test_duplicate_semantic_model_name(  # noqa: D
         ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
-def test_duplicate_metric_name(simple_semantic_manifest__with_primary_transforms: SemanticManifest) -> None:  # noqa:D
+def test_duplicate_metric_name(  # noqa:D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
     duplicated_metric = model.metrics[0]
     model.metrics.append(duplicated_metric)
@@ -54,7 +58,7 @@ def test_duplicate_metric_name(simple_semantic_manifest__with_primary_transforms
 
 
 def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     metric_name = simple_semantic_manifest__with_primary_transforms.metrics[0].name
 
@@ -77,7 +81,9 @@ def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(  # noq
 """
 
 
-def test_duplicate_measure_name(simple_semantic_manifest__with_primary_transforms: SemanticManifest) -> None:  # noqa:D
+def test_duplicate_measure_name(  # noqa:D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
 
     # Ensure we have a usable semantic model for the test
@@ -98,7 +104,7 @@ def test_duplicate_measure_name(simple_semantic_manifest__with_primary_transform
 
 
 def test_duplicate_dimension_name(  # noqa: D
-    simple_semantic_manifest__with_primary_transforms: SemanticManifest,
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
 
@@ -119,7 +125,9 @@ def test_duplicate_dimension_name(  # noqa: D
         ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
-def test_duplicate_entity_name(simple_semantic_manifest__with_primary_transforms: SemanticManifest) -> None:  # noqa:D
+def test_duplicate_entity_name(  # noqa:D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
     model = deepcopy(simple_semantic_manifest__with_primary_transforms)
 
     # Ensure we have a usable semantic model for the test

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -19,11 +19,11 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
     Top level elements include
     - Semantic Models
     - Metrics
-    - Metric Sets
+    - PydanticMetric Sets
     - Dimension Sets
 
     A name for any of these elements must be unique to all other top level elements
-    except metrics. Metric names only need to be unique in comparison to other metric
+    except metrics. PydanticMetric names only need to be unique in comparison to other metric
     names.
 """
 


### PR DESCRIPTION
### Description

This PR changes the protocols used for defining the semantic manifest to use an abstract property as it allows us to use the existing Pydantic implementations.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
