### PR TITLE
Change Validations to be Generic

### DIFF
--- a/dbt_semantic_interfaces/model_validator.py
+++ b/dbt_semantic_interfaces/model_validator.py
@@ -43,7 +43,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 logger = logging.getLogger(__name__)
 
 
-class ModelValidator:
+class SemanticManifestValidator:
     """A Validator that acts on SemanticManifest."""
 
     DEFAULT_RULES = (
@@ -76,7 +76,9 @@ class ModelValidator:
         """
         # Raises an error if 'rules' is an empty sequence or None
         if not rules:
-            raise ValueError("ModelValidator 'rules' must be a sequence with at least one ModelValidationRule.")
+            raise ValueError(
+                "SemanticManifestValidator 'rules' must be a sequence with at least one ModelValidationRule."
+            )
 
         self._rules = rules
         self._executor = ProcessPoolExecutor(max_workers=max_workers)

--- a/dbt_semantic_interfaces/model_validator.py
+++ b/dbt_semantic_interfaces/model_validator.py
@@ -36,8 +36,8 @@ from dbt_semantic_interfaces.validations.semantic_models import (
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
     ModelValidationException,
-    ModelValidationRule,
     SemanticManifestValidationResults,
+    SemanticManifestValidationRule,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ class SemanticManifestValidator:
         MeasuresNonAdditiveDimensionRule(),
     )
 
-    def __init__(self, rules: Sequence[ModelValidationRule] = DEFAULT_RULES, max_workers: int = 1) -> None:
+    def __init__(self, rules: Sequence[SemanticManifestValidationRule] = DEFAULT_RULES, max_workers: int = 1) -> None:
         """Constructor.
 
         Args:
@@ -77,7 +77,7 @@ class SemanticManifestValidator:
         # Raises an error if 'rules' is an empty sequence or None
         if not rules:
             raise ValueError(
-                "SemanticManifestValidator 'rules' must be a sequence with at least one ModelValidationRule."
+                "SemanticManifestValidator 'rules' must be a sequence with at least one SemanticManifestValidationRule."
             )
 
         self._rules = rules

--- a/dbt_semantic_interfaces/model_validator.py
+++ b/dbt_semantic_interfaces/model_validator.py
@@ -36,8 +36,8 @@ from dbt_semantic_interfaces.validations.semantic_models import (
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
     ModelValidationException,
-    ModelValidationResults,
     ModelValidationRule,
+    SemanticManifestValidationResults,
 )
 
 logger = logging.getLogger(__name__)
@@ -83,11 +83,11 @@ class SemanticManifestValidator:
         self._rules = rules
         self._executor = ProcessPoolExecutor(max_workers=max_workers)
 
-    def validate_model(self, model: PydanticSemanticManifest) -> ModelValidationResults:
+    def validate_model(self, model: PydanticSemanticManifest) -> SemanticManifestValidationResults:
         """Validate a model according to configured rules."""
         serialized_model = model.json()
 
-        results: List[ModelValidationResults] = []
+        results: List[SemanticManifestValidationResults] = []
 
         futures = [
             self._executor.submit(validation_rule.validate_model_serialized_for_multiprocessing, serialized_model)
@@ -95,10 +95,10 @@ class SemanticManifestValidator:
         ]
         for future in as_completed(futures):
             res = future.result()
-            result = ModelValidationResults.parse_raw(res)
+            result = SemanticManifestValidationResults.parse_raw(res)
             results.append(result)
 
-        return ModelValidationResults.merge(results)
+        return SemanticManifestValidationResults.merge(results)
 
     def checked_validations(self, model: PydanticSemanticManifest) -> None:
         """Similar to validate(), but throws an exception if validation fails."""

--- a/dbt_semantic_interfaces/model_validator.py
+++ b/dbt_semantic_interfaces/model_validator.py
@@ -49,7 +49,7 @@ def _validate_manifest_with_one_rule(
     Result is returned as a serialized object as there are pickling issues with SemanticManifestValidationResults.
     """
     return SemanticManifestValidationResults.from_issues_sequence(
-        validation_rule.validate_model(semantic_manifest)
+        validation_rule.validate_manifest(semantic_manifest)
     ).json()
 
 

--- a/dbt_semantic_interfaces/model_validator.py
+++ b/dbt_semantic_interfaces/model_validator.py
@@ -33,7 +33,7 @@ from dbt_semantic_interfaces.validations.semantic_models import (
 )
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
     SemanticManifestValidationResults,
     SemanticManifestValidationRule,
 )
@@ -113,4 +113,4 @@ class SemanticManifestValidator:
         model_copy = copy.deepcopy(model)
         model_issues = self.validate_model(model_copy)
         if model_issues.has_blocking_issues:
-            raise ModelValidationException(issues=tuple(model_issues.all_issues))
+            raise SemanticManifestValidationException(issues=tuple(model_issues.all_issues))

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -26,7 +26,7 @@ from dbt_semantic_interfaces.parsing.yaml_loader import (
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationException,
+    SemanticManifestValidationException,
     SemanticManifestValidationResults,
     ValidationError,
     ValidationIssue,
@@ -172,7 +172,7 @@ def parse_yaml_files_to_validation_ready_model(
         build_issues = SemanticManifestValidationResults.merge([build_issues, transformation_issue_results])
 
     if raise_issues_as_exceptions and build_issues.has_blocking_issues:
-        raise ModelValidationException(build_issues.all_issues)
+        raise SemanticManifestValidationException(build_issues.all_issues)
 
     return ModelBuildResult(model=model, issues=build_issues)
 

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -27,7 +27,7 @@ from dbt_semantic_interfaces.parsing.yaml_loader import (
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     ModelValidationException,
-    ModelValidationResults,
+    SemanticManifestValidationResults,
     ValidationError,
     ValidationIssue,
 )
@@ -44,7 +44,7 @@ DOCUMENT_TYPES = [METRIC_TYPE, SEMANTIC_MODEL_TYPE]
 class ModelBuildResult:  # noqa: D
     model: PydanticSemanticManifest
     # Issues found in the model.
-    issues: ModelValidationResults = ModelValidationResults()
+    issues: SemanticManifestValidationResults = SemanticManifestValidationResults()
 
 
 @dataclass(frozen=True)
@@ -168,8 +168,8 @@ def parse_yaml_files_to_validation_ready_model(
         if apply_transformations:
             model = ModelTransformer.transform(model)
     except Exception as e:
-        transformation_issue_results = ModelValidationResults(errors=[ValidationError(message=str(e))])
-        build_issues = ModelValidationResults.merge([build_issues, transformation_issue_results])
+        transformation_issue_results = SemanticManifestValidationResults(errors=[ValidationError(message=str(e))])
+        build_issues = SemanticManifestValidationResults.merge([build_issues, transformation_issue_results])
 
     if raise_issues_as_exceptions and build_issues.has_blocking_issues:
         raise ModelValidationException(build_issues.all_issues)
@@ -221,7 +221,7 @@ def parse_yaml_files_to_model(
             semantic_models=semantic_models,
             metrics=metrics,
         ),
-        issues=ModelValidationResults.from_issues_sequence(issues),
+        issues=SemanticManifestValidationResults.from_issues_sequence(issues),
     )
 
 

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import List, Optional, Protocol, Sequence
+from typing import Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.protocols.where_filter import WhereFilter
@@ -180,19 +180,19 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def input_measures(self: Metric) -> List[MetricInputMeasure]:
+    def input_measures(self: Metric) -> Sequence[MetricInputMeasure]:
         """Return the complete list of input measure configurations for this metric."""
         ...
 
     @property
     @abstractmethod
-    def measure_references(self) -> List[MeasureReference]:
+    def measure_references(self) -> Sequence[MeasureReference]:
         """Return the measure references associated with all input measure configurations for this metric."""
         ...
 
     @property
     @abstractmethod
-    def input_metrics(self) -> List[MetricInput]:
+    def input_metrics(self) -> Sequence[MetricInput]:
         """Return the associated input metrics for this metric."""
         ...
 

--- a/dbt_semantic_interfaces/protocols/semantic_manifest.py
+++ b/dbt_semantic_interfaces/protocols/semantic_manifest.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol, Sequence
+from typing import Protocol, Sequence, TypeVar
 
 from dbt_semantic_interfaces.protocols.metric import Metric
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
@@ -22,3 +22,6 @@ class SemanticManifest(Protocol):
     @abstractmethod
     def interfaces_version(self) -> str:  # noqa: D
         pass
+
+
+SemanticManifestT = TypeVar("SemanticManifestT", bound=SemanticManifest)

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Optional, Protocol, Sequence
+from typing import Optional, Protocol, Sequence, TypeVar
 
 from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
@@ -129,3 +129,6 @@ class SemanticModel(Protocol):
     @abstractmethod
     def metadata(self) -> Optional[Metadata]:  # noqa: D
         pass
+
+
+SemanticModelT = TypeVar("SemanticModelT", bound=SemanticModel)

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import List, Optional, Protocol, Sequence
+from typing import Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
@@ -73,19 +73,19 @@ class SemanticModel(Protocol):
 
     @property
     @abstractmethod
-    def entity_references(self) -> List[LinkableElementReference]:
+    def entity_references(self) -> Sequence[LinkableElementReference]:
         """Returns a list of references to all entities in the semantic model."""
         ...
 
     @property
     @abstractmethod
-    def dimension_references(self) -> List[LinkableElementReference]:
+    def dimension_references(self) -> Sequence[LinkableElementReference]:
         """Returns a list of references to all dimensions in the semantic model."""
         ...
 
     @property
     @abstractmethod
-    def measure_references(self) -> List[MeasureReference]:
+    def measure_references(self) -> Sequence[MeasureReference]:
         """Returns a list of references to all measures in the semantic model."""
         ...
 
@@ -109,7 +109,7 @@ class SemanticModel(Protocol):
 
     @property
     @abstractmethod
-    def partitions(self) -> List[Dimension]:
+    def partitions(self) -> Sequence[Dimension]:
         """Returns a list of all partition dimensions."""
         ...
 

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -1,6 +1,6 @@
-from typing import List, Sequence
+from typing import Generic, List, Sequence
 
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     SemanticModelElementReference,
@@ -18,12 +18,12 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class AggregationTimeDimensionRule(SemanticManifestValidationRule):
+class AggregationTimeDimensionRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that the agg time dimension for a measure points to a valid time dimension in the semantic model."""
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for semantic models in the model")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         for semantic_model in semantic_manifest.semantic_models:
             issues.extend(AggregationTimeDimensionRule._validate_semantic_model(semantic_model))

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.references import (
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelElementContext,
     SemanticModelElementType,
     ValidationError,
@@ -18,7 +18,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class AggregationTimeDimensionRule(ModelValidationRule):
+class AggregationTimeDimensionRule(SemanticManifestValidationRule):
     """Checks that the agg time dimension for a measure points to a valid time dimension in the semantic model."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -23,9 +23,9 @@ class AggregationTimeDimensionRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for semantic models in the model")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues.extend(AggregationTimeDimensionRule._validate_semantic_model(semantic_model))
 
         return issues

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.references import (
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelElementContext,
     SemanticModelElementType,
     ValidationIssue,
@@ -18,7 +18,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class CommonEntitysRule(ModelValidationRule):
+class CommonEntitysRule(SemanticManifestValidationRule):
     """Checks that entities exist on more than one semantic model."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -65,12 +65,12 @@ class CommonEntitysRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation warning if entities are only one one semantic model")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         """Issues a warning for any entity that is associated with only one semantic_model."""
         issues = []
 
-        entities_to_semantic_models = CommonEntitysRule._map_semantic_model_entities(model.semantic_models)
-        for semantic_model in model.semantic_models or []:
+        entities_to_semantic_models = CommonEntitysRule._map_semantic_model_entities(semantic_manifest.semantic_models)
+        for semantic_model in semantic_manifest.semantic_models or []:
             for entity in semantic_model.entities or []:
                 issues += CommonEntitysRule._check_entity(
                     entity=entity,

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -1,7 +1,7 @@
-from typing import Dict, List, Sequence, Set
+from typing import Dict, Generic, List, Sequence, Set
 
 from dbt_semantic_interfaces.protocols.entity import Entity
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     EntityReference,
@@ -18,7 +18,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class CommonEntitysRule(SemanticManifestValidationRule):
+class CommonEntitysRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that entities exist on more than one semantic model."""
 
     @staticmethod
@@ -65,7 +65,7 @@ class CommonEntitysRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation warning if entities are only one one semantic model")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
         """Issues a warning for any entity that is associated with only one semantic_model."""
         issues = []
 

--- a/dbt_semantic_interfaces/validations/dimension_const.py
+++ b/dbt_semantic_interfaces/validations/dimension_const.py
@@ -30,12 +30,12 @@ class DimensionConsistencyRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring dimension consistency")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         dimension_to_invariant: Dict[DimensionReference, DimensionInvariants] = {}
         time_dims_to_granularity: Dict[DimensionReference, TimeGranularity] = {}
         issues: List[ValidationIssue] = []
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues += DimensionConsistencyRule._validate_semantic_model(
                 semantic_model=semantic_model, dimension_to_invariant=dimension_to_invariant, update_invariant_dict=True
             )

--- a/dbt_semantic_interfaces/validations/dimension_const.py
+++ b/dbt_semantic_interfaces/validations/dimension_const.py
@@ -1,7 +1,7 @@
-from typing import Dict, List, Sequence
+from typing import Dict, Generic, List, Sequence
 
 from dbt_semantic_interfaces.protocols.dimension import Dimension
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     DimensionReference,
@@ -21,7 +21,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class DimensionConsistencyRule(SemanticManifestValidationRule):
+class DimensionConsistencyRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks for consistent dimension properties in the semantic models in a model.
 
     * Dimensions with the same name should be of the same type.
@@ -30,7 +30,7 @@ class DimensionConsistencyRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring dimension consistency")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         dimension_to_invariant: Dict[DimensionReference, DimensionInvariants] = {}
         time_dims_to_granularity: Dict[DimensionReference, TimeGranularity] = {}
         issues: List[ValidationIssue] = []

--- a/dbt_semantic_interfaces/validations/dimension_const.py
+++ b/dbt_semantic_interfaces/validations/dimension_const.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.validator_helpers import (
     DimensionInvariants,
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelElementContext,
     SemanticModelElementType,
     ValidationError,
@@ -21,7 +21,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class DimensionConsistencyRule(ModelValidationRule):
+class DimensionConsistencyRule(SemanticManifestValidationRule):
     """Checks for consistent dimension properties in the semantic models in a model.
 
     * Dimensions with the same name should be of the same type.

--- a/dbt_semantic_interfaces/validations/element_const.py
+++ b/dbt_semantic_interfaces/validations/element_const.py
@@ -27,9 +27,9 @@ class ElementConsistencyRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring model wide element consistency")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
-        element_name_to_types = ElementConsistencyRule._get_element_name_to_types(model=model)
+        element_name_to_types = ElementConsistencyRule._get_element_name_to_types(model=semantic_manifest)
         invalid_elements = {
             name: type_mapping for name, type_mapping in element_name_to_types.items() if len(type_mapping) > 1
         }

--- a/dbt_semantic_interfaces/validations/element_const.py
+++ b/dbt_semantic_interfaces/validations/element_const.py
@@ -1,9 +1,10 @@
 from collections import defaultdict
-from typing import DefaultDict, List, Sequence
+from typing import DefaultDict, Generic, List, Sequence
 
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
@@ -16,7 +17,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class ElementConsistencyRule(SemanticManifestValidationRule):
+class ElementConsistencyRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that elements in semantic models with the same name are of the same element type across the model.
 
     This reduces the potential confusion that might arise from having an entity named `country` and a dimension

--- a/dbt_semantic_interfaces/validations/element_const.py
+++ b/dbt_semantic_interfaces/validations/element_const.py
@@ -7,7 +7,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelContext,
     SemanticModelElementType,
     ValidationError,
@@ -16,7 +16,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class ElementConsistencyRule(ModelValidationRule):
+class ElementConsistencyRule(SemanticManifestValidationRule):
     """Checks that elements in semantic models with the same name are of the same element type across the model.
 
     This reduces the potential confusion that might arise from having an entity named `country` and a dimension

--- a/dbt_semantic_interfaces/validations/entities.py
+++ b/dbt_semantic_interfaces/validations/entities.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelContext,
     ValidationError,
     ValidationFutureError,
@@ -19,7 +19,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 logger = logging.getLogger(__name__)
 
 
-class NaturalEntityConfigurationRule(ModelValidationRule):
+class NaturalEntityConfigurationRule(SemanticManifestValidationRule):
     """Ensures that entities marked as EntityType.NATURAL are configured correctly."""
 
     @staticmethod
@@ -72,7 +72,7 @@ class NaturalEntityConfigurationRule(ModelValidationRule):
         return issues
 
 
-class OnePrimaryEntityPerSemanticModelRule(ModelValidationRule):
+class OnePrimaryEntityPerSemanticModelRule(SemanticManifestValidationRule):
     """Ensures that each semantic model has only one primary entity."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/entities.py
+++ b/dbt_semantic_interfaces/validations/entities.py
@@ -61,10 +61,10 @@ class NaturalEntityConfigurationRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that entities marked as EntityType.NATURAL are properly configured")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         """Validate entities marked as EntityType.NATURAL."""
         issues: List[ValidationIssue] = []
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues += NaturalEntityConfigurationRule._validate_semantic_model_natural_entities(
                 semantic_model=semantic_model
             )
@@ -101,10 +101,10 @@ class OnePrimaryEntityPerSemanticModelRule(SemanticManifestValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring each semantic model has only one primary entity"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues += OnePrimaryEntityPerSemanticModelRule._only_one_primary_entity(semantic_model=semantic_model)
 
         return issues

--- a/dbt_semantic_interfaces/validations/entities.py
+++ b/dbt_semantic_interfaces/validations/entities.py
@@ -1,8 +1,8 @@
 import logging
 from datetime import date
-from typing import List, MutableSet, Sequence
+from typing import Generic, List, MutableSet, Sequence
 
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
@@ -19,7 +19,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 logger = logging.getLogger(__name__)
 
 
-class NaturalEntityConfigurationRule(SemanticManifestValidationRule):
+class NaturalEntityConfigurationRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Ensures that entities marked as EntityType.NATURAL are configured correctly."""
 
     @staticmethod
@@ -61,7 +61,7 @@ class NaturalEntityConfigurationRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that entities marked as EntityType.NATURAL are properly configured")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
         """Validate entities marked as EntityType.NATURAL."""
         issues: List[ValidationIssue] = []
         for semantic_model in semantic_manifest.semantic_models:
@@ -72,7 +72,9 @@ class NaturalEntityConfigurationRule(SemanticManifestValidationRule):
         return issues
 
 
-class OnePrimaryEntityPerSemanticModelRule(SemanticManifestValidationRule):
+class OnePrimaryEntityPerSemanticModelRule(
+    SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]
+):
     """Ensures that each semantic model has only one primary entity."""
 
     @staticmethod
@@ -101,7 +103,7 @@ class OnePrimaryEntityPerSemanticModelRule(SemanticManifestValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring each semantic model has only one primary entity"
     )
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
 
         for semantic_model in semantic_manifest.semantic_models:

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -30,11 +30,11 @@ class SemanticModelMeasuresUniqueRule(SemanticManifestValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring measures exist in only one configured semantic model"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         measure_references_to_semantic_models: Dict[MeasureReference, List] = defaultdict(list)
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             for measure in semantic_model.measures:
                 if measure.reference in measure_references_to_semantic_models:
                     issues.append(
@@ -124,7 +124,7 @@ class MeasureConstraintAliasesRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking constrained measures are aliased properly")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         """Ensures measures that might need an alias have one set, and that the alias is distinct.
 
         We do not allow aliases to collide with other alias or measure names, since that could create
@@ -132,9 +132,9 @@ class MeasureConstraintAliasesRule(SemanticManifestValidationRule):
         """
         issues: List[ValidationIssue] = []
 
-        measure_names = _get_measure_names_from_model(model)
+        measure_names = _get_measure_names_from_model(semantic_manifest)
         measure_alias_to_metrics: DefaultDict[str, List[str]] = defaultdict(list)
-        for metric in model.metrics:
+        for metric in semantic_manifest.metrics:
             metric_context = MetricContext(
                 file_context=FileContext.from_metadata(metadata=metric.metadata),
                 metric=MetricModelReference(metric_name=metric.name),
@@ -207,11 +207,11 @@ class MetricMeasuresRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
-        valid_measure_names = _get_measure_names_from_model(model)
+        valid_measure_names = _get_measure_names_from_model(semantic_manifest)
 
-        for metric in model.metrics or []:
+        for metric in semantic_manifest.metrics or []:
             issues += MetricMeasuresRule._validate_metric_measure_references(
                 metric=metric, valid_measure_names=valid_measure_names
             )
@@ -223,9 +223,9 @@ class MeasuresNonAdditiveDimensionRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring that a measure's non_additive_dimensions is valid")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
-        for semantic_model in model.semantic_models or []:
+        for semantic_model in semantic_manifest.semantic_models or []:
             for measure in semantic_model.measures:
                 non_additive_dimension = measure.non_additive_dimension
                 if non_additive_dimension is None:
@@ -380,10 +380,10 @@ class CountAggregationExprRule(SemanticManifestValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring expr exist for measures with count aggregation"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             for measure in semantic_model.measures:
                 context = SemanticModelElementContext(
                     file_context=FileContext.from_metadata(metadata=semantic_model.metadata),
@@ -432,10 +432,10 @@ class PercentileAggregationRule(SemanticManifestValidationRule):
         whats_being_done="running model validation ensuring the agg_params.percentile value exist for measures with "
         "percentile aggregation"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             for measure in semantic_model.measures:
                 context = SemanticModelElementContext(
                     file_context=FileContext.from_metadata(metadata=semantic_model.metadata),

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -3,10 +3,8 @@ from typing import DefaultDict, Dict, List, Sequence, Set
 
 from more_itertools import bucket
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
 from dbt_semantic_interfaces.protocols.metric import Metric
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import MeasureReference, MetricModelReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -32,7 +30,7 @@ class SemanticModelMeasuresUniqueRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring measures exist in only one configured semantic model"
     )
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         measure_references_to_semantic_models: Dict[MeasureReference, List] = defaultdict(list)
@@ -126,7 +124,7 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking constrained measures are aliased properly")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
         """Ensures measures that might need an alias have one set, and that the alias is distinct.
 
         We do not allow aliases to collide with other alias or measure names, since that could create
@@ -209,7 +207,7 @@ class MetricMeasuresRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         valid_measure_names = _get_measure_names_from_model(model)
 
@@ -225,7 +223,7 @@ class MeasuresNonAdditiveDimensionRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring that a measure's non_additive_dimensions is valid")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         for semantic_model in model.semantic_models or []:
             for measure in semantic_model.measures:
@@ -253,8 +251,8 @@ class MeasuresNonAdditiveDimensionRule(ModelValidationRule):
                             ),
                             message=(
                                 f"Measure '{measure.name}' has a agg_time_dimension of "
-                                f"{measure.checked_agg_time_dimension.element_name} ",
-                                f"that is not defined as a dimension in semantic model '{semantic_model.name}'.",
+                                f"{measure.checked_agg_time_dimension.element_name} "
+                                f"that is not defined as a dimension in semantic model '{semantic_model.name}'."
                             ),
                         )
                     )
@@ -382,7 +380,7 @@ class CountAggregationExprRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring expr exist for measures with count aggregation"
     )
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in model.semantic_models:
@@ -434,7 +432,7 @@ class PercentileAggregationRule(ModelValidationRule):
         whats_being_done="running model validation ensuring the agg_params.percentile value exist for measures with "
         "percentile aggregation"
     )
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in model.semantic_models:
@@ -517,7 +515,7 @@ class PercentileAggregationRule(ModelValidationRule):
         return issues
 
 
-def _get_measure_names_from_model(model: PydanticSemanticManifest) -> Set[str]:
+def _get_measure_names_from_model(model: SemanticManifest) -> Set[str]:
     """Return every distinct measure name specified in the model."""
     measure_names = set()
     for semantic_model in model.semantic_models:

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValid
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     MetricContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelElementContext,
     SemanticModelElementReference,
     SemanticModelElementType,
@@ -23,7 +23,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class SemanticModelMeasuresUniqueRule(ModelValidationRule):
+class SemanticModelMeasuresUniqueRule(SemanticManifestValidationRule):
     """Asserts all measure names are unique across the model."""
 
     @staticmethod
@@ -55,7 +55,7 @@ class SemanticModelMeasuresUniqueRule(ModelValidationRule):
         return issues
 
 
-class MeasureConstraintAliasesRule(ModelValidationRule):
+class MeasureConstraintAliasesRule(SemanticManifestValidationRule):
     """Checks that aliases are configured correctly for constrained measure references.
 
     These are, currently, only applicable for PydanticMetric types, since the MetricInputMeasure is only
@@ -181,7 +181,7 @@ class MeasureConstraintAliasesRule(ModelValidationRule):
         return issues
 
 
-class MetricMeasuresRule(ModelValidationRule):
+class MetricMeasuresRule(SemanticManifestValidationRule):
     """Checks that the measures referenced in the metrics exist."""
 
     @staticmethod
@@ -218,7 +218,7 @@ class MetricMeasuresRule(ModelValidationRule):
         return issues
 
 
-class MeasuresNonAdditiveDimensionRule(ModelValidationRule):
+class MeasuresNonAdditiveDimensionRule(SemanticManifestValidationRule):
     """Checks that the measure's non_additive_dimensions are properly defined."""
 
     @staticmethod
@@ -373,7 +373,7 @@ class MeasuresNonAdditiveDimensionRule(ModelValidationRule):
         return issues
 
 
-class CountAggregationExprRule(ModelValidationRule):
+class CountAggregationExprRule(SemanticManifestValidationRule):
     """Checks that COUNT measures have an expr provided."""
 
     @staticmethod
@@ -424,7 +424,7 @@ class CountAggregationExprRule(ModelValidationRule):
         return issues
 
 
-class PercentileAggregationRule(ModelValidationRule):
+class PercentileAggregationRule(SemanticManifestValidationRule):
     """Checks that only PERCENTILE measures have agg_params and valid percentile value provided."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -1,10 +1,13 @@
 from collections import defaultdict
-from typing import DefaultDict, Dict, List, Sequence, Set
+from typing import DefaultDict, Dict, Generic, List, Sequence, Set
 
 from more_itertools import bucket
 
 from dbt_semantic_interfaces.protocols.metric import Metric
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import (
+    SemanticManifest,
+    SemanticManifestT,
+)
 from dbt_semantic_interfaces.references import MeasureReference, MetricModelReference
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -23,14 +26,14 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class SemanticModelMeasuresUniqueRule(SemanticManifestValidationRule):
+class SemanticModelMeasuresUniqueRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Asserts all measure names are unique across the model."""
 
     @staticmethod
     @validate_safely(
         whats_being_done="running model validation ensuring measures exist in only one configured semantic model"
     )
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         measure_references_to_semantic_models: Dict[MeasureReference, List] = defaultdict(list)
@@ -55,7 +58,7 @@ class SemanticModelMeasuresUniqueRule(SemanticManifestValidationRule):
         return issues
 
 
-class MeasureConstraintAliasesRule(SemanticManifestValidationRule):
+class MeasureConstraintAliasesRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that aliases are configured correctly for constrained measure references.
 
     These are, currently, only applicable for PydanticMetric types, since the MetricInputMeasure is only
@@ -124,7 +127,7 @@ class MeasureConstraintAliasesRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking constrained measures are aliased properly")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
         """Ensures measures that might need an alias have one set, and that the alias is distinct.
 
         We do not allow aliases to collide with other alias or measure names, since that could create
@@ -181,7 +184,7 @@ class MeasureConstraintAliasesRule(SemanticManifestValidationRule):
         return issues
 
 
-class MetricMeasuresRule(SemanticManifestValidationRule):
+class MetricMeasuresRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that the measures referenced in the metrics exist."""
 
     @staticmethod
@@ -207,7 +210,7 @@ class MetricMeasuresRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring metric measures exist")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         valid_measure_names = _get_measure_names_from_model(semantic_manifest)
 
@@ -218,12 +221,12 @@ class MetricMeasuresRule(SemanticManifestValidationRule):
         return issues
 
 
-class MeasuresNonAdditiveDimensionRule(SemanticManifestValidationRule):
+class MeasuresNonAdditiveDimensionRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that the measure's non_additive_dimensions are properly defined."""
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring that a measure's non_additive_dimensions is valid")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
         for semantic_model in semantic_manifest.semantic_models or []:
             for measure in semantic_model.measures:
@@ -373,14 +376,14 @@ class MeasuresNonAdditiveDimensionRule(SemanticManifestValidationRule):
         return issues
 
 
-class CountAggregationExprRule(SemanticManifestValidationRule):
+class CountAggregationExprRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that COUNT measures have an expr provided."""
 
     @staticmethod
     @validate_safely(
         whats_being_done="running model validation ensuring expr exist for measures with count aggregation"
     )
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in semantic_manifest.semantic_models:
@@ -424,7 +427,7 @@ class CountAggregationExprRule(SemanticManifestValidationRule):
         return issues
 
 
-class PercentileAggregationRule(SemanticManifestValidationRule):
+class PercentileAggregationRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that only PERCENTILE measures have agg_params and valid percentile value provided."""
 
     @staticmethod
@@ -432,7 +435,7 @@ class PercentileAggregationRule(SemanticManifestValidationRule):
         whats_being_done="running model validation ensuring the agg_params.percentile value exist for measures with "
         "percentile aggregation"
     )
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in semantic_manifest.semantic_models:

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -10,14 +10,14 @@ from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValid
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     MetricContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     ValidationError,
     ValidationIssue,
     validate_safely,
 )
 
 
-class CumulativeMetricRule(ModelValidationRule):
+class CumulativeMetricRule(SemanticManifestValidationRule):
     """Checks that cumulative sum metrics are configured properly."""
 
     @staticmethod
@@ -67,7 +67,7 @@ class CumulativeMetricRule(ModelValidationRule):
         return issues
 
 
-class DerivedMetricRule(ModelValidationRule):
+class DerivedMetricRule(SemanticManifestValidationRule):
     """Checks that derived metrics are configured properly."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -1,10 +1,13 @@
 import traceback
-from typing import List, Sequence
+from typing import Generic, List, Sequence
 
 from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.implementations.metric import PydanticMetricTimeWindow
 from dbt_semantic_interfaces.protocols.metric import Metric, MetricType
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import (
+    SemanticManifest,
+    SemanticManifestT,
+)
 from dbt_semantic_interfaces.references import MetricModelReference
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -17,7 +20,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class CumulativeMetricRule(SemanticManifestValidationRule):
+class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that cumulative sum metrics are configured properly."""
 
     @staticmethod
@@ -58,7 +61,7 @@ class CumulativeMetricRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring cumulative sum metrics are valid")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for metric in semantic_manifest.metrics or []:
@@ -67,7 +70,7 @@ class CumulativeMetricRule(SemanticManifestValidationRule):
         return issues
 
 
-class DerivedMetricRule(SemanticManifestValidationRule):
+class DerivedMetricRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that derived metrics are configured properly."""
 
     @staticmethod
@@ -141,7 +144,7 @@ class DerivedMetricRule(SemanticManifestValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring derived metrics properties are configured properly"
     )
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         issues += DerivedMetricRule._validate_input_metrics_exist(model=semantic_manifest)

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -2,14 +2,9 @@ import traceback
 from typing import List, Sequence
 
 from dbt_semantic_interfaces.errors import ParsingException
-from dbt_semantic_interfaces.implementations.metric import (
-    MetricType,
-    PydanticMetricTimeWindow,
-)
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
-from dbt_semantic_interfaces.protocols.metric import Metric
+from dbt_semantic_interfaces.implementations.metric import PydanticMetricTimeWindow
+from dbt_semantic_interfaces.protocols.metric import Metric, MetricType
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import MetricModelReference
 from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -45,6 +40,7 @@ class CumulativeMetricRule(ModelValidationRule):
             if metric.type_params.window:
                 try:
                     window_str = f"{metric.type_params.window.count} {metric.type_params.window.granularity.value}"
+                    # TODO: Should not call an implementation class.
                     PydanticMetricTimeWindow.parse(window_str)
                 except ParsingException as e:
                     issues.append(
@@ -62,7 +58,7 @@ class CumulativeMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring cumulative sum metrics are valid")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for metric in model.metrics or []:
@@ -101,7 +97,7 @@ class DerivedMetricRule(ModelValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the input metrics exist")
-    def _validate_input_metrics_exist(model: PydanticSemanticManifest) -> List[ValidationIssue]:
+    def _validate_input_metrics_exist(model: SemanticManifest) -> List[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         all_metrics = {m.name for m in model.metrics}
@@ -145,7 +141,7 @@ class DerivedMetricRule(ModelValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring derived metrics properties are configured properly"
     )
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         issues += DerivedMetricRule._validate_input_metrics_exist(model=model)

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -58,10 +58,10 @@ class CumulativeMetricRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring cumulative sum metrics are valid")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
-        for metric in model.metrics or []:
+        for metric in semantic_manifest.metrics or []:
             issues += CumulativeMetricRule._validate_cumulative_sum_metric_params(metric=metric)
 
         return issues
@@ -141,11 +141,11 @@ class DerivedMetricRule(SemanticManifestValidationRule):
     @validate_safely(
         whats_being_done="running model validation ensuring derived metrics properties are configured properly"
     )
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
-        issues += DerivedMetricRule._validate_input_metrics_exist(model=model)
-        for metric in model.metrics or []:
+        issues += DerivedMetricRule._validate_input_metrics_exist(model=semantic_manifest)
+        for metric in semantic_manifest.metrics or []:
             issues += DerivedMetricRule._validate_alias_collision(metric=metric)
             issues += DerivedMetricRule._validate_time_offset_params(metric=metric)
         return issues

--- a/dbt_semantic_interfaces/validations/non_empty.py
+++ b/dbt_semantic_interfaces/validations/non_empty.py
@@ -1,8 +1,9 @@
-from typing import List, Sequence
+from typing import Generic, List, Sequence
 
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationRule,
     ValidationError,
@@ -11,7 +12,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 )
 
 
-class NonEmptyRule(SemanticManifestValidationRule):
+class NonEmptyRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Check if the model contains semantic models and metrics."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/non_empty.py
+++ b/dbt_semantic_interfaces/validations/non_empty.py
@@ -49,8 +49,8 @@ class NonEmptyRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely("running model validation rule ensuring metrics and semantic models are defined")
-    def validate_model(model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
-        issues += NonEmptyRule._check_model_has_semantic_models(model=model)
-        issues += NonEmptyRule._check_model_has_metrics(model=model)
+        issues += NonEmptyRule._check_model_has_semantic_models(model=semantic_manifest)
+        issues += NonEmptyRule._check_model_has_metrics(model=semantic_manifest)
         return issues

--- a/dbt_semantic_interfaces/validations/non_empty.py
+++ b/dbt_semantic_interfaces/validations/non_empty.py
@@ -4,14 +4,14 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     ValidationError,
     ValidationIssue,
     validate_safely,
 )
 
 
-class NonEmptyRule(ModelValidationRule):
+class NonEmptyRule(SemanticManifestValidationRule):
     """Check if the model contains semantic models and metrics."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/reserved_keywords.py
+++ b/dbt_semantic_interfaces/validations/reserved_keywords.py
@@ -1,6 +1,9 @@
-from typing import List
+from typing import Generic, List
 
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import (
+    SemanticManifest,
+    SemanticManifestT,
+)
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelElementReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -14,7 +17,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
     validate_safely,
 )
 
-# A non-exaustive tuple of reserved keywords
+# A non-exhaustive tuple of reserved keywords
 # This list was created by running an intersection of keywords for redshift,
 # postgres, bigquery, and snowflake
 RESERVED_KEYWORDS = (
@@ -47,7 +50,7 @@ RESERVED_KEYWORDS = (
 )
 
 
-class ReservedKeywordsRule(SemanticManifestValidationRule):
+class ReservedKeywordsRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Check that any element that ends up being selected by name (instead of expr) isn't a commonly reserved keyword.
 
     Note: This rule DOES NOT catch all keywords. That is because keywords are

--- a/dbt_semantic_interfaces/validations/reserved_keywords.py
+++ b/dbt_semantic_interfaces/validations/reserved_keywords.py
@@ -5,7 +5,7 @@ from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelElementReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelContext,
     SemanticModelElementContext,
     SemanticModelElementType,
@@ -47,7 +47,7 @@ RESERVED_KEYWORDS = (
 )
 
 
-class ReservedKeywordsRule(ModelValidationRule):
+class ReservedKeywordsRule(SemanticManifestValidationRule):
     """Check that any element that ends up being selected by name (instead of expr) isn't a commonly reserved keyword.
 
     Note: This rule DOES NOT catch all keywords. That is because keywords are

--- a/dbt_semantic_interfaces/validations/reserved_keywords.py
+++ b/dbt_semantic_interfaces/validations/reserved_keywords.py
@@ -153,5 +153,5 @@ class ReservedKeywordsRule(SemanticManifestValidationRule):
         whats_being_done="running model validation ensuring elements that aren't selected via a defined expr don't "
         "contain reserved keywords"
     )
-    def validate_model(cls, model: SemanticManifest) -> List[ValidationIssue]:  # noqa: D
-        return cls._validate_semantic_models(model=model)
+    def validate_manifest(cls, semantic_manifest: SemanticManifest) -> List[ValidationIssue]:  # noqa: D
+        return cls._validate_semantic_models(model=semantic_manifest)

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -23,10 +23,10 @@ class SemanticModelTimeDimensionWarningsRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring time dimensions are defined properly")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues.extend(
                 SemanticModelTimeDimensionWarningsRule._validate_semantic_model(semantic_model=semantic_model)
             )
@@ -83,11 +83,11 @@ class SemanticModelValidityWindowRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="checking correctness of the time dimension validity parameters in the model")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         """Checks the validity param definitions in every semantic model in the model."""
         issues: List[ValidationIssue] = []
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues.extend(SemanticModelValidityWindowRule._validate_semantic_model(semantic_model=semantic_model))
 
         return issues

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -1,7 +1,7 @@
 import logging
-from typing import List, Sequence
+from typing import Generic, List, Sequence
 
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
@@ -18,12 +18,14 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 logger = logging.getLogger(__name__)
 
 
-class SemanticModelTimeDimensionWarningsRule(SemanticManifestValidationRule):
+class SemanticModelTimeDimensionWarningsRule(
+    SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]
+):
     """Checks time dimensions in semantic models."""
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring time dimensions are defined properly")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues: List[ValidationIssue] = []
 
         for semantic_model in semantic_manifest.semantic_models:
@@ -78,12 +80,12 @@ class SemanticModelTimeDimensionWarningsRule(SemanticManifestValidationRule):
         return issues
 
 
-class SemanticModelValidityWindowRule(SemanticManifestValidationRule):
+class SemanticModelValidityWindowRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks validity windows in semantic models to ensure they comply with runtime requirements."""
 
     @staticmethod
     @validate_safely(whats_being_done="checking correctness of the time dimension validity parameters in the model")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
         """Checks the validity param definitions in every semantic model in the model."""
         issues: List[ValidationIssue] = []
 

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelContext,
     ValidationError,
     ValidationIssue,
@@ -18,7 +18,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 logger = logging.getLogger(__name__)
 
 
-class SemanticModelTimeDimensionWarningsRule(ModelValidationRule):
+class SemanticModelTimeDimensionWarningsRule(SemanticManifestValidationRule):
     """Checks time dimensions in semantic models."""
 
     @staticmethod
@@ -78,7 +78,7 @@ class SemanticModelTimeDimensionWarningsRule(ModelValidationRule):
         return issues
 
 
-class SemanticModelValidityWindowRule(ModelValidationRule):
+class SemanticModelValidityWindowRule(SemanticManifestValidationRule):
     """Checks validity windows in semantic models to ensure they comply with runtime requirements."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import enum
 import re
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Dict, Generic, List, Optional, Sequence, Tuple
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import (
+    SemanticManifest,
+    SemanticManifestT,
+)
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     ElementReference,
@@ -49,7 +52,7 @@ class MetricFlowReservedKeywords(enum.Enum):
             assert_values_exhausted(keyword)
 
 
-class UniqueAndValidNameRule(SemanticManifestValidationRule):
+class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Check that names are unique and valid.
 
     * Names of elements in semantic models are unique / valid within the semantic model.
@@ -217,7 +220,7 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
-    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
         issues += UniqueAndValidNameRule._validate_top_level_objects(model=semantic_manifest)
 

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -17,7 +17,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     MetricContext,
-    ModelValidationRule,
+    SemanticManifestValidationRule,
     SemanticModelContext,
     SemanticModelElementContext,
     SemanticModelElementType,
@@ -49,7 +49,7 @@ class MetricFlowReservedKeywords(enum.Enum):
             assert_values_exhausted(keyword)
 
 
-class UniqueAndValidNameRule(ModelValidationRule):
+class UniqueAndValidNameRule(SemanticManifestValidationRule):
     """Check that names are unique and valid.
 
     * Names of elements in semantic models are unique / valid within the semantic model.

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -217,11 +217,11 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule):
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
-    def validate_model(model: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
-        issues += UniqueAndValidNameRule._validate_top_level_objects(model=model)
+        issues += UniqueAndValidNameRule._validate_top_level_objects(model=semantic_manifest)
 
-        for semantic_model in model.semantic_models:
+        for semantic_model in semantic_manifest.semantic_models:
             issues += UniqueAndValidNameRule._validate_semantic_model_elements(semantic_model=semantic_model)
 
         return issues

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -12,10 +12,8 @@ import click
 from pydantic import BaseModel, Extra
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
 from dbt_semantic_interfaces.protocols.metadata import Metadata
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 from dbt_semantic_interfaces.references import (
     MetricModelReference,
     SemanticModelElementReference,
@@ -383,7 +381,7 @@ class ModelValidationRule(ABC):
 
     @classmethod
     @abstractmethod
-    def validate_model(cls, model: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_model(cls, model: SemanticManifest) -> Sequence[ValidationIssue]:
         """Check the given model and return a list of validation issues."""
         pass
 
@@ -396,7 +394,7 @@ class ModelValidationRule(ABC):
         idiosyncratic behavior and inscrutable errors due to interactions between pickling and pydantic objects.
         """
         return ModelValidationResults.from_issues_sequence(
-            cls.validate_model(PydanticSemanticManifest.parse_raw(serialized_model))
+            cls.validate_model(SemanticManifest.parse_raw(serialized_model))
         ).json()
 
 

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -245,7 +245,7 @@ class ValidationError(ValidationIssue, BaseModel):
         return ValidationIssueSet(error_issues=(self,))
 
 
-class ModelValidationResults(FrozenBaseModel):
+class SemanticManifestValidationResults(FrozenBaseModel):
     """Class for organizing the results of running validations."""
 
     warnings: Tuple[ValidationWarning, ...] = tuple()
@@ -254,21 +254,21 @@ class ModelValidationResults(FrozenBaseModel):
 
     @property
     def has_blocking_issues(self) -> bool:
-        """Does the ModelValidationResults have ERROR issues."""
+        """Does the SemanticManifestValidationResults have ERROR issues."""
         return len(self.errors) != 0
 
     @staticmethod
-    def from_issues_sequence(issues: Sequence[ValidationIssue]) -> ModelValidationResults:
-        """Constructs a ModelValidationResults class from a list of ValidationIssues."""
+    def from_issues_sequence(issues: Sequence[ValidationIssue]) -> SemanticManifestValidationResults:
+        """Constructs a SemanticManifestValidationResults class from a list of ValidationIssues."""
         combined_issue_set = ValidationIssueSet.combine(tuple(issue.as_issue_set for issue in issues))
-        return ModelValidationResults(
+        return SemanticManifestValidationResults(
             warnings=tuple(combined_issue_set.warning_issues),
             future_errors=tuple(combined_issue_set.future_error_issues),
             errors=tuple(combined_issue_set.error_issues),
         )
 
     @classmethod
-    def merge(cls, results: Sequence[ModelValidationResults]) -> ModelValidationResults:
+    def merge(cls, results: Sequence[SemanticManifestValidationResults]) -> SemanticManifestValidationResults:
         """Creates a new ModelValidatorResults instance from multiple instances.
 
         This is useful when there are multiple validators that are run and the
@@ -393,7 +393,7 @@ class ModelValidationRule(ABC):
         multiprocessing.ProcessPoolExecutor, and passing a model or validation results object can result in
         idiosyncratic behavior and inscrutable errors due to interactions between pickling and pydantic objects.
         """
-        return ModelValidationResults.from_issues_sequence(
+        return SemanticManifestValidationResults.from_issues_sequence(
             cls.validate_model(SemanticManifest.parse_raw(serialized_model))
         ).json()
 

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -377,12 +377,12 @@ class DimensionInvariants:
 
 
 class SemanticManifestValidationRule(ABC):
-    """Encapsulates logic for checking the values of objects in a model."""
+    """Encapsulates logic for checking the values of objects in a manifest."""
 
     @classmethod
     @abstractmethod
-    def validate_model(cls, model: SemanticManifest) -> Sequence[ValidationIssue]:
-        """Check the given model and return a list of validation issues."""
+    def validate_manifest(cls, semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
+        """Check the given manifest and return a list of validation issues."""
         pass
 
 

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -386,7 +386,7 @@ class SemanticManifestValidationRule(ABC):
         pass
 
 
-class ModelValidationException(Exception):
+class SemanticManifestValidationException(Exception):
     """Exception raised when validation of a model fails."""
 
     def __init__(self, issues: Tuple[ValidationIssue, ...]) -> None:  # noqa: D

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -385,18 +385,6 @@ class SemanticManifestValidationRule(ABC):
         """Check the given model and return a list of validation issues."""
         pass
 
-    @classmethod
-    def validate_model_serialized_for_multiprocessing(cls, serialized_model: str) -> str:
-        """Validate a model serialized via Pydantic's .json() method, and return a list of JSON serialized issues.
-
-        This method exists because our validations are forked into parallel processes via
-        multiprocessing.ProcessPoolExecutor, and passing a model or validation results object can result in
-        idiosyncratic behavior and inscrutable errors due to interactions between pickling and pydantic objects.
-        """
-        return SemanticManifestValidationResults.from_issues_sequence(
-            cls.validate_model(SemanticManifest.parse_raw(serialized_model))
-        ).json()
-
 
 class ModelValidationException(Exception):
     """Exception raised when validation of a model fails."""

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -24,9 +24,7 @@ from pydantic import BaseModel, Extra
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
 from dbt_semantic_interfaces.protocols.metadata import Metadata
-from dbt_semantic_interfaces.protocols.semantic_manifest import (
-    SemanticManifestT,
-)
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.references import (
     MetricModelReference,
     SemanticModelElementReference,

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -272,7 +272,7 @@ class ModelValidationResults(FrozenBaseModel):
         """Creates a new ModelValidatorResults instance from multiple instances.
 
         This is useful when there are multiple validators that are run and the
-        combined results are desirable. For instance there is a ModelValidator
+        combined results are desirable. For instance there is a SemanticManifestValidator
         and a DataWarehouseModelValidator. These both return validation issues.
         If it's desirable to combine the results, the following makes it easy.
         """

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -376,7 +376,7 @@ class DimensionInvariants:
     is_partition: bool
 
 
-class ModelValidationRule(ABC):
+class SemanticManifestValidationRule(ABC):
     """Encapsulates logic for checking the values of objects in a model."""
 
     @classmethod

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -6,14 +6,27 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import click
 from pydantic import BaseModel, Extra
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
 from dbt_semantic_interfaces.protocols.metadata import Metadata
-from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
+from dbt_semantic_interfaces.protocols.semantic_manifest import (
+    SemanticManifestT,
+)
 from dbt_semantic_interfaces.references import (
     MetricModelReference,
     SemanticModelElementReference,
@@ -376,12 +389,12 @@ class DimensionInvariants:
     is_partition: bool
 
 
-class SemanticManifestValidationRule(ABC):
+class SemanticManifestValidationRule(ABC, Generic[SemanticManifestT]):
     """Encapsulates logic for checking the values of objects in a manifest."""
 
     @classmethod
     @abstractmethod
-    def validate_manifest(cls, semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
+    def validate_manifest(cls, semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
         """Check the given manifest and return a list of validation issues."""
         pass
 

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -13,7 +13,7 @@ from dbt_semantic_interfaces.parsing.dir_to_model import parse_yaml_files_to_mod
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
@@ -407,7 +407,9 @@ def test_invalid_metric_type_parsing_error() -> None:
 
     build_result = parse_yaml_files_to_model(files=[file])
     assert build_result.issues.has_blocking_issues
-    assert "'this is not a valid type' is not one of" in str(ModelValidationException(build_result.issues.all_issues))
+    assert "'this is not a valid type' is not one of" in str(
+        SemanticManifestValidationException(build_result.issues.all_issues)
+    )
 
 
 def test_invalid_cumulative_metric_window_format_parsing_error() -> None:
@@ -427,7 +429,7 @@ def test_invalid_cumulative_metric_window_format_parsing_error() -> None:
 
     build_result = parse_yaml_files_to_model(files=[file])
     assert build_result.issues.has_blocking_issues
-    assert "Invalid window" in str(ModelValidationException(build_result.issues.all_issues))
+    assert "Invalid window" in str(SemanticManifestValidationException(build_result.issues.all_issues))
 
 
 def test_invalid_cumulative_metric_window_granularity_parsing_error() -> None:
@@ -447,7 +449,7 @@ def test_invalid_cumulative_metric_window_granularity_parsing_error() -> None:
 
     build_result = parse_yaml_files_to_model(files=[file])
     assert build_result.issues.has_blocking_issues
-    assert "Invalid time granularity" in str(ModelValidationException(build_result.issues.all_issues))
+    assert "Invalid time granularity" in str(SemanticManifestValidationException(build_result.issues.all_issues))
 
 
 def test_invalid_cumulative_metric_window_count_parsing_error() -> None:
@@ -467,4 +469,4 @@ def test_invalid_cumulative_metric_window_count_parsing_error() -> None:
 
     build_result = parse_yaml_files_to_model(files=[file])
     assert build_result.issues.has_blocking_issues
-    assert "Invalid count" in str(ModelValidationException(build_result.issues.all_issues))
+    assert "Invalid count" in str(SemanticManifestValidationException(build_result.issues.all_issues))

--- a/tests/validations/test_agg_time_dimension.py
+++ b/tests/validations/test_agg_time_dimension.py
@@ -32,7 +32,7 @@ def test_invalid_aggregation_time_dimension(simple_semantic_manifest: PydanticSe
             "in the semantic model"
         ),
     ):
-        model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest]([AggregationTimeDimensionRule()])
         model_validator.checked_validations(model)
 
 
@@ -49,7 +49,7 @@ def test_unset_aggregation_time_dimension(simple_semantic_manifest: PydanticSema
         SemanticManifestValidationException,
         match=("Aggregation time dimension for measure \\w+ is not set!"),
     ):
-        model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest]([AggregationTimeDimensionRule()])
         model_validator.checked_validations(model)
 
 
@@ -67,5 +67,5 @@ def test_missing_primary_time_ok_if_all_measures_have_agg_time_dim(  # noqa:D
             assert dimension.type_params, f"Time dimension `{dimension.name}` is missing `type_params`"
             dimension.type_params.is_primary = False
 
-    model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([AggregationTimeDimensionRule()])
     model_validator.checked_validations(model)

--- a/tests/validations/test_agg_time_dimension.py
+++ b/tests/validations/test_agg_time_dimension.py
@@ -5,7 +5,7 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.validations.agg_time_dimension import (
@@ -32,7 +32,7 @@ def test_invalid_aggregation_time_dimension(simple_semantic_manifest: PydanticSe
             "in the semantic model"
         ),
     ):
-        model_validator = ModelValidator([AggregationTimeDimensionRule()])
+        model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])
         model_validator.checked_validations(model)
 
 
@@ -49,7 +49,7 @@ def test_unset_aggregation_time_dimension(simple_semantic_manifest: PydanticSema
         ModelValidationException,
         match=("Aggregation time dimension for measure \\w+ is not set!"),
     ):
-        model_validator = ModelValidator([AggregationTimeDimensionRule()])
+        model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])
         model_validator.checked_validations(model)
 
 
@@ -67,5 +67,5 @@ def test_missing_primary_time_ok_if_all_measures_have_agg_time_dim(  # noqa:D
             assert dimension.type_params, f"Time dimension `{dimension.name}` is missing `type_params`"
             dimension.type_params.is_primary = False
 
-    model_validator = ModelValidator([AggregationTimeDimensionRule()])
+    model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])
     model_validator.checked_validations(model)

--- a/tests/validations/test_agg_time_dimension.py
+++ b/tests/validations/test_agg_time_dimension.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.validations.agg_time_dimension import (
     AggregationTimeDimensionRule,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
@@ -26,7 +26,7 @@ def test_invalid_aggregation_time_dimension(simple_semantic_manifest: PydanticSe
     semantic_model_with_measures.measures[0].agg_time_dimension = "invalid_time_dimension"
 
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=(
             "has the aggregation time dimension set to 'invalid_time_dimension', which is not a valid time dimension "
             "in the semantic model"
@@ -46,7 +46,7 @@ def test_unset_aggregation_time_dimension(simple_semantic_manifest: PydanticSema
     semantic_model_with_measures.measures[0].agg_time_dimension = None
 
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=("Aggregation time dimension for measure \\w+ is not set!"),
     ):
         model_validator = SemanticManifestValidator([AggregationTimeDimensionRule()])

--- a/tests/validations/test_common_entities.py
+++ b/tests/validations/test_common_entities.py
@@ -21,7 +21,7 @@ def test_lonely_entity_raises_issue(  # noqa: D
 
     semantic_model_with_entities, _ = find_semantic_model_with(model, func)
     semantic_model_with_entities.entities[0].name = lonely_entity_name
-    model_validator = SemanticManifestValidator([CommonEntitysRule()])
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([CommonEntitysRule()])
     model_issues = model_validator.validate_model(model)
 
     found_warning = False

--- a/tests/validations/test_common_entities.py
+++ b/tests/validations/test_common_entities.py
@@ -5,7 +5,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.validations.common_entities import CommonEntitysRule
 
@@ -21,7 +21,7 @@ def test_lonely_entity_raises_issue(  # noqa: D
 
     semantic_model_with_entities, _ = find_semantic_model_with(model, func)
     semantic_model_with_entities.entities[0].name = lonely_entity_name
-    model_validator = ModelValidator([CommonEntitysRule()])
+    model_validator = SemanticManifestValidator([CommonEntitysRule()])
     model_issues = model_validator.validate_model(model)
 
     found_warning = False

--- a/tests/validations/test_configurable_rules.py
+++ b/tests/validations/test_configurable_rules.py
@@ -31,23 +31,24 @@ def test_can_configure_model_validator_rules(  # noqa: D
     )
 
     # confirm that with the default configuration, an issue is raised
-    issues = SemanticManifestValidator().validate_model(model)
+    validator = SemanticManifestValidator[PydanticSemanticManifest]()
+    issues = SemanticManifestValidator[PydanticSemanticManifest]().validate_model(model)
     assert (
         len(issues.all_issues) == 1
     ), f"SemanticManifestValidator with default rules had unexpected number of issues {issues}"
 
     # confirm that a custom configuration excluding ValidMaterializationRule, no issue is raised
-    rules = [rule for rule in SemanticManifestValidator.DEFAULT_RULES if rule.__class__ is not DerivedMetricRule]
-    issues = SemanticManifestValidator(rules=rules).validate_model(model)
+    rules = [rule for rule in validator.DEFAULT_RULES if rule.__class__ is not DerivedMetricRule]
+    issues = SemanticManifestValidator[PydanticSemanticManifest](rules=rules).validate_model(model)
     assert len(issues.all_issues) == 0, f"SemanticManifestValidator without DerivedMetricRule returned issues {issues}"
 
 
 def test_cant_configure_model_validator_without_rules() -> None:  # noqa: D
     with pytest.raises(ValueError):
-        SemanticManifestValidator(rules=[])
+        SemanticManifestValidator[PydanticSemanticManifest](rules=[])
 
     with pytest.raises(ValueError):
-        SemanticManifestValidator(rules=())
+        SemanticManifestValidator[PydanticSemanticManifest](rules=())
 
     with pytest.raises(ValueError):
-        SemanticManifestValidator(rules=None)  # type: ignore
+        SemanticManifestValidator[PydanticSemanticManifest](rules=None)  # type: ignore

--- a/tests/validations/test_configurable_rules.py
+++ b/tests/validations/test_configurable_rules.py
@@ -10,7 +10,7 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.test_utils import metric_with_guaranteed_meta
 from dbt_semantic_interfaces.validations.metrics import DerivedMetricRule
 
@@ -31,21 +31,23 @@ def test_can_configure_model_validator_rules(  # noqa: D
     )
 
     # confirm that with the default configuration, an issue is raised
-    issues = ModelValidator().validate_model(model)
-    assert len(issues.all_issues) == 1, f"ModelValidator with default rules had unexpected number of issues {issues}"
+    issues = SemanticManifestValidator().validate_model(model)
+    assert (
+        len(issues.all_issues) == 1
+    ), f"SemanticManifestValidator with default rules had unexpected number of issues {issues}"
 
     # confirm that a custom configuration excluding ValidMaterializationRule, no issue is raised
-    rules = [rule for rule in ModelValidator.DEFAULT_RULES if rule.__class__ is not DerivedMetricRule]
-    issues = ModelValidator(rules=rules).validate_model(model)
-    assert len(issues.all_issues) == 0, f"ModelValidator without DerivedMetricRule returned issues {issues}"
+    rules = [rule for rule in SemanticManifestValidator.DEFAULT_RULES if rule.__class__ is not DerivedMetricRule]
+    issues = SemanticManifestValidator(rules=rules).validate_model(model)
+    assert len(issues.all_issues) == 0, f"SemanticManifestValidator without DerivedMetricRule returned issues {issues}"
 
 
 def test_cant_configure_model_validator_without_rules() -> None:  # noqa: D
     with pytest.raises(ValueError):
-        ModelValidator(rules=[])
+        SemanticManifestValidator(rules=[])
 
     with pytest.raises(ValueError):
-        ModelValidator(rules=())
+        SemanticManifestValidator(rules=())
 
     with pytest.raises(ValueError):
-        ModelValidator(rules=None)  # type: ignore
+        SemanticManifestValidator(rules=None)  # type: ignore

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -17,7 +17,7 @@ from dbt_semantic_interfaces.implementations.semantic_model import (
     NodeRelation,
     PydanticSemanticModel,
 )
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     MeasureReference,
@@ -43,7 +43,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
     with pytest.raises(ModelValidationException, match=r"type conflict for dimension"):
         dim_name = "dim"
         measure_name = "measure"
-        model_validator = ModelValidator([DimensionConsistencyRule()])
+        model_validator = SemanticManifestValidator([DimensionConsistencyRule()])
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -81,7 +81,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
     with pytest.raises(ModelValidationException, match=r"conflicting is_partition attribute for dimension"):
         dim_name = "dim1"
         measure_name = "measure"
-        model_validator = ModelValidator([DimensionConsistencyRule()])
+        model_validator = SemanticManifestValidator([DimensionConsistencyRule()])
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -130,7 +130,7 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
         dimension_reference = TimeDimensionReference(element_name="ds")
         dimension_reference2 = DimensionReference(element_name="not_ds")
         measure_reference = MeasureReference(element_name="measure")
-        model_validator = ModelValidator([SemanticModelTimeDimensionWarningsRule()])
+        model_validator = SemanticManifestValidator([SemanticModelTimeDimensionWarningsRule()])
         model_validator.checked_validations(
             model=PydanticSemanticManifest(
                 semantic_models=[

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -43,7 +43,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
     with pytest.raises(SemanticManifestValidationException, match=r"type conflict for dimension"):
         dim_name = "dim"
         measure_name = "measure"
-        model_validator = SemanticManifestValidator([DimensionConsistencyRule()])
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DimensionConsistencyRule()])
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -81,7 +81,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
     with pytest.raises(SemanticManifestValidationException, match=r"conflicting is_partition attribute for dimension"):
         dim_name = "dim1"
         measure_name = "measure"
-        model_validator = SemanticManifestValidator([DimensionConsistencyRule()])
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DimensionConsistencyRule()])
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -130,7 +130,9 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
         dimension_reference = TimeDimensionReference(element_name="ds")
         dimension_reference2 = DimensionReference(element_name="not_ds")
         measure_reference = MeasureReference(element_name="measure")
-        model_validator = SemanticManifestValidator([SemanticModelTimeDimensionWarningsRule()])
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest](
+            [SemanticModelTimeDimensionWarningsRule()]
+        )
         model_validator.checked_validations(
             model=PydanticSemanticManifest(
                 semantic_models=[

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -35,12 +35,12 @@ from dbt_semantic_interfaces.validations.semantic_models import (
     SemanticModelTimeDimensionWarningsRule,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
 def test_incompatible_dimension_type() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException, match=r"type conflict for dimension"):
+    with pytest.raises(SemanticManifestValidationException, match=r"type conflict for dimension"):
         dim_name = "dim"
         measure_name = "measure"
         model_validator = SemanticManifestValidator([DimensionConsistencyRule()])
@@ -78,7 +78,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
 
 
 def test_incompatible_dimension_is_partition() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException, match=r"conflicting is_partition attribute for dimension"):
+    with pytest.raises(SemanticManifestValidationException, match=r"conflicting is_partition attribute for dimension"):
         dim_name = "dim1"
         measure_name = "measure"
         model_validator = SemanticManifestValidator([DimensionConsistencyRule()])
@@ -126,7 +126,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
 
 
 def test_multiple_primary_time_dimensions() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException, match=r"one of many defined as primary"):
+    with pytest.raises(SemanticManifestValidationException, match=r"one of many defined as primary"):
         dimension_reference = TimeDimensionReference(element_name="ds")
         dimension_reference2 = DimensionReference(element_name="not_ds")
         measure_reference = MeasureReference(element_name="measure")

--- a/tests/validations/test_element_const.py
+++ b/tests/validations/test_element_const.py
@@ -13,7 +13,7 @@ from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.validations.element_const import ElementConsistencyRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
     SemanticModelElementType,
 )
 
@@ -51,7 +51,7 @@ def test_cross_element_names(  # noqa:D
 
     model.semantic_models[usable_ds_index] = ds_measure_x_dimension
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=(
             f"element `{measure_reference.element_name}` is of type {SemanticModelElementType.DIMENSION}, but it is "
             "used as types .*?SemanticModelElementType.DIMENSION.*?SemanticModelElementType.MEASURE.*? across the "
@@ -62,7 +62,7 @@ def test_cross_element_names(  # noqa:D
 
     model.semantic_models[usable_ds_index] = ds_measure_x_entity
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=(
             f"element `{measure_reference.element_name}` is of type {SemanticModelElementType.ENTITY}, but it is "
             "used as types .*?SemanticModelElementType.ENTITY.*?SemanticModelElementType.MEASURE.*? across the model"
@@ -72,7 +72,7 @@ def test_cross_element_names(  # noqa:D
 
     model.semantic_models[usable_ds_index] = ds_dimension_x_entity
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=(
             f"element `{dimension_reference.element_name}` is of type {SemanticModelElementType.DIMENSION}, but it is "
             "used as types .*?SemanticModelElementType.DIMENSION.*?SemanticModelElementType.ENTITY.*? across the model"

--- a/tests/validations/test_element_const.py
+++ b/tests/validations/test_element_const.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.validations.element_const import ElementConsistencyRule
@@ -58,7 +58,7 @@ def test_cross_element_names(  # noqa:D
             "model"
         ),
     ):
-        ModelValidator([ElementConsistencyRule()]).checked_validations(model)
+        SemanticManifestValidator([ElementConsistencyRule()]).checked_validations(model)
 
     model.semantic_models[usable_ds_index] = ds_measure_x_entity
     with pytest.raises(
@@ -68,7 +68,7 @@ def test_cross_element_names(  # noqa:D
             "used as types .*?SemanticModelElementType.ENTITY.*?SemanticModelElementType.MEASURE.*? across the model"
         ),
     ):
-        ModelValidator([ElementConsistencyRule()]).checked_validations(model)
+        SemanticManifestValidator([ElementConsistencyRule()]).checked_validations(model)
 
     model.semantic_models[usable_ds_index] = ds_dimension_x_entity
     with pytest.raises(
@@ -78,4 +78,4 @@ def test_cross_element_names(  # noqa:D
             "used as types .*?SemanticModelElementType.DIMENSION.*?SemanticModelElementType.ENTITY.*? across the model"
         ),
     ):
-        ModelValidator([ElementConsistencyRule()]).checked_validations(model)
+        SemanticManifestValidator([ElementConsistencyRule()]).checked_validations(model)

--- a/tests/validations/test_element_const.py
+++ b/tests/validations/test_element_const.py
@@ -58,7 +58,7 @@ def test_cross_element_names(  # noqa:D
             "model"
         ),
     ):
-        SemanticManifestValidator([ElementConsistencyRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([ElementConsistencyRule()]).checked_validations(model)
 
     model.semantic_models[usable_ds_index] = ds_measure_x_entity
     with pytest.raises(
@@ -68,7 +68,7 @@ def test_cross_element_names(  # noqa:D
             "used as types .*?SemanticModelElementType.ENTITY.*?SemanticModelElementType.MEASURE.*? across the model"
         ),
     ):
-        SemanticManifestValidator([ElementConsistencyRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([ElementConsistencyRule()]).checked_validations(model)
 
     model.semantic_models[usable_ds_index] = ds_dimension_x_entity
     with pytest.raises(
@@ -78,4 +78,4 @@ def test_cross_element_names(  # noqa:D
             "used as types .*?SemanticModelElementType.DIMENSION.*?SemanticModelElementType.ENTITY.*? across the model"
         ),
     ):
-        SemanticManifestValidator([ElementConsistencyRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([ElementConsistencyRule()]).checked_validations(model)

--- a/tests/validations/test_entities.py
+++ b/tests/validations/test_entities.py
@@ -43,7 +43,9 @@ def test_semantic_model_cant_have_more_than_one_primary_entity(
         entity.type = EntityType.PRIMARY
         entity_references.add(entity.reference)
 
-    model_issues = SemanticManifestValidator([OnePrimaryEntityPerSemanticModelRule()]).validate_model(model)
+    model_issues = SemanticManifestValidator[PydanticSemanticManifest](
+        [OnePrimaryEntityPerSemanticModelRule()]
+    ).validate_model(model)
 
     future_issue = (
         f"Semantic models can have only one primary entity. The semantic model"
@@ -95,7 +97,9 @@ def test_multiple_natural_entities() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), natural_entity_file])
 
     with pytest.raises(SemanticManifestValidationException, match="can have at most one natural entity"):
-        SemanticManifestValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([NaturalEntityConfigurationRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_natural_entity_used_in_wrong_context() -> None:
@@ -121,4 +125,6 @@ def test_natural_entity_used_in_wrong_context() -> None:
     with pytest.raises(
         SemanticManifestValidationException, match="use of `natural` entities is currently supported only in"
     ):
-        SemanticManifestValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([NaturalEntityConfigurationRule()]).checked_validations(
+            model.model
+        )

--- a/tests/validations/test_entities.py
+++ b/tests/validations/test_entities.py
@@ -8,7 +8,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
 )
@@ -43,7 +43,7 @@ def test_semantic_model_cant_have_more_than_one_primary_entity(
         entity.type = EntityType.PRIMARY
         entity_references.add(entity.reference)
 
-    model_issues = ModelValidator([OnePrimaryEntityPerSemanticModelRule()]).validate_model(model)
+    model_issues = SemanticManifestValidator([OnePrimaryEntityPerSemanticModelRule()]).validate_model(model)
 
     future_issue = (
         f"Semantic models can have only one primary entity. The semantic model"
@@ -95,7 +95,7 @@ def test_multiple_natural_entities() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), natural_entity_file])
 
     with pytest.raises(ModelValidationException, match="can have at most one natural entity"):
-        ModelValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)
+        SemanticManifestValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)
 
 
 def test_natural_entity_used_in_wrong_context() -> None:
@@ -119,4 +119,4 @@ def test_natural_entity_used_in_wrong_context() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), natural_entity_file])
 
     with pytest.raises(ModelValidationException, match="use of `natural` entities is currently supported only in"):
-        ModelValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)
+        SemanticManifestValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)

--- a/tests/validations/test_entities.py
+++ b/tests/validations/test_entities.py
@@ -23,7 +23,7 @@ from dbt_semantic_interfaces.validations.entities import (
     OnePrimaryEntityPerSemanticModelRule,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
@@ -94,7 +94,7 @@ def test_multiple_natural_entities() -> None:
     natural_entity_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), natural_entity_file])
 
-    with pytest.raises(ModelValidationException, match="can have at most one natural entity"):
+    with pytest.raises(SemanticManifestValidationException, match="can have at most one natural entity"):
         SemanticManifestValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)
 
 
@@ -118,5 +118,7 @@ def test_natural_entity_used_in_wrong_context() -> None:
     natural_entity_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), natural_entity_file])
 
-    with pytest.raises(ModelValidationException, match="use of `natural` entities is currently supported only in"):
+    with pytest.raises(
+        SemanticManifestValidationException, match="use of `natural` entities is currently supported only in"
+    ):
         SemanticManifestValidator([NaturalEntityConfigurationRule()]).checked_validations(model.model)

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -4,7 +4,7 @@ import textwrap
 import pytest
 
 from dbt_semantic_interfaces.model_transformer import ModelTransformer
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
 )
@@ -45,7 +45,7 @@ def test_metric_missing_measure() -> None:
         ModelValidationException,
         match=f"Measure {measure_name} referenced in metric {metric_name} is not defined in the model!",
     ):
-        ModelValidator([MetricMeasuresRule()]).checked_validations(model=model.model)
+        SemanticManifestValidator([MetricMeasuresRule()]).checked_validations(model=model.model)
 
 
 def test_measures_only_exist_in_one_semantic_model() -> None:  # noqa: D
@@ -76,7 +76,7 @@ def test_measures_only_exist_in_one_semantic_model() -> None:  # noqa: D
     )
     base_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents_1)
     model = parse_yaml_files_to_validation_ready_model([base_file])
-    model_issues = ModelValidator().validate_model(model.model)
+    model_issues = SemanticManifestValidator().validate_model(model.model)
     duplicate_measure_message = "Found measure with name .* in multiple semantic models with names"
     found_issue = False
 
@@ -114,7 +114,7 @@ def test_measures_only_exist_in_one_semantic_model() -> None:  # noqa: D
     )
     dup_measure_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents_2)
     dup_model = parse_yaml_files_to_validation_ready_model([base_file, dup_measure_file])
-    model_issues = ModelValidator([SemanticModelMeasuresUniqueRule()]).validate_model(dup_model.model)
+    model_issues = SemanticManifestValidator([SemanticModelMeasuresUniqueRule()]).validate_model(dup_model.model)
 
     if model_issues is not None:
         for issue in model_issues.all_issues:
@@ -166,7 +166,7 @@ def test_measure_alias_is_set_when_required() -> None:
     missing_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([missing_alias_file])
 
-    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = SemanticManifestValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
     assert len(model_issues.errors) == 1
     expected_error_substring = f"depends on multiple different constrained versions of measure {measure_name}"
@@ -216,7 +216,7 @@ def test_invalid_measure_alias_name() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = SemanticManifestValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
     assert len(model_issues.errors) == 1
     expected_error_substring = f"Invalid name `{invalid_alias}` - names should only consist of"
@@ -267,7 +267,7 @@ def test_measure_alias_measure_name_conflict() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = SemanticManifestValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
     assert len(model_issues.errors) == 1
     expected_error_substring = (
@@ -330,7 +330,7 @@ def test_reused_measure_alias() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = SemanticManifestValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
     assert len(model_issues.errors) == 1
     expected_error_substring = (
@@ -389,7 +389,7 @@ def test_reused_measure_alias_within_metric() -> None:
     invalid_alias_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([invalid_alias_file])
 
-    model_issues = ModelValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
+    model_issues = SemanticManifestValidator([MeasureConstraintAliasesRule()]).validate_model(model.model)
 
     assert len(model_issues.errors) == 1
     expected_error_substring = (
@@ -458,7 +458,7 @@ def test_invalid_non_additive_dimension_properties() -> None:
         model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
     )
 
-    model_issues = ModelValidator([MeasuresNonAdditiveDimensionRule()]).validate_model(transformed_model)
+    model_issues = SemanticManifestValidator([MeasuresNonAdditiveDimensionRule()]).validate_model(transformed_model)
     expected_error_substring_1 = "that is not defined as a dimension in semantic model 'sample_semantic_model_2'."
     expected_error_substring_2 = "has a non_additive_dimension with an invalid 'window_groupings'"
     expected_error_substring_3 = "that is defined as a categorical dimension which is not supported."
@@ -514,7 +514,7 @@ def test_count_measure_missing_expr() -> None:
         model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
     )
 
-    model_issues = ModelValidator([CountAggregationExprRule()]).validate_model(transformed_model)
+    model_issues = SemanticManifestValidator([CountAggregationExprRule()]).validate_model(transformed_model)
     expected_error_substring = (
         "Measure 'bad_measure' uses a COUNT aggregation, which requires an expr to be provided. "
         "Provide 'expr: 1' if a count of all rows is desired."
@@ -564,7 +564,7 @@ def test_count_measure_with_distinct_expr() -> None:
         model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
     )
 
-    model_issues = ModelValidator([CountAggregationExprRule()]).validate_model(transformed_model)
+    model_issues = SemanticManifestValidator([CountAggregationExprRule()]).validate_model(transformed_model)
     expected_error_substring = "Measure 'distinct_count' uses a 'count' aggregation with a DISTINCT expr"
 
     assert len(model_issues.errors) == 1
@@ -614,7 +614,7 @@ def test_percentile_measure_missing_agg_params() -> None:
     missing_agg_params_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([missing_agg_params_file])
 
-    model_issues = ModelValidator().validate_model(model.model)
+    model_issues = SemanticManifestValidator().validate_model(model.model)
     expected_error_substring_1 = (
         "Measure 'bad_measure_1' uses a PERCENTILE aggregation, which requires agg_params.percentile to be provided."
     )
@@ -675,7 +675,7 @@ def test_percentile_measure_bad_percentile_values() -> None:
     bad_percentile_values_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([bad_percentile_values_file])
 
-    model_issues = ModelValidator().validate_model(model.model)
+    model_issues = SemanticManifestValidator().validate_model(model.model)
     expected_error_substring_1 = (
         "Percentile aggregation parameter for measure 'bad_measure_1' is '1.0', but "
         + "must be between 0 and 1 (non-inclusive). For example, to indicate the 65th percentile value, set "

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -17,7 +17,7 @@ from dbt_semantic_interfaces.validations.measures import (
     SemanticModelMeasuresUniqueRule,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
@@ -42,7 +42,7 @@ def test_metric_missing_measure() -> None:
     model = parse_yaml_files_to_validation_ready_model([metric_missing_measure_file])
 
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=f"Measure {measure_name} referenced in metric {metric_name} is not defined in the model!",
     ):
         SemanticManifestValidator([MetricMeasuresRule()]).checked_validations(model=model.model)

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -14,7 +14,7 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     EntityReference,
@@ -38,7 +38,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
     dim_name = "country"
     dim2_name = "ename"
     measure_name = "foo"
-    model_validator = ModelValidator()
+    model_validator = SemanticManifestValidator()
     model_validator.checked_validations(
         PydanticSemanticManifest(
             semantic_models=[
@@ -84,7 +84,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
     with pytest.raises(ModelValidationException):
         dim_name = "country"
         measure_name = "foo"
-        model_validator = ModelValidator()
+        model_validator = SemanticManifestValidator()
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -115,7 +115,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
         dim_name = "date_created"
         dim2_name = "date_deleted"
         measure_name = "foo"
-        model_validator = ModelValidator()
+        model_validator = SemanticManifestValidator()
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -179,7 +179,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
     )
     semantic_model.measures[0].create_metric = True
 
-    ModelValidator().checked_validations(
+    SemanticManifestValidator().checked_validations(
         PydanticSemanticManifest(
             semantic_models=[semantic_model],
             metrics=[],
@@ -189,7 +189,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
 
 def test_derived_metric() -> None:  # noqa: D
     measure_name = "foo"
-    model_validator = ModelValidator([DerivedMetricRule()])
+    model_validator = SemanticManifestValidator([DerivedMetricRule()])
     model_issues = model_validator.validate_model(
         PydanticSemanticManifest(
             semantic_models=[

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -30,7 +30,7 @@ from dbt_semantic_interfaces.type_enums.entity_type import EntityType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.metrics import DerivedMetricRule
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
@@ -81,7 +81,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
 
 
 def test_metric_no_time_dim() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException):
+    with pytest.raises(SemanticManifestValidationException):
         dim_name = "country"
         measure_name = "foo"
         model_validator = SemanticManifestValidator()
@@ -111,7 +111,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
 
 
 def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException):
+    with pytest.raises(SemanticManifestValidationException):
         dim_name = "date_created"
         dim2_name = "date_deleted"
         measure_name = "foo"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -38,7 +38,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
     dim_name = "country"
     dim2_name = "ename"
     measure_name = "foo"
-    model_validator = SemanticManifestValidator()
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]()
     model_validator.checked_validations(
         PydanticSemanticManifest(
             semantic_models=[
@@ -84,7 +84,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
     with pytest.raises(SemanticManifestValidationException):
         dim_name = "country"
         measure_name = "foo"
-        model_validator = SemanticManifestValidator()
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest]()
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -115,7 +115,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
         dim_name = "date_created"
         dim2_name = "date_deleted"
         measure_name = "foo"
-        model_validator = SemanticManifestValidator()
+        model_validator = SemanticManifestValidator[PydanticSemanticManifest]()
         model_validator.checked_validations(
             PydanticSemanticManifest(
                 semantic_models=[
@@ -179,7 +179,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
     )
     semantic_model.measures[0].create_metric = True
 
-    SemanticManifestValidator().checked_validations(
+    SemanticManifestValidator[PydanticSemanticManifest]().checked_validations(
         PydanticSemanticManifest(
             semantic_models=[semantic_model],
             metrics=[],
@@ -189,7 +189,7 @@ def test_generated_metrics_only() -> None:  # noqa:D
 
 def test_derived_metric() -> None:  # noqa: D
     measure_name = "foo"
-    model_validator = SemanticManifestValidator([DerivedMetricRule()])
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DerivedMetricRule()])
     model_issues = model_validator.validate_model(
         PydanticSemanticManifest(
             semantic_models=[

--- a/tests/validations/test_reserved_keywords.py
+++ b/tests/validations/test_reserved_keywords.py
@@ -20,7 +20,7 @@ def random_keyword() -> str:  # noqa: D
 def test_no_reserved_keywords(  # noqa: D
     simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
-    issues = ReservedKeywordsRule.validate_model(simple_semantic_manifest__with_primary_transforms)
+    issues = ReservedKeywordsRule.validate_manifest(simple_semantic_manifest__with_primary_transforms)
     assert len(issues) == 0
 
 
@@ -34,7 +34,7 @@ def test_reserved_keywords_in_dimensions(  # noqa: D
     dimension = semantic_model.dimensions[0]
     dimension.name = random_keyword()
 
-    issues = ReservedKeywordsRule.validate_model(model)
+    issues = ReservedKeywordsRule.validate_manifest(model)
     assert len(issues) == 1
     assert issues[0].level == ValidationIssueLevel.ERROR
 
@@ -49,7 +49,7 @@ def test_reserved_keywords_in_measures(  # noqa: D
     measure = semantic_model.measures[0]
     measure.name = random_keyword()
 
-    issues = ReservedKeywordsRule.validate_model(model)
+    issues = ReservedKeywordsRule.validate_manifest(model)
     assert len(issues) == 1
     assert issues[0].level == ValidationIssueLevel.ERROR
 
@@ -64,7 +64,7 @@ def test_reserved_keywords_in_entities(  # noqa: D
     entity = semantic_model.entities[0]
     entity.name = random_keyword()
 
-    issues = ReservedKeywordsRule.validate_model(model)
+    issues = ReservedKeywordsRule.validate_manifest(model)
     assert len(issues) == 1
     assert issues[0].level == ValidationIssueLevel.ERROR
 
@@ -80,6 +80,6 @@ def test_reserved_keywords_in_node_relation(  # noqa: D
         alias=random_keyword(),
         schema_name="some_schema",
     )
-    issues = ReservedKeywordsRule.validate_model(model)
+    issues = ReservedKeywordsRule.validate_manifest(model)
     assert len(issues) == 1
     assert issues[0].level == ValidationIssueLevel.ERROR

--- a/tests/validations/test_semantic_models.py
+++ b/tests/validations/test_semantic_models.py
@@ -8,13 +8,13 @@ from dbt_semantic_interfaces.test_utils import semantic_model_with_guaranteed_me
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
 @pytest.mark.skip("TODO: Will convert to validation rule")
 def test_semantic_model_invalid_sql() -> None:  # noqa:D
-    with pytest.raises(ModelValidationException, match=r"Invalid SQL"):
+    with pytest.raises(SemanticManifestValidationException, match=r"Invalid SQL"):
         semantic_model_with_guaranteed_meta(
             name="invalid_sql_source",
             dimensions=[

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -41,7 +41,9 @@ def test_duplicate_semantic_model_name(  # noqa: D
         match=rf"Can't use name `{duplicated_semantic_model.name}` for a semantic model when it was already used for "
         "a semantic model",
     ):
-        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest](
+            [UniqueAndValidNameRule[PydanticSemanticManifest]()]
+        ).checked_validations(model)
 
 
 def test_duplicate_metric_name(  # noqa:D
@@ -54,7 +56,7 @@ def test_duplicate_metric_name(  # noqa:D
         SemanticManifestValidationException,
         match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for a metric",
     ):
-        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(  # noqa: D
@@ -66,7 +68,9 @@ def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(  # noq
 
     model_semantic_model.semantic_models[0].name = metric_name
 
-    SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model_semantic_model)
+    SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(
+        model_semantic_model
+    )
 
 
 """
@@ -100,7 +104,7 @@ def test_duplicate_measure_name(  # noqa:D
         match=rf"can't use name `{duplicated_measure.reference.element_name}` for a measure when it was already used "
         "for a measure",
     ):
-        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_duplicate_dimension_name(  # noqa: D
@@ -122,7 +126,7 @@ def test_duplicate_dimension_name(  # noqa: D
         match=rf"can't use name `{duplicated_dimension.reference.element_name}` for a "
         rf"dimension when it was already used for a dimension",
     ):
-        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_duplicate_entity_name(  # noqa:D
@@ -144,7 +148,7 @@ def test_duplicate_entity_name(  # noqa:D
         match=rf"can't use name `{duplicated_entity.reference.element_name}` for a entity when it was already used "
         "for a entity",
     ):
-        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 """

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -13,7 +13,7 @@ from dbt_semantic_interfaces.validations.unique_valid_name import (
     UniqueAndValidNameRule,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 """
@@ -37,7 +37,7 @@ def test_duplicate_semantic_model_name(  # noqa: D
     duplicated_semantic_model = model.semantic_models[0]
     model.semantic_models.append(duplicated_semantic_model)
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=rf"Can't use name `{duplicated_semantic_model.name}` for a semantic model when it was already used for "
         "a semantic model",
     ):
@@ -51,7 +51,7 @@ def test_duplicate_metric_name(  # noqa:D
     duplicated_metric = model.metrics[0]
     model.metrics.append(duplicated_metric)
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for a metric",
     ):
         SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
@@ -96,7 +96,7 @@ def test_duplicate_measure_name(  # noqa:D
     semantic_model_with_measures.measures = tuple(more_itertools.flatten(duplicated_measures_tuple))
 
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=rf"can't use name `{duplicated_measure.reference.element_name}` for a measure when it was already used "
         "for a measure",
     ):
@@ -118,7 +118,7 @@ def test_duplicate_dimension_name(  # noqa: D
     semantic_model_with_dimensions.dimensions = tuple(more_itertools.flatten(duplicated_dimensions_tuple))
 
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=rf"can't use name `{duplicated_dimension.reference.element_name}` for a "
         rf"dimension when it was already used for a dimension",
     ):
@@ -140,7 +140,7 @@ def test_duplicate_entity_name(  # noqa:D
     semantic_model_with_entities.entities = tuple(more_itertools.flatten(duplicated_entities_tuple))
 
     with pytest.raises(
-        ModelValidationException,
+        SemanticManifestValidationException,
         match=rf"can't use name `{duplicated_entity.reference.element_name}` for a entity when it was already used "
         "for a entity",
     ):

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -6,7 +6,7 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.validations.unique_valid_name import (
     MetricFlowReservedKeywords,
@@ -41,7 +41,7 @@ def test_duplicate_semantic_model_name(  # noqa: D
         match=rf"Can't use name `{duplicated_semantic_model.name}` for a semantic model when it was already used for "
         "a semantic model",
     ):
-        ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_duplicate_metric_name(  # noqa:D
@@ -54,7 +54,7 @@ def test_duplicate_metric_name(  # noqa:D
         ModelValidationException,
         match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for a metric",
     ):
-        ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(  # noqa: D
@@ -66,7 +66,7 @@ def test_top_level_metric_can_have_same_name_as_any_other_top_level_item(  # noq
 
     model_semantic_model.semantic_models[0].name = metric_name
 
-    ModelValidator([UniqueAndValidNameRule()]).checked_validations(model_semantic_model)
+    SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model_semantic_model)
 
 
 """
@@ -100,7 +100,7 @@ def test_duplicate_measure_name(  # noqa:D
         match=rf"can't use name `{duplicated_measure.reference.element_name}` for a measure when it was already used "
         "for a measure",
     ):
-        ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_duplicate_dimension_name(  # noqa: D
@@ -122,7 +122,7 @@ def test_duplicate_dimension_name(  # noqa: D
         match=rf"can't use name `{duplicated_dimension.reference.element_name}` for a "
         rf"dimension when it was already used for a dimension",
     ):
-        ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 def test_duplicate_entity_name(  # noqa:D
@@ -144,7 +144,7 @@ def test_duplicate_entity_name(  # noqa:D
         match=rf"can't use name `{duplicated_entity.reference.element_name}` for a entity when it was already used "
         "for a entity",
     ):
-        ModelValidator([UniqueAndValidNameRule()]).checked_validations(model)
+        SemanticManifestValidator([UniqueAndValidNameRule()]).checked_validations(model)
 
 
 """

--- a/tests/validations/test_validator_helpers.py
+++ b/tests/validations/test_validator_helpers.py
@@ -11,7 +11,7 @@ from dbt_semantic_interfaces.references import (
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     MetricContext,
-    ModelValidationResults,
+    SemanticManifestValidationResults,
     SemanticModelContext,
     SemanticModelElementContext,
     SemanticModelElementType,
@@ -96,13 +96,13 @@ def test_creating_model_validation_results_from_issue_list(  # noqa: D
     future_errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.FUTURE_ERROR]
     errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.ERROR]
 
-    model_validation_issues = ModelValidationResults.from_issues_sequence(list_of_issues)
+    model_validation_issues = SemanticManifestValidationResults.from_issues_sequence(list_of_issues)
     assert len(model_validation_issues.warnings) == len(warnings)
     assert len(model_validation_issues.future_errors) == len(future_errors)
     assert len(model_validation_issues.errors) == len(errors)
     assert model_validation_issues.has_blocking_issues
 
-    model_validation_issues = ModelValidationResults(warnings=warnings, future_errors=future_errors)
+    model_validation_issues = SemanticManifestValidationResults(warnings=warnings, future_errors=future_errors)
     assert not model_validation_issues.has_blocking_issues
 
 
@@ -113,10 +113,10 @@ def test_jsonifying_and_reloading_model_validation_results_is_equal(  # noqa: D
     errors = [issue for issue in list_of_issues if issue.level == ValidationIssueLevel.ERROR]
     set_context_types = set([issue.context.__class__ for issue in list_of_issues])
 
-    model_validation_issues = ModelValidationResults.from_issues_sequence(list_of_issues)
-    model_validation_issues_new = ModelValidationResults.parse_raw(model_validation_issues.json())
+    model_validation_issues = SemanticManifestValidationResults.from_issues_sequence(list_of_issues)
+    model_validation_issues_new = SemanticManifestValidationResults.parse_raw(model_validation_issues.json())
     assert model_validation_issues_new == model_validation_issues
-    assert model_validation_issues_new != ModelValidationResults(warnings=warnings, errors=errors)
+    assert model_validation_issues_new != SemanticManifestValidationResults(warnings=warnings, errors=errors)
 
     # ensure ValidationContexts were properly parsed into the differen subclasses
     new_context_types = [issue.context.__class__ for issue in model_validation_issues_new.warnings]
@@ -126,9 +126,9 @@ def test_jsonifying_and_reloading_model_validation_results_is_equal(  # noqa: D
 
 
 def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssue]) -> None:  # noqa: D
-    validation_results = ModelValidationResults.from_issues_sequence(list_of_issues)
-    validation_results_dup = ModelValidationResults.from_issues_sequence(list_of_issues)
-    merged = ModelValidationResults.merge([validation_results, validation_results_dup])
+    validation_results = SemanticManifestValidationResults.from_issues_sequence(list_of_issues)
+    validation_results_dup = SemanticManifestValidationResults.from_issues_sequence(list_of_issues)
+    merged = SemanticManifestValidationResults.merge([validation_results, validation_results_dup])
 
     assert merged.warnings == validation_results.warnings + validation_results_dup.warnings
     assert merged.future_errors == validation_results.future_errors + validation_results_dup.future_errors

--- a/tests/validations/test_validity_param_definitions.py
+++ b/tests/validations/test_validity_param_definitions.py
@@ -2,6 +2,9 @@ import textwrap
 
 import pytest
 
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
@@ -48,7 +51,7 @@ def test_validity_window_configuration() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    model_issues = SemanticManifestValidator().validate_model(model.model)
+    model_issues = SemanticManifestValidator[PydanticSemanticManifest]().validate_model(model.model)
 
     assert not model_issues.has_blocking_issues, (
         f"Found blocking issues validating model with validity window properly configured: "
@@ -83,7 +86,9 @@ def test_validity_window_must_have_a_start() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="has 1 dimensions defined with validity params"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_validity_window_must_have_an_end() -> None:
@@ -113,7 +118,9 @@ def test_validity_window_must_have_an_end() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="has 1 dimensions defined with validity params"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_validity_window_uses_two_dimensions() -> None:
@@ -149,7 +156,9 @@ def test_validity_window_uses_two_dimensions() -> None:
     with pytest.raises(
         SemanticManifestValidationException, match="single validity param dimension that defines its window"
     ):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_two_dimension_validity_windows_must_not_overload_start_and_end() -> None:
@@ -186,7 +195,9 @@ def test_two_dimension_validity_windows_must_not_overload_start_and_end() -> Non
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="does not have exactly one each"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_multiple_validity_windows_are_invalid() -> None:
@@ -234,7 +245,9 @@ def test_multiple_validity_windows_are_invalid() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="has 4 dimensions defined with validity params"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_empty_validity_windows_are_invalid() -> None:
@@ -270,7 +283,9 @@ def test_empty_validity_windows_are_invalid() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="does not have exactly one each"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_measures_are_prevented() -> None:
@@ -317,7 +332,9 @@ def test_measures_are_prevented() -> None:
     with pytest.raises(
         SemanticManifestValidationException, match="has both measures and validity param dimensions defined"
     ):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_validity_window_must_have_a_natural_key() -> None:
@@ -353,7 +370,9 @@ def test_validity_window_must_have_a_natural_key() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="does not have an entity with type `natural` set"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )
 
 
 def test_validity_window_does_not_use_primary_key() -> None:
@@ -396,4 +415,6 @@ def test_validity_window_does_not_use_primary_key() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(SemanticManifestValidationException, match="has one or more entities designated as `primary`"):
-        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator[PydanticSemanticManifest]([SemanticModelValidityWindowRule()]).checked_validations(
+            model.model
+        )

--- a/tests/validations/test_validity_param_definitions.py
+++ b/tests/validations/test_validity_param_definitions.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.validations.semantic_models import (
     SemanticModelValidityWindowRule,
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
-    ModelValidationException,
+    SemanticManifestValidationException,
 )
 
 
@@ -82,7 +82,7 @@ def test_validity_window_must_have_a_start() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
+    with pytest.raises(SemanticManifestValidationException, match="has 1 dimensions defined with validity params"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -112,7 +112,7 @@ def test_validity_window_must_have_an_end() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
+    with pytest.raises(SemanticManifestValidationException, match="has 1 dimensions defined with validity params"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -146,7 +146,9 @@ def test_validity_window_uses_two_dimensions() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="single validity param dimension that defines its window"):
+    with pytest.raises(
+        SemanticManifestValidationException, match="single validity param dimension that defines its window"
+    ):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -183,7 +185,7 @@ def test_two_dimension_validity_windows_must_not_overload_start_and_end() -> Non
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="does not have exactly one each"):
+    with pytest.raises(SemanticManifestValidationException, match="does not have exactly one each"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -231,7 +233,7 @@ def test_multiple_validity_windows_are_invalid() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has 4 dimensions defined with validity params"):
+    with pytest.raises(SemanticManifestValidationException, match="has 4 dimensions defined with validity params"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -267,7 +269,7 @@ def test_empty_validity_windows_are_invalid() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="does not have exactly one each"):
+    with pytest.raises(SemanticManifestValidationException, match="does not have exactly one each"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -312,7 +314,9 @@ def test_measures_are_prevented() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has both measures and validity param dimensions defined"):
+    with pytest.raises(
+        SemanticManifestValidationException, match="has both measures and validity param dimensions defined"
+    ):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -348,7 +352,7 @@ def test_validity_window_must_have_a_natural_key() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="does not have an entity with type `natural` set"):
+    with pytest.raises(SemanticManifestValidationException, match="does not have an entity with type `natural` set"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
@@ -391,5 +395,5 @@ def test_validity_window_does_not_use_primary_key() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    with pytest.raises(ModelValidationException, match="has one or more entities designated as `primary`"):
+    with pytest.raises(SemanticManifestValidationException, match="has one or more entities designated as `primary`"):
         SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)

--- a/tests/validations/test_validity_param_definitions.py
+++ b/tests/validations/test_validity_param_definitions.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from dbt_semantic_interfaces.model_validator import ModelValidator
+from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
 )
@@ -48,7 +48,7 @@ def test_validity_window_configuration() -> None:
     validity_window_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
-    model_issues = ModelValidator().validate_model(model.model)
+    model_issues = SemanticManifestValidator().validate_model(model.model)
 
     assert not model_issues.has_blocking_issues, (
         f"Found blocking issues validating model with validity window properly configured: "
@@ -83,7 +83,7 @@ def test_validity_window_must_have_a_start() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_validity_window_must_have_an_end() -> None:
@@ -113,7 +113,7 @@ def test_validity_window_must_have_an_end() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="has 1 dimensions defined with validity params"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_validity_window_uses_two_dimensions() -> None:
@@ -147,7 +147,7 @@ def test_validity_window_uses_two_dimensions() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="single validity param dimension that defines its window"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_two_dimension_validity_windows_must_not_overload_start_and_end() -> None:
@@ -184,7 +184,7 @@ def test_two_dimension_validity_windows_must_not_overload_start_and_end() -> Non
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="does not have exactly one each"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_multiple_validity_windows_are_invalid() -> None:
@@ -232,7 +232,7 @@ def test_multiple_validity_windows_are_invalid() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="has 4 dimensions defined with validity params"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_empty_validity_windows_are_invalid() -> None:
@@ -268,7 +268,7 @@ def test_empty_validity_windows_are_invalid() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="does not have exactly one each"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_measures_are_prevented() -> None:
@@ -313,7 +313,7 @@ def test_measures_are_prevented() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="has both measures and validity param dimensions defined"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_validity_window_must_have_a_natural_key() -> None:
@@ -349,7 +349,7 @@ def test_validity_window_must_have_a_natural_key() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="does not have an entity with type `natural` set"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
 
 
 def test_validity_window_does_not_use_primary_key() -> None:
@@ -392,4 +392,4 @@ def test_validity_window_does_not_use_primary_key() -> None:
     model = parse_yaml_files_to_validation_ready_model([base_semantic_manifest_file(), validity_window_file])
 
     with pytest.raises(ModelValidationException, match="has one or more entities designated as `primary`"):
-        ModelValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)
+        SemanticManifestValidator([SemanticModelValidityWindowRule()]).checked_validations(model.model)


### PR DESCRIPTION
Resolves #20 

### Description

This PR changes the signature of the classes used for validation to be generic so that other implementations of the `SemanticManifest` can use the same framework with type-safety.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
