### PR TITLE
Remove `--ignore-missing-imports` from Mypy and Add Pydantic Plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,6 @@ repos:
     rev: v1.3.0
     hooks:
     - id: mypy
-      args: [--ignore-missing-imports,--show-error-codes]
+      args: [--show-error-codes]
       verbose: true
       language: system

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -168,7 +168,7 @@ def parse_yaml_files_to_validation_ready_model(
         if apply_transformations:
             model = ModelTransformer.transform(model)
     except Exception as e:
-        transformation_issue_results = SemanticManifestValidationResults(errors=[ValidationError(message=str(e))])
+        transformation_issue_results = SemanticManifestValidationResults(errors=(ValidationError(message=str(e)),))
         build_issues = SemanticManifestValidationResults.merge([build_issues, transformation_issue_results])
 
     if raise_issues_as_exceptions and build_issues.has_blocking_issues:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+plugins = pydantic.mypy
+
+[pydantic-mypy]
+init_forbid_extra = True
+init_typed = True
+warn_required_dynamic_aliases = True
+warn_untyped_fields = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pydantic~=1.9.0",
+  "pydantic~=1.10.8",
   "jsonschema==3.2.0",
   "PyYAML~=6.0",
   "more-itertools==8.10.0",

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -8,6 +8,7 @@ from dbt_semantic_interfaces.implementations.elements.measure import PydanticMea
 from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
     PydanticMetric,
+    PydanticMetricInputMeasure,
     PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
@@ -70,7 +71,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name=measure_name,
                         type=MetricType.MEASURE_PROXY,
-                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                     )
                 ],
             )
@@ -118,7 +119,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name=measure_name,
                         type=MetricType.MEASURE_PROXY,
-                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                     )
                 ],
             )
@@ -173,7 +174,9 @@ def test_multiple_primary_time_dimensions() -> None:  # noqa:D
                     PydanticMetric(
                         name=measure_reference.element_name,
                         type=MetricType.MEASURE_PROXY,
-                        type_params=PydanticMetricTypeParams(measures=[measure_reference.element_name]),
+                        type_params=PydanticMetricTypeParams(
+                            measures=[PydanticMetricInputMeasure(name=measure_reference.element_name)]
+                        ),
                     )
                 ],
             )

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -9,6 +9,8 @@ from dbt_semantic_interfaces.implementations.elements.measure import PydanticMea
 from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
     PydanticMetricInput,
+    PydanticMetricInputMeasure,
+    PydanticMetricTimeWindow,
     PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
@@ -73,7 +75,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                 metric_with_guaranteed_meta(
                     name="metric_with_no_time_dim",
                     type=MetricType.MEASURE_PROXY,
-                    type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                    type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                 )
             ],
         )
@@ -103,7 +105,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name="metric_with_no_time_dim",
                         type=MetricType.MEASURE_PROXY,
-                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                     )
                 ],
             )
@@ -144,7 +146,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name="foo",
                         type=MetricType.MEASURE_PROXY,
-                        type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                        type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                     )
                 ],
             )
@@ -218,12 +220,12 @@ def test_derived_metric() -> None:  # noqa: D
                 metric_with_guaranteed_meta(
                     name="random_metric",
                     type=MetricType.MEASURE_PROXY,
-                    type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                    type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                 ),
                 metric_with_guaranteed_meta(
                     name="random_metric2",
                     type=MetricType.MEASURE_PROXY,
-                    type_params=PydanticMetricTypeParams(measures=[measure_name]),
+                    type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
                 ),
                 metric_with_guaranteed_meta(
                     name="alias_collision",
@@ -249,8 +251,12 @@ def test_derived_metric() -> None:  # noqa: D
                     type_params=PydanticMetricTypeParams(
                         expr="random_metric / random_metric3",
                         metrics=[
-                            PydanticMetricInput(name="random_metric", offset_window="3 weeks"),
-                            PydanticMetricInput(name="random_metric", offset_to_grain="month", alias="random_metric3"),
+                            PydanticMetricInput(
+                                name="random_metric", offset_window=PydanticMetricTimeWindow.parse("3 weeks")
+                            ),
+                            PydanticMetricInput(
+                                name="random_metric", offset_to_grain=TimeGranularity.MONTH, alias="random_metric3"
+                            ),
                         ],
                     ),
                 ),
@@ -260,7 +266,11 @@ def test_derived_metric() -> None:  # noqa: D
                     type_params=PydanticMetricTypeParams(
                         expr="random_metric * 2",
                         metrics=[
-                            PydanticMetricInput(name="random_metric", offset_window="3 weeks", offset_to_grain="month")
+                            PydanticMetricInput(
+                                name="random_metric",
+                                offset_window=PydanticMetricTimeWindow.parse("3 weeks"),
+                                offset_to_grain=TimeGranularity.MONTH,
+                            )
                         ],
                     ),
                 ),


### PR DESCRIPTION
### Description

This PR improves type checking in the project by removing the `--ignore-missing-imports` flag for the mypy pre-commit check and adding the Pydantic Mypy plugin. The plugin allows for more checks on Pydantic types.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
