### PR TITLE
Change Transforms to be Generic

### DIFF
--- a/dbt_semantic_interfaces/model_transformer.py
+++ b/dbt_semantic_interfaces/model_transformer.py
@@ -15,7 +15,7 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 logger = logging.getLogger(__name__)
 
 
-class SemanticManifestTransformer:
+class PydanticSemanticManifestTransformer:
     """Helps to make transformations to a model for convenience.
 
     Generally used to make it more convenient for the user to develop their model.

--- a/dbt_semantic_interfaces/model_transformer.py
+++ b/dbt_semantic_interfaces/model_transformer.py
@@ -20,23 +20,25 @@ from dbt_semantic_interfaces.transformations.convert_median import (
 )
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class ModelTransformer:
+class SemanticManifestTransformer:
     """Helps to make transformations to a model for convenience.
 
     Generally used to make it more convenient for the user to develop their model.
     """
 
-    PRIMARY_RULES: Sequence[ModelTransformRule] = (
+    PRIMARY_RULES: Sequence[SemanticManifestTransformRule] = (
         LowerCaseNamesRule(),
         SetMeasureAggregationTimeDimensionRule(),
     )
 
-    SECONDARY_RULES: Sequence[ModelTransformRule] = (
+    SECONDARY_RULES: Sequence[SemanticManifestTransformRule] = (
         CreateProxyMeasureRule(),
         BooleanMeasureAggregationRule(),
         ConvertCountToSumRule(),
@@ -44,7 +46,7 @@ class ModelTransformer:
         AddInputMetricMeasuresRule(),
     )
 
-    DEFAULT_RULES: Tuple[Sequence[ModelTransformRule], ...] = (
+    DEFAULT_RULES: Tuple[Sequence[SemanticManifestTransformRule], ...] = (
         PRIMARY_RULES,
         SECONDARY_RULES,
     )
@@ -52,7 +54,7 @@ class ModelTransformer:
     @staticmethod
     def transform(
         model: PydanticSemanticManifest,
-        ordered_rule_sequences: Tuple[Sequence[ModelTransformRule], ...] = DEFAULT_RULES,
+        ordered_rule_sequences: Tuple[Sequence[SemanticManifestTransformRule], ...] = DEFAULT_RULES,
     ) -> PydanticSemanticManifest:
         """Copies the passed in model, applies the rules to the new model, and then returns that model.
 
@@ -71,7 +73,7 @@ class ModelTransformer:
 
     @staticmethod
     def pre_validation_transform_model(
-        model: PydanticSemanticManifest, rules: Sequence[ModelTransformRule] = PRIMARY_RULES
+        model: PydanticSemanticManifest, rules: Sequence[SemanticManifestTransformRule] = PRIMARY_RULES
     ) -> PydanticSemanticManifest:
         """Transform a model according to configured rules before validations are run."""
         logger.warning(
@@ -79,12 +81,12 @@ class ModelTransformer:
             "Please use `ModelTransformer.transform` instead.",
         )
 
-        return ModelTransformer.transform(model=model, ordered_rule_sequences=(rules,))
+        return SemanticManifestTransformer.transform(model=model, ordered_rule_sequences=(rules,))
 
     @staticmethod
     def post_validation_transform_model(
         model: PydanticSemanticManifest,
-        rules: Sequence[ModelTransformRule] = SECONDARY_RULES,
+        rules: Sequence[SemanticManifestTransformRule] = SECONDARY_RULES,
     ) -> PydanticSemanticManifest:
         """Transform a model according to configured rules after validations are run."""
         logger.warning(
@@ -92,4 +94,4 @@ class ModelTransformer:
             "Please use `ModelTransformer.transform` instead.",
         )
 
-        return ModelTransformer.transform(model=model, ordered_rule_sequences=(rules,))
+        return SemanticManifestTransformer.transform(model=model, ordered_rule_sequences=(rules,))

--- a/dbt_semantic_interfaces/model_transformer.py
+++ b/dbt_semantic_interfaces/model_transformer.py
@@ -1,10 +1,12 @@
 import copy
 import logging
-from typing import Optional, Sequence
+from abc import abstractmethod
+from typing import Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.transformations.pydantic_rule_set import (
     PydanticSemanticManifestTransformRuleSet,
 )
@@ -15,17 +17,18 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 logger = logging.getLogger(__name__)
 
 
-class PydanticSemanticManifestTransformer:
+class SemanticManifestTransformer(Protocol[SemanticManifestT]):
     """Helps to make transformations to a model for convenience.
 
     Generally used to make it more convenient for the user to develop their model.
     """
 
-    @staticmethod
+    @abstractmethod
     def transform(
-        model: PydanticSemanticManifest,
+        self,
+        model: SemanticManifestT,
         ordered_rule_sequences: Optional[Sequence[Sequence[SemanticManifestTransformRule]]] = None,
-    ) -> PydanticSemanticManifest:
+    ) -> SemanticManifestT:
         """Copies the passed in model, applies the rules to the new model, and then returns that model.
 
         It's important to note that some rules need to happen before or after other rules. Thus rules
@@ -33,6 +36,17 @@ class PydanticSemanticManifestTransformer:
         secondary rules. We don't currently have tertiary, quaternary, or etc currently, but this
         system easily allows for it.
         """
+        pass
+
+
+class PydanticSemanticManifestTransformer:
+    """Transforms PydanticSemanticManifest."""
+
+    @staticmethod
+    def transform(  # noqa: D
+        model: PydanticSemanticManifest,
+        ordered_rule_sequences: Optional[Sequence[Sequence[SemanticManifestTransformRule]]] = None,
+    ) -> PydanticSemanticManifest:
         if ordered_rule_sequences is None:
             ordered_rule_sequences = PydanticSemanticManifestTransformRuleSet().all_rules
 

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -13,7 +13,9 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
+from dbt_semantic_interfaces.model_transformer import (
+    PydanticSemanticManifestTransformer,
+)
 from dbt_semantic_interfaces.parsing.objects import Version, YamlConfigFile
 from dbt_semantic_interfaces.parsing.schemas import (
     metric_validator,
@@ -166,7 +168,7 @@ def parse_yaml_files_to_validation_ready_model(
     build_issues = build_result.issues
     try:
         if apply_transformations:
-            model = SemanticManifestTransformer.transform(model)
+            model = PydanticSemanticManifestTransformer.transform(model)
     except Exception as e:
         transformation_issue_results = SemanticManifestValidationResults(errors=(ValidationError(message=str(e)),))
         build_issues = SemanticManifestValidationResults.merge([build_issues, transformation_issue_results])

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -13,7 +13,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.model_transformer import ModelTransformer
+from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
 from dbt_semantic_interfaces.parsing.objects import Version, YamlConfigFile
 from dbt_semantic_interfaces.parsing.schemas import (
     metric_validator,
@@ -166,7 +166,7 @@ def parse_yaml_files_to_validation_ready_model(
     build_issues = build_result.issues
     try:
         if apply_transformations:
-            model = ModelTransformer.transform(model)
+            model = SemanticManifestTransformer.transform(model)
     except Exception as e:
         transformation_issue_results = SemanticManifestValidationResults(errors=(ValidationError(message=str(e)),))
         build_issues = SemanticManifestValidationResults.merge([build_issues, transformation_issue_results])

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -8,10 +8,12 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 
 
-class AddInputMetricMeasuresRule(ModelTransformRule):
+class AddInputMetricMeasuresRule(SemanticManifestTransformRule):
     """Add all measures corresponding to the input metrics of the derived metric."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -6,13 +6,15 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.references import TimeDimensionReference
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 
 logger = logging.getLogger(__name__)
 
 
-class SetMeasureAggregationTimeDimensionRule(ModelTransformRule):
+class SetMeasureAggregationTimeDimensionRule(SemanticManifestTransformRule):
     """Sets the aggregation time dimension for measures to the primary time dimension if not defined."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/transformations/boolean_measure.py
+++ b/dbt_semantic_interfaces/transformations/boolean_measure.py
@@ -3,13 +3,15 @@ import logging
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
 logger = logging.getLogger(__name__)
 
 
-class BooleanMeasureAggregationRule(ModelTransformRule):
+class BooleanMeasureAggregationRule(SemanticManifestTransformRule):
     """Converts the expression used in boolean measures so that it can be aggregated."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/transformations/convert_count.py
+++ b/dbt_semantic_interfaces/transformations/convert_count.py
@@ -2,13 +2,15 @@ from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
 ONE = "1"
 
 
-class ConvertCountToSumRule(ModelTransformRule):
+class ConvertCountToSumRule(SemanticManifestTransformRule):
     """Converts any COUNT measures to SUM equivalent."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/transformations/convert_median.py
+++ b/dbt_semantic_interfaces/transformations/convert_median.py
@@ -5,13 +5,15 @@ from dbt_semantic_interfaces.implementations.elements.measure import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 
 MEDIAN_PERCENTILE = 0.5
 
 
-class ConvertMedianToPercentileRule(ModelTransformRule):
+class ConvertMedianToPercentileRule(SemanticManifestTransformRule):
     """Converts any MEDIAN measures to percentile equivalent."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/transformations/names.py
+++ b/dbt_semantic_interfaces/transformations/names.py
@@ -4,12 +4,14 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class LowerCaseNamesRule(ModelTransformRule):
+class LowerCaseNamesRule(SemanticManifestTransformRule):
     """Lowercases the names of both top level objects and semantic model elements in a model."""
 
     @staticmethod

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -10,12 +10,14 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class CreateProxyMeasureRule(ModelTransformRule):
+class CreateProxyMeasureRule(SemanticManifestTransformRule):
     """Adds a proxy metric for measures that have the create_metric flag set, if it does not already exist.
 
     Also checks that a defined metric with the same name as a measure is a proxy metric.

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -1,6 +1,9 @@
 import logging
 from typing import Sequence
 
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
 from dbt_semantic_interfaces.transformations.add_input_metric_measures import (
     AddInputMetricMeasuresRule,
 )
@@ -27,14 +30,14 @@ class PydanticSemanticManifestTransformRuleSet:
     """Transform rules that should be used for the Pydantic implementation of SemanticManifest."""
 
     @property
-    def primary_rules(self) -> Sequence[SemanticManifestTransformRule]:  # noqa:
+    def primary_rules(self) -> Sequence[SemanticManifestTransformRule[PydanticSemanticManifest]]:  # noqa:
         return (
             LowerCaseNamesRule(),
             SetMeasureAggregationTimeDimensionRule(),
         )
 
     @property
-    def secondary_rules(self) -> Sequence[SemanticManifestTransformRule]:  # noqa: D
+    def secondary_rules(self) -> Sequence[SemanticManifestTransformRule[PydanticSemanticManifest]]:  # noqa: D
         return (
             CreateProxyMeasureRule(),
             BooleanMeasureAggregationRule(),
@@ -44,5 +47,5 @@ class PydanticSemanticManifestTransformRuleSet:
         )
 
     @property
-    def all_rules(self) -> Sequence[Sequence[SemanticManifestTransformRule]]:  # noqa: D
+    def all_rules(self) -> Sequence[Sequence[SemanticManifestTransformRule[PydanticSemanticManifest]]]:  # noqa: D
         return self.primary_rules, self.secondary_rules

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Sequence
+
+from dbt_semantic_interfaces.transformations.add_input_metric_measures import (
+    AddInputMetricMeasuresRule,
+)
+from dbt_semantic_interfaces.transformations.agg_time_dimension import (
+    SetMeasureAggregationTimeDimensionRule,
+)
+from dbt_semantic_interfaces.transformations.boolean_measure import (
+    BooleanMeasureAggregationRule,
+)
+from dbt_semantic_interfaces.transformations.convert_count import ConvertCountToSumRule
+from dbt_semantic_interfaces.transformations.convert_median import (
+    ConvertMedianToPercentileRule,
+)
+from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
+from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PydanticSemanticManifestTransformRuleSet:
+    """Transform rules that should be used for the Pydantic implementation of SemanticManifest."""
+
+    @property
+    def primary_rules(self) -> Sequence[SemanticManifestTransformRule]:  # noqa:
+        return (
+            LowerCaseNamesRule(),
+            SetMeasureAggregationTimeDimensionRule(),
+        )
+
+    @property
+    def secondary_rules(self) -> Sequence[SemanticManifestTransformRule]:  # noqa: D
+        return (
+            CreateProxyMeasureRule(),
+            BooleanMeasureAggregationRule(),
+            ConvertCountToSumRule(),
+            ConvertMedianToPercentileRule(),
+            AddInputMetricMeasuresRule(),
+        )
+
+    @property
+    def all_rules(self) -> Sequence[Sequence[SemanticManifestTransformRule]]:  # noqa: D
+        return self.primary_rules, self.secondary_rules

--- a/dbt_semantic_interfaces/transformations/rule_set.py
+++ b/dbt_semantic_interfaces/transformations/rule_set.py
@@ -1,0 +1,31 @@
+import logging
+from abc import abstractmethod
+from typing import Protocol, Sequence
+
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SemanticManifestTransformRuleSet(Protocol):
+    """Groups rules that should be run for a SemanticManifest."""
+
+    @property
+    @abstractmethod
+    def primary_rules(self) -> Sequence[SemanticManifestTransformRule]:
+        """TODO: Define what primary means."""
+        pass
+
+    @property
+    @abstractmethod
+    def secondary_rules(self) -> Sequence[SemanticManifestTransformRule]:
+        """TODO: Define what secondary means."""
+        pass
+
+    @property
+    @abstractmethod
+    def all_rules(self) -> Sequence[Sequence[SemanticManifestTransformRule]]:
+        """TODO: Why a nested sequence?"""
+        pass

--- a/dbt_semantic_interfaces/transformations/rule_set.py
+++ b/dbt_semantic_interfaces/transformations/rule_set.py
@@ -2,6 +2,7 @@ import logging
 from abc import abstractmethod
 from typing import Protocol, Sequence
 
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -9,23 +10,23 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 logger = logging.getLogger(__name__)
 
 
-class SemanticManifestTransformRuleSet(Protocol):
+class SemanticManifestTransformRuleSet(Protocol[SemanticManifestT]):
     """Groups rules that should be run for a SemanticManifest."""
 
     @property
     @abstractmethod
-    def primary_rules(self) -> Sequence[SemanticManifestTransformRule]:
+    def primary_rules(self) -> Sequence[SemanticManifestTransformRule[SemanticManifestT]]:
         """TODO: Define what primary means."""
         pass
 
     @property
     @abstractmethod
-    def secondary_rules(self) -> Sequence[SemanticManifestTransformRule]:
+    def secondary_rules(self) -> Sequence[SemanticManifestTransformRule[SemanticManifestT]]:
         """TODO: Define what secondary means."""
         pass
 
     @property
     @abstractmethod
-    def all_rules(self) -> Sequence[Sequence[SemanticManifestTransformRule]]:
+    def all_rules(self) -> Sequence[Sequence[SemanticManifestTransformRule[SemanticManifestT]]]:
         """TODO: Why a nested sequence?"""
         pass

--- a/dbt_semantic_interfaces/transformations/transform_rule.py
+++ b/dbt_semantic_interfaces/transformations/transform_rule.py
@@ -1,15 +1,21 @@
-from abc import ABC, abstractmethod
+from __future__ import annotations
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
+from abc import abstractmethod
+from typing import Protocol, TypeVar
+
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 
 
-class SemanticManifestTransformRule(ABC):
+class SemanticManifestTransformRule(Protocol[SemanticManifestT]):
     """Encapsulates logic for transforming a model. e.g. add metrics based on measures."""
 
-    @staticmethod
     @abstractmethod
-    def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:
+    def transform_model(self, model: SemanticManifestT) -> SemanticManifestT:
         """Copy and transform the given model into a new model."""
         pass
+
+
+SemanticManifestTransformRuleT = TypeVar("SemanticManifestTransformRuleT", bound=SemanticManifestTransformRule)
+SemanticManifestTransformRuleT_co = TypeVar(
+    "SemanticManifestTransformRuleT_co", bound=SemanticManifestTransformRule, covariant=True
+)

--- a/dbt_semantic_interfaces/transformations/transform_rule.py
+++ b/dbt_semantic_interfaces/transformations/transform_rule.py
@@ -5,7 +5,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 )
 
 
-class ModelTransformRule(ABC):
+class SemanticManifestTransformRule(ABC):
     """Encapsulates logic for transforming a model. e.g. add metrics based on measures."""
 
     @staticmethod

--- a/tests/fixtures/semantic_manifest_fixtures.py
+++ b/tests/fixtures/semantic_manifest_fixtures.py
@@ -15,6 +15,9 @@ from dbt_semantic_interfaces.model_transformer import SemanticManifestTransforme
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_directory_of_yaml_files_to_model,
 )
+from dbt_semantic_interfaces.transformations.pydantic_rule_set import (
+    PydanticSemanticManifestTransformRuleSet,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +50,7 @@ def simple_semantic_manifest__with_primary_transforms(template_mapping: Dict[str
         apply_transformations=False,
     )
     transformed_model = SemanticManifestTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
+        model=model_build_result.model,
+        ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )
     return transformed_model

--- a/tests/fixtures/semantic_manifest_fixtures.py
+++ b/tests/fixtures/semantic_manifest_fixtures.py
@@ -11,7 +11,7 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_transformer import ModelTransformer
+from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_directory_of_yaml_files_to_model,
 )
@@ -46,7 +46,7 @@ def simple_semantic_manifest__with_primary_transforms(template_mapping: Dict[str
         template_mapping=template_mapping,
         apply_transformations=False,
     )
-    transformed_model = ModelTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
+    transformed_model = SemanticManifestTransformer.transform(
+        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
     )
     return transformed_model

--- a/tests/fixtures/semantic_manifest_fixtures.py
+++ b/tests/fixtures/semantic_manifest_fixtures.py
@@ -11,7 +11,9 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
+from dbt_semantic_interfaces.model_transformer import (
+    PydanticSemanticManifestTransformer,
+)
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_directory_of_yaml_files_to_model,
 )
@@ -49,7 +51,7 @@ def simple_semantic_manifest__with_primary_transforms(template_mapping: Dict[str
         template_mapping=template_mapping,
         apply_transformations=False,
     )
-    transformed_model = SemanticManifestTransformer.transform(
+    transformed_model = PydanticSemanticManifestTransformer.transform(
         model=model_build_result.model,
         ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )

--- a/tests/transformations/test_configurable_transform_rules.py
+++ b/tests/transformations/test_configurable_transform_rules.py
@@ -1,7 +1,9 @@
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
+from dbt_semantic_interfaces.model_transformer import (
+    PydanticSemanticManifestTransformer,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -28,5 +30,5 @@ def test_can_configure_model_transform_rules(  # noqa: D
 
     # Confirms that a custom transformation works `for ModelTransformer.transform`
     rules = [SliceNamesRule()]
-    transformed_model = SemanticManifestTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
+    transformed_model = PydanticSemanticManifestTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
     assert all(len(x.name) == 3 for x in transformed_model.semantic_models)

--- a/tests/transformations/test_configurable_transform_rules.py
+++ b/tests/transformations/test_configurable_transform_rules.py
@@ -1,11 +1,13 @@
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_transformer import ModelTransformer
-from dbt_semantic_interfaces.transformations.transform_rule import ModelTransformRule
+from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
 
 
-class SliceNamesRule(ModelTransformRule):
+class SliceNamesRule(SemanticManifestTransformRule):
     """Slice the names of semantic model elements in a model.
 
     NOTE: specifically for testing
@@ -26,5 +28,5 @@ def test_can_configure_model_transform_rules(  # noqa: D
 
     # Confirms that a custom transformation works `for ModelTransformer.transform`
     rules = [SliceNamesRule()]
-    transformed_model = ModelTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
+    transformed_model = SemanticManifestTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
     assert all(len(x.name) == 3 for x in transformed_model.semantic_models)

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -6,7 +6,7 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_transformer import ModelTransformer
+from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
 from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
@@ -471,8 +471,8 @@ def test_invalid_non_additive_dimension_properties() -> None:
     model_build_result = parse_yaml_files_to_validation_ready_model(
         [invalid_dim_file], apply_transformations=False, raise_issues_as_exceptions=False
     )
-    transformed_model = ModelTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
+    transformed_model = SemanticManifestTransformer.transform(
+        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
     )
 
     model_issues = SemanticManifestValidator[PydanticSemanticManifest](
@@ -529,8 +529,8 @@ def test_count_measure_missing_expr() -> None:
     )
     missing_expr_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents)
     model_build_result = parse_yaml_files_to_validation_ready_model([missing_expr_file], apply_transformations=False)
-    transformed_model = ModelTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
+    transformed_model = SemanticManifestTransformer.transform(
+        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
     )
 
     model_issues = SemanticManifestValidator[PydanticSemanticManifest]([CountAggregationExprRule()]).validate_model(
@@ -581,8 +581,8 @@ def test_count_measure_with_distinct_expr() -> None:
     )
     distinct_count_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model_build_result = parse_yaml_files_to_validation_ready_model([distinct_count_file], apply_transformations=False)
-    transformed_model = ModelTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(ModelTransformer.PRIMARY_RULES,)
+    transformed_model = SemanticManifestTransformer.transform(
+        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
     )
 
     model_issues = SemanticManifestValidator[PydanticSemanticManifest]([CountAggregationExprRule()]).validate_model(

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -6,7 +6,9 @@ import pytest
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.model_transformer import SemanticManifestTransformer
+from dbt_semantic_interfaces.model_transformer import (
+    PydanticSemanticManifestTransformer,
+)
 from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
 from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
@@ -474,7 +476,7 @@ def test_invalid_non_additive_dimension_properties() -> None:
     model_build_result = parse_yaml_files_to_validation_ready_model(
         [invalid_dim_file], apply_transformations=False, raise_issues_as_exceptions=False
     )
-    transformed_model = SemanticManifestTransformer.transform(
+    transformed_model = PydanticSemanticManifestTransformer.transform(
         model=model_build_result.model,
         ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )
@@ -533,7 +535,7 @@ def test_count_measure_missing_expr() -> None:
     )
     missing_expr_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents)
     model_build_result = parse_yaml_files_to_validation_ready_model([missing_expr_file], apply_transformations=False)
-    transformed_model = SemanticManifestTransformer.transform(
+    transformed_model = PydanticSemanticManifestTransformer.transform(
         model=model_build_result.model,
         ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )
@@ -586,7 +588,7 @@ def test_count_measure_with_distinct_expr() -> None:
     )
     distinct_count_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model_build_result = parse_yaml_files_to_validation_ready_model([distinct_count_file], apply_transformations=False)
-    transformed_model = SemanticManifestTransformer.transform(
+    transformed_model = PydanticSemanticManifestTransformer.transform(
         model=model_build_result.model,
         ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -12,6 +12,9 @@ from dbt_semantic_interfaces.parsing.dir_to_model import (
     parse_yaml_files_to_validation_ready_model,
 )
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
+from dbt_semantic_interfaces.transformations.pydantic_rule_set import (
+    PydanticSemanticManifestTransformRuleSet,
+)
 from dbt_semantic_interfaces.validations.measures import (
     CountAggregationExprRule,
     MeasureConstraintAliasesRule,
@@ -472,7 +475,8 @@ def test_invalid_non_additive_dimension_properties() -> None:
         [invalid_dim_file], apply_transformations=False, raise_issues_as_exceptions=False
     )
     transformed_model = SemanticManifestTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
+        model=model_build_result.model,
+        ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )
 
     model_issues = SemanticManifestValidator[PydanticSemanticManifest](
@@ -530,7 +534,8 @@ def test_count_measure_missing_expr() -> None:
     missing_expr_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents)
     model_build_result = parse_yaml_files_to_validation_ready_model([missing_expr_file], apply_transformations=False)
     transformed_model = SemanticManifestTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
+        model=model_build_result.model,
+        ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )
 
     model_issues = SemanticManifestValidator[PydanticSemanticManifest]([CountAggregationExprRule()]).validate_model(
@@ -582,7 +587,8 @@ def test_count_measure_with_distinct_expr() -> None:
     distinct_count_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
     model_build_result = parse_yaml_files_to_validation_ready_model([distinct_count_file], apply_transformations=False)
     transformed_model = SemanticManifestTransformer.transform(
-        model=model_build_result.model, ordered_rule_sequences=(SemanticManifestTransformer.PRIMARY_RULES,)
+        model=model_build_result.model,
+        ordered_rule_sequences=(PydanticSemanticManifestTransformRuleSet().primary_rules,),
     )
 
     model_issues = SemanticManifestValidator[PydanticSemanticManifest]([CountAggregationExprRule()]).validate_model(


### PR DESCRIPTION
Resolves #21 

### Description

This PR changes the signature of the classes used for semantic manifest transforms to be generic so that other implementations of the SemanticManifest can use the same transformation framework with type-safety.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
