### PR TITLE
Add Protocol Hints

### DIFF
--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -2,14 +2,21 @@ from typing import List
 
 from importlib_metadata import version
 from pydantic import validator
+from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 from dbt_semantic_interfaces.implementations.metric import PydanticMetric
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
+from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifest
 
 
-class PydanticSemanticManifest(HashableBaseModel):
+class PydanticSemanticManifest(HashableBaseModel, ProtocolHint[SemanticManifest]):
     """Model holds all the information the SemanticLayer needs to render a query."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifest:  # noqa: D
+        return self
 
     semantic_models: List[PydanticSemanticModel]
     metrics: List[PydanticMetric]

--- a/dbt_semantic_interfaces/model_transformer.py
+++ b/dbt_semantic_interfaces/model_transformer.py
@@ -3,9 +3,12 @@ import logging
 from abc import abstractmethod
 from typing import Optional, Protocol, Sequence
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.transformations.pydantic_rule_set import (
     PydanticSemanticManifestTransformRuleSet,
@@ -39,8 +42,12 @@ class SemanticManifestTransformer(Protocol[SemanticManifestT]):
         pass
 
 
-class PydanticSemanticManifestTransformer:
+class PydanticSemanticManifestTransformer(ProtocolHint[SemanticManifestTransformer[PydanticSemanticManifest]]):
     """Transforms PydanticSemanticManifest."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformer[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def transform(  # noqa: D

--- a/dbt_semantic_interfaces/protocols/protocol_hint.py
+++ b/dbt_semantic_interfaces/protocols/protocol_hint.py
@@ -1,0 +1,29 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class ProtocolHint(Generic[T], ABC):
+    """Add this to show inspections / hints in the IDE for whether a class properly implements a protocol.
+
+    The type parameter T should be the protocol that is expected to be implemented.
+
+    This is only used to help generate the inspections to improve the developer experience, but otherwise does nothing.
+    This also allows developers to quickly figure out implementing classes by doing a grep.
+
+    This is a temporary solution for inspection as Protocol enhancements are not yet fully there in the IDE.
+    """
+
+    @abstractmethod
+    def _implements_protocol(self) -> T:
+        """Helps show IDE inspections / hints for whether the given class properly implements a protocol.
+
+        This method should never be called - it only serves as a place where the IDE can show a red squiggle if the
+        class does not implement the protocol. Hovering over the squiggle will list the fields that are out of spec.
+
+        The return type should be the protocol that is expected to be implemented.
+
+        The body of this method should be "return self".
+        """
+        pass

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -1,5 +1,7 @@
 from typing import Set
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
@@ -8,13 +10,18 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
 
 
-class AddInputMetricMeasuresRule(SemanticManifestTransformRule):
+class AddInputMetricMeasuresRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Add all measures corresponding to the input metrics of the derived metric."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def _get_measures_for_metric(model: PydanticSemanticManifest, metric_name: str) -> Set[PydanticMetricInputMeasure]:

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -1,10 +1,13 @@
 import logging
 from typing import Optional
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.references import TimeDimensionReference
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
@@ -14,8 +17,12 @@ from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 logger = logging.getLogger(__name__)
 
 
-class SetMeasureAggregationTimeDimensionRule(SemanticManifestTransformRule):
+class SetMeasureAggregationTimeDimensionRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Sets the aggregation time dimension for measures to the primary time dimension if not defined."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def _find_primary_time_dimension(semantic_model: PydanticSemanticModel) -> Optional[TimeDimensionReference]:

--- a/dbt_semantic_interfaces/transformations/boolean_measure.py
+++ b/dbt_semantic_interfaces/transformations/boolean_measure.py
@@ -1,8 +1,11 @@
 import logging
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -11,8 +14,12 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 logger = logging.getLogger(__name__)
 
 
-class BooleanMeasureAggregationRule(SemanticManifestTransformRule):
+class BooleanMeasureAggregationRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Converts the expression used in boolean measures so that it can be aggregated."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D

--- a/dbt_semantic_interfaces/transformations/convert_count.py
+++ b/dbt_semantic_interfaces/transformations/convert_count.py
@@ -1,7 +1,10 @@
+from typing_extensions import override
+
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -10,8 +13,12 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 ONE = "1"
 
 
-class ConvertCountToSumRule(SemanticManifestTransformRule):
+class ConvertCountToSumRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Converts any COUNT measures to SUM equivalent."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D

--- a/dbt_semantic_interfaces/transformations/convert_median.py
+++ b/dbt_semantic_interfaces/transformations/convert_median.py
@@ -1,3 +1,5 @@
+from typing_extensions import override
+
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.elements.measure import (
     PydanticMeasureAggregationParameters,
@@ -5,6 +7,7 @@ from dbt_semantic_interfaces.implementations.elements.measure import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -13,8 +16,12 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 MEDIAN_PERCENTILE = 0.5
 
 
-class ConvertMedianToPercentileRule(SemanticManifestTransformRule):
+class ConvertMedianToPercentileRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Converts any MEDIAN measures to percentile equivalent."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D

--- a/dbt_semantic_interfaces/transformations/names.py
+++ b/dbt_semantic_interfaces/transformations/names.py
@@ -1,9 +1,12 @@
 import logging
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -11,8 +14,12 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 logger = logging.getLogger(__name__)
 
 
-class LowerCaseNamesRule(SemanticManifestTransformRule):
+class LowerCaseNamesRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Lowercases the names of both top level objects and semantic model elements in a model."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -1,5 +1,7 @@
 import logging
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
@@ -10,6 +12,7 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -17,11 +20,15 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 logger = logging.getLogger(__name__)
 
 
-class CreateProxyMeasureRule(SemanticManifestTransformRule):
+class CreateProxyMeasureRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """Adds a proxy metric for measures that have the create_metric flag set, if it does not already exist.
 
     Also checks that a defined metric with the same name as a measure is a proxy metric.
     """
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -1,9 +1,12 @@
 import logging
 from typing import Sequence
 
+from typing_extensions import override
+
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
 from dbt_semantic_interfaces.transformations.add_input_metric_measures import (
     AddInputMetricMeasuresRule,
 )
@@ -19,6 +22,9 @@ from dbt_semantic_interfaces.transformations.convert_median import (
 )
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
+from dbt_semantic_interfaces.transformations.rule_set import (
+    SemanticManifestTransformRuleSet,
+)
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
@@ -26,8 +32,14 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 logger = logging.getLogger(__name__)
 
 
-class PydanticSemanticManifestTransformRuleSet:
+class PydanticSemanticManifestTransformRuleSet(
+    ProtocolHint[SemanticManifestTransformRuleSet[PydanticSemanticManifest]]
+):
     """Transform rules that should be used for the Pydantic implementation of SemanticManifest."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRuleSet[PydanticSemanticManifest]:  # noqa: D
+        return self
 
     @property
     def primary_rules(self) -> Sequence[SemanticManifestTransformRule[PydanticSemanticManifest]]:  # noqa:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
   "Jinja2==3.1.2",
   "click>=7.1.2",
   "python-dateutil==2.8.2",
-  "importlib_metadata==6.6.0"
+  "importlib_metadata==6.6.0",
+  "typing-extensions~=4.6.1",
 ]
 
 [build-system]


### PR DESCRIPTION
### Description

This PR adds `ProtocolHint` - a way to hint to the inspections in the IDE that a class is supposed to implement a `Protocol` without explicitly inheriting from a `Protocol`. The explicit inheritance can cause issues with Pydantic classes.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
