### PR TITLE
Add Defaults for SemanticModel

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230529-190835.yaml
+++ b/.changes/unreleased/Breaking Changes-20230529-190835.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Add a defaults section for SemanticModel and remove Dimension.is_primary.
+time: 2023-05-29T19:08:35.894545-07:00
+custom:
+  Author: plypaul
+  Issue: "50"

--- a/dbt_semantic_interfaces/implementations/elements/dimension.py
+++ b/dbt_semantic_interfaces/implementations/elements/dimension.py
@@ -34,7 +34,6 @@ class PydanticDimensionValidityParams(HashableBaseModel):
 class PydanticDimensionTypeParams(HashableBaseModel):
     """PydanticDimension type params add additional context to some types (time) of dimensions."""
 
-    is_primary: bool = False
     time_granularity: TimeGranularity
     validity_params: Optional[PydanticDimensionValidityParams] = None
 
@@ -49,13 +48,6 @@ class PydanticDimension(HashableBaseModel, ModelWithMetadataParsing):
     type_params: Optional[PydanticDimensionTypeParams]
     expr: Optional[str] = None
     metadata: Optional[PydanticMetadata]
-
-    @property
-    def is_primary_time(self) -> bool:  # noqa: D
-        if self.type == DimensionType.TIME and self.type_params is not None:
-            return self.type_params.is_primary
-
-        return False
 
     @property
     def reference(self) -> DimensionReference:  # noqa: D

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, List, Optional, Sequence
 
 from pydantic import validator
+from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
@@ -12,6 +13,11 @@ from dbt_semantic_interfaces.implementations.elements.dimension import PydanticD
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
+from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
+from dbt_semantic_interfaces.protocols.semantic_model import (
+    SemanticModel,
+    SemanticModelDefaults,
+)
 from dbt_semantic_interfaces.references import (
     LinkableElementReference,
     MeasureReference,
@@ -60,10 +66,23 @@ class NodeRelation(HashableBaseModel):
         )
 
 
-class PydanticSemanticModel(HashableBaseModel, ModelWithMetadataParsing):
+class PydanticSemanticModelDefaults(HashableBaseModel, ProtocolHint[SemanticModelDefaults]):  # noqa: D
+    @override
+    def _implements_protocol(self) -> SemanticModelDefaults:  # noqa: D
+        return self
+
+    agg_time_dimension: str
+
+
+class PydanticSemanticModel(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[SemanticModel]):
     """Describes a semantic model."""
 
+    @override
+    def _implements_protocol(self) -> SemanticModel:
+        return self
+
     name: str
+    defaults: Optional[PydanticSemanticModelDefaults]
     description: Optional[str]
     node_relation: NodeRelation
 

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -118,7 +118,6 @@ dimension_type_params_schema = {
     "$id": "dimension_type_params_schema",
     "type": "object",
     "properties": {
-        "is_primary": {"type": "boolean"},
         "time_granularity": {"enum": time_granularity_values},
         "validity_params": {"$ref": "validity_params_schema"},
     },

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -235,6 +235,18 @@ node_relation_schema = {
     "required": ["alias", "schema_name"],
 }
 
+
+semantic_model_defaults_schema = {
+    "$id": "semantic_model_defaults_schema",
+    "type": "object",
+    "properties": {
+        "agg_time_dimension": {"type": "string"},
+    },
+    "additionalProperties": False,
+    "required": [],
+}
+
+
 semantic_model_schema = {
     "$id": "semantic_model",
     "type": "object",
@@ -244,6 +256,7 @@ semantic_model_schema = {
             "pattern": TRANSFORM_OBJECT_NAME_PATTERN,
         },
         "node_relation": {"$ref": "node_relation_schema"},
+        "defaults": {"$ref": "semantic_model_defaults_schema"},
         "entities": {"type": "array", "items": {"$ref": "entity_schema"}},
         "measures": {"type": "array", "items": {"$ref": "measure_schema"}},
         "dimensions": {"type": "array", "items": {"$ref": "dimension_schema"}},
@@ -288,6 +301,7 @@ schema_store = {
     non_additive_dimension_schema["$id"]: non_additive_dimension_schema,
     metric_input_schema["$id"]: metric_input_schema,
     node_relation_schema["$id"]: node_relation_schema,
+    semantic_model_defaults_schema["$id"]: semantic_model_defaults_schema,
 }
 
 

--- a/dbt_semantic_interfaces/parsing/schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/schemas/default_explicit_schema.json
@@ -98,9 +98,6 @@
             "$id": "dimension_type_params_schema",
             "additionalProperties": false,
             "properties": {
-                "is_primary": {
-                    "type": "boolean"
-                },
                 "time_granularity": {
                     "enum": [
                         "DAY",
@@ -417,6 +414,9 @@
             "$id": "semantic_model",
             "additionalProperties": false,
             "properties": {
+                "defaults": {
+                    "$ref": "#/definitions/semantic_model_defaults_schema"
+                },
                 "description": {
                     "type": "string"
                 },
@@ -449,6 +449,17 @@
             "required": [
                 "name"
             ],
+            "type": "object"
+        },
+        "semantic_model_defaults_schema": {
+            "$id": "semantic_model_defaults_schema",
+            "additionalProperties": false,
+            "properties": {
+                "agg_time_dimension": {
+                    "type": "string"
+                }
+            },
+            "required": [],
             "type": "object"
         },
         "validity_params_schema": {

--- a/dbt_semantic_interfaces/protocols/dimension.py
+++ b/dbt_semantic_interfaces/protocols/dimension.py
@@ -38,11 +38,6 @@ class DimensionTypeParams(Protocol):
 
     @property
     @abstractmethod
-    def is_primary(self) -> bool:  # noqa: D
-        pass
-
-    @property
-    @abstractmethod
     def time_granularity(self) -> TimeGranularity:  # noqa: D
         pass
 
@@ -89,12 +84,6 @@ class Dimension(Protocol):
     @abstractmethod
     def metadata(self) -> Optional[Metadata]:  # noqa: D
         pass
-
-    @property
-    @abstractmethod
-    def is_primary_time(self) -> bool:
-        """Returns boolean of whether the dimension is a the primary time dimension."""
-        ...
 
     @property
     @abstractmethod

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -38,12 +38,28 @@ class NodeRelation(Protocol):
         pass
 
 
+class SemanticModelDefaults(Protocol):
+    """Path object to where the data should be."""
+
+    @property
+    @abstractmethod
+    def agg_time_dimension(self) -> Optional[str]:
+        """The aggregation time dimension to use for a measure if one was not specified."""
+        pass
+
+
 class SemanticModel(Protocol):
     """Describes a semantic model."""
 
     @property
     @abstractmethod
     def name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def defaults(self) -> Optional[SemanticModelDefaults]:
+        """The defaults to use for fields when parsing this model."""
         pass
 
     @property

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -94,6 +94,7 @@ def base_semantic_manifest_file() -> YamlConfigFile:
           measures:
             - name: num_sample_rows
               agg: sum
+              agg_time_dimension: ds
               expr: 1
               create_metric: true
           dimensions:
@@ -101,7 +102,6 @@ def base_semantic_manifest_file() -> YamlConfigFile:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     return YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class SetMeasureAggregationTimeDimensionRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
-    """Sets the aggregation time dimension for measures to the primary time dimension if not defined."""
+    """Sets the aggregation time dimension for measures to the one specified as default."""
 
     @override
     def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
@@ -34,16 +34,14 @@ class SetMeasureAggregationTimeDimensionRule(ProtocolHint[SemanticManifestTransf
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for semantic_model in model.semantic_models:
-            primary_time_dimension_reference = SetMeasureAggregationTimeDimensionRule._find_primary_time_dimension(
-                semantic_model
-            )
+            if semantic_model.defaults is None:
+                continue
 
-            if not primary_time_dimension_reference:
-                # PydanticDimension semantic models won't have a primary time dimension.
+            if semantic_model.defaults.agg_time_dimension is None:
                 continue
 
             for measure in semantic_model.measures:
                 if not measure.agg_time_dimension:
-                    measure.agg_time_dimension = primary_time_dimension_reference.element_name
+                    measure.agg_time_dimension = semantic_model.defaults.agg_time_dimension
 
         return model

--- a/dbt_semantic_interfaces/transformations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/transformations/agg_time_dimension.py
@@ -1,18 +1,14 @@
 import logging
-from typing import Optional
 
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
-from dbt_semantic_interfaces.references import TimeDimensionReference
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
-from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 
 logger = logging.getLogger(__name__)
 
@@ -23,13 +19,6 @@ class SetMeasureAggregationTimeDimensionRule(ProtocolHint[SemanticManifestTransf
     @override
     def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
         return self
-
-    @staticmethod
-    def _find_primary_time_dimension(semantic_model: PydanticSemanticModel) -> Optional[TimeDimensionReference]:
-        for dimension in semantic_model.dimensions:
-            if dimension.type == DimensionType.TIME and dimension.type_params and dimension.type_params.is_primary:
-                return dimension.time_dimension_reference
-        return None
 
     @staticmethod
     def transform_model(model: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D

--- a/dbt_semantic_interfaces/validations/dimension_const.py
+++ b/dbt_semantic_interfaces/validations/dimension_const.py
@@ -79,10 +79,8 @@ class DimensionConsistencyRule(SemanticManifestValidationRule[SemanticManifestT]
             if dimension.reference not in time_dims_to_granularity and dimension.type_params:
                 time_dims_to_granularity[dimension.reference] = dimension.type_params.time_granularity
 
-                # The primary time dimension can be of different time granularities, so don't check for it.
                 if (
                     dimension.type_params is not None
-                    and not dimension.type_params.is_primary
                     and dimension.type_params.time_granularity != time_dims_to_granularity[dimension.reference]
                 ):
                     expected_granularity = time_dims_to_granularity[dimension.reference]

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/accounts_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/accounts_source.yaml
@@ -7,6 +7,9 @@ semantic_model:
     schema_name: $source_schema
     alias: fct_accounts
 
+  defaults:
+    agg_time_dimension: ds
+
   measures:
     - name: account_balance
       agg: sum
@@ -31,7 +34,6 @@ semantic_model:
     - name: ds
       type: time
       type_params:
-        is_primary: True
         time_granularity: day
     - name: account_type
       type: categorical

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_source.yaml
@@ -7,6 +7,9 @@ semantic_model:
     schema_name: $source_schema
     alias: fct_bookings
 
+  defaults:
+    agg_time_dimension: ds
+
   measures:
     - name: bookings
       expr: "1"
@@ -70,7 +73,6 @@ semantic_model:
     - name: ds
       type: time
       type_params:
-        is_primary: True
         time_granularity: day
     - name: ds_partitioned
       type: time

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/id_verifications.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/id_verifications.yaml
@@ -7,6 +7,9 @@ semantic_model:
     schema_name: $source_schema
     alias: fct_id_verifications
 
+  defaults:
+    agg_time_dimension: ds
+
   measures:
     - name: identity_verifications
       expr: "1"
@@ -16,7 +19,6 @@ semantic_model:
     - name: ds
       type: time
       type_params:
-        is_primary: True
         time_granularity: day
     - name: ds_partitioned
       type: time

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/listings_latest.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/listings_latest.yaml
@@ -7,6 +7,9 @@ semantic_model:
     schema_name: $source_schema
     alias: dim_listings_latest
 
+  defaults:
+    agg_time_dimension: ds
+
   measures:
     - name: listings
       expr: 1
@@ -23,7 +26,6 @@ semantic_model:
       type: time
       expr: created_at
       type_params:
-        is_primary: True
         time_granularity: day
     - name: created_at
       type: time

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/revenue.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/revenue.yaml
@@ -7,6 +7,9 @@ semantic_model:
     schema_name: $source_schema
     alias: fct_revenue
 
+  defaults:
+    agg_time_dimension: ds
+
   measures:
     - name: txn_revenue
       expr: revenue
@@ -17,7 +20,6 @@ semantic_model:
       type: time
       expr: created_at
       type_params:
-        is_primary: True
         time_granularity: day
 
   entities:

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/user_sm_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/user_sm_source.yaml
@@ -7,11 +7,13 @@ semantic_model:
     schema_name: $source_schema
     alias: dim_users
 
+  defaults:
+    agg_time_dimension: ds
+
   dimensions:
     - name: ds
       type: time
       type_params:
-        is_primary: True
         time_granularity: day
     - name: created_at
       type: time

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/users_latest.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/users_latest.yaml
@@ -11,7 +11,6 @@ semantic_model:
     - name: ds
       type: time
       type_params:
-        is_primary: True
         time_granularity: day
     - name: home_state_latest
       type: categorical

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/views_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/views_source.yaml
@@ -7,6 +7,9 @@ semantic_model:
     schema_name: $source_schema
     alias: fct_views
 
+  defaults:
+    agg_time_dimension: ds
+
   measures:
     - name: views
       expr: "1"
@@ -16,7 +19,6 @@ semantic_model:
     - name: ds
       type: time
       type_params:
-        is_primary: True
         time_granularity: day
     - name: ds_partitioned
       type: time

--- a/tests/parsing/test_semantic_model_parsing.py
+++ b/tests/parsing/test_semantic_model_parsing.py
@@ -296,7 +296,6 @@ def test_semantic_model_time_dimension_parsing() -> None:
     dimension = semantic_model.dimensions[0]
     assert dimension.type is DimensionType.TIME
     assert dimension.type_params is not None
-    assert dimension.type_params.is_primary is not True
     assert dimension.type_params.time_granularity is TimeGranularity.MONTH
 
 
@@ -314,7 +313,6 @@ def test_semantic_model_primary_time_dimension_parsing() -> None:
               type: time
               type_params:
                 time_granularity: month
-                is_primary: true
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -327,7 +325,6 @@ def test_semantic_model_primary_time_dimension_parsing() -> None:
     dimension = semantic_model.dimensions[0]
     assert dimension.type is DimensionType.TIME
     assert dimension.type_params is not None
-    assert dimension.type_params.is_primary is True
 
 
 def test_semantic_model_dimension_metadata_parsing() -> None:

--- a/tests/validations/test_agg_time_dimension.py
+++ b/tests/validations/test_agg_time_dimension.py
@@ -65,7 +65,6 @@ def test_missing_primary_time_ok_if_all_measures_have_agg_time_dim(  # noqa:D
     for dimension in semantic_model_with_measures.dimensions:
         if dimension.type == DimensionType.TIME:
             assert dimension.type_params, f"Time dimension `{dimension.name}` is missing `type_params`"
-            dimension.type_params.is_primary = False
 
     model_validator = SemanticManifestValidator[PydanticSemanticManifest]([AggregationTimeDimensionRule()])
     model_validator.checked_validations(model)

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -7,23 +7,13 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metric import (
     MetricType,
-    PydanticMetric,
     PydanticMetricInputMeasure,
     PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import (
-    NodeRelation,
-    PydanticSemanticModel,
-)
 from dbt_semantic_interfaces.model_validator import SemanticManifestValidator
-from dbt_semantic_interfaces.references import (
-    DimensionReference,
-    MeasureReference,
-    TimeDimensionReference,
-)
 from dbt_semantic_interfaces.test_utils import (
     metric_with_guaranteed_meta,
     semantic_model_with_guaranteed_meta,
@@ -32,9 +22,6 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import AggregationType
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 from dbt_semantic_interfaces.validations.dimension_const import DimensionConsistencyRule
-from dbt_semantic_interfaces.validations.semantic_models import (
-    SemanticModelTimeDimensionWarningsRule,
-)
 from dbt_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationException,
 )
@@ -120,63 +107,6 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                         name=measure_name,
                         type=MetricType.SIMPLE,
                         type_params=PydanticMetricTypeParams(measures=[PydanticMetricInputMeasure(name=measure_name)]),
-                    )
-                ],
-            )
-        )
-
-
-def test_multiple_primary_time_dimensions() -> None:  # noqa:D
-    with pytest.raises(SemanticManifestValidationException, match=r"one of many defined as primary"):
-        dimension_reference = TimeDimensionReference(element_name="ds")
-        dimension_reference2 = DimensionReference(element_name="not_ds")
-        measure_reference = MeasureReference(element_name="measure")
-        model_validator = SemanticManifestValidator[PydanticSemanticManifest](
-            [SemanticModelTimeDimensionWarningsRule()]
-        )
-        model_validator.checked_validations(
-            model=PydanticSemanticManifest(
-                semantic_models=[
-                    PydanticSemanticModel(
-                        name="dim1",
-                        node_relation=NodeRelation(
-                            alias="table",
-                            schema_name="schema",
-                        ),
-                        measures=[
-                            PydanticMeasure(
-                                name=measure_reference.element_name,
-                                agg=AggregationType.SUM,
-                                agg_time_dimension=dimension_reference.element_name,
-                            )
-                        ],
-                        dimensions=[
-                            PydanticDimension(
-                                name=dimension_reference.element_name,
-                                type=DimensionType.TIME,
-                                type_params=PydanticDimensionTypeParams(
-                                    is_primary=True,
-                                    time_granularity=TimeGranularity.DAY,
-                                ),
-                            ),
-                            PydanticDimension(
-                                name=dimension_reference2.element_name,
-                                type=DimensionType.TIME,
-                                type_params=PydanticDimensionTypeParams(
-                                    is_primary=True,
-                                    time_granularity=TimeGranularity.DAY,
-                                ),
-                            ),
-                        ],
-                    ),
-                ],
-                metrics=[
-                    PydanticMetric(
-                        name=measure_reference.element_name,
-                        type=MetricType.SIMPLE,
-                        type_params=PydanticMetricTypeParams(
-                            measures=[PydanticMetricInputMeasure(name=measure_reference.element_name)]
-                        ),
                     )
                 ],
             )

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -43,7 +43,6 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                                 name=dim_name,
                                 type=DimensionType.TIME,
                                 type_params=PydanticDimensionTypeParams(
-                                    is_primary=True,
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )
@@ -82,7 +81,6 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                                 type=DimensionType.TIME,
                                 is_partition=True,
                                 type_params=PydanticDimensionTypeParams(
-                                    is_primary=True,
                                     time_granularity=TimeGranularity.DAY,
                                 ),
                             )

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -81,7 +81,6 @@ def test_measures_only_exist_in_one_semantic_model() -> None:  # noqa: D
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     base_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents_1)
@@ -119,7 +118,6 @@ def test_measures_only_exist_in_one_semantic_model() -> None:  # noqa: D
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     dup_measure_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents_2)
@@ -163,7 +161,6 @@ def test_measure_alias_is_set_when_required() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         ---
         metric:
           name: "metric1"
@@ -216,7 +213,6 @@ def test_invalid_measure_alias_name() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         ---
         metric:
           name: "metric1"
@@ -269,7 +265,6 @@ def test_measure_alias_measure_name_conflict() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         ---
         metric:
           name: "metric1"
@@ -326,7 +321,6 @@ def test_reused_measure_alias() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         ---
         metric:
           name: "metric1"
@@ -393,7 +387,6 @@ def test_reused_measure_alias_within_metric() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         ---
         metric:
           name: "metric1"
@@ -463,7 +456,6 @@ def test_invalid_non_additive_dimension_properties() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
             - name: weekly_time
               type: time
               type_params:
@@ -530,7 +522,6 @@ def test_count_measure_missing_expr() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     missing_expr_file = YamlConfigFile(filepath="inline_for_test_2", contents=yaml_contents)
@@ -583,7 +574,6 @@ def test_count_measure_with_distinct_expr() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     distinct_count_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -639,7 +629,6 @@ def test_percentile_measure_missing_agg_params() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     missing_agg_params_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -700,7 +689,6 @@ def test_percentile_measure_bad_percentile_values() -> None:
               type: time
               type_params:
                 time_granularity: day
-                is_primary: true
         """
     )
     bad_percentile_values_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -64,7 +64,6 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                             name=dim2_name,
                             type=DimensionType.TIME,
                             type_params=PydanticDimensionTypeParams(
-                                is_primary=True,
                                 time_granularity=TimeGranularity.DAY,
                             ),
                         ),
@@ -170,7 +169,6 @@ def test_generated_metrics_only() -> None:  # noqa:D
                 name=dim2_reference.element_name,
                 type=DimensionType.TIME,
                 type_params=PydanticDimensionTypeParams(
-                    is_primary=True,
                     time_granularity=TimeGranularity.DAY,
                 ),
             ),
@@ -209,7 +207,6 @@ def test_derived_metric() -> None:  # noqa: D
                             name="ds",
                             type=DimensionType.TIME,
                             type_params=PydanticDimensionTypeParams(
-                                is_primary=True,
                                 time_granularity=TimeGranularity.DAY,
                             ),
                         ),

--- a/tests/validations/test_validity_param_definitions.py
+++ b/tests/validations/test_validity_param_definitions.py
@@ -313,7 +313,6 @@ def test_measures_are_prevented() -> None:
                 time_granularity: day
                 validity_params:
                   is_start: true
-                is_primary: true
             - name: window_end
               type: time
               type_params:
@@ -323,6 +322,7 @@ def test_measures_are_prevented() -> None:
           measures:
             - name: num_countries
               agg: count_distinct
+              agg_time_dimension: window_start
               expr: country
         """
     )


### PR DESCRIPTION
resolves # 50


### Description

This PR adds a `defaults` section in the `SemanticModel` definition that can be used to specify default values for objects listed in the model. e.g.

```
semantic_model:
  name: accounts_source
  description: accounts_source

  defaults:
    agg_time_dimension: ds

```

In addition, this removes `Dimension.is_primary` since it's no longer needed with the introduction of `metric_time` and `defaults.agg_time_dimensions`.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
