### PR TITLE
Add Validation for Semantic Model Defaults 

### DIFF
--- a/.changes/unreleased/Features-20230606-130140.yaml
+++ b/.changes/unreleased/Features-20230606-130140.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added new validation rule for validating SemanticModel.defaults
+time: 2023-06-06T13:01:40.461195-04:00
+custom:
+  Author: WilliamDee
+  Issue: metricflow#565

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -71,7 +71,7 @@ class PydanticSemanticModelDefaults(HashableBaseModel, ProtocolHint[SemanticMode
     def _implements_protocol(self) -> SemanticModelDefaults:  # noqa: D
         return self
 
-    agg_time_dimension: str
+    agg_time_dimension: Optional[str]
 
 
 class PydanticSemanticModel(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[SemanticModel]):

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -2,16 +2,13 @@ from typing import Generic, List, Sequence
 
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
 from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
-from dbt_semantic_interfaces.references import (
-    SemanticModelElementReference,
-    TimeDimensionReference,
-)
-from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType
+from dbt_semantic_interfaces.references import SemanticModelElementReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     SemanticManifestValidationRule,
     SemanticModelElementContext,
     SemanticModelElementType,
+    SemanticModelValidationHelpers,
     ValidationError,
     ValidationIssue,
     validate_safely,
@@ -31,15 +28,6 @@ class AggregationTimeDimensionRule(SemanticManifestValidationRule[SemanticManife
         return issues
 
     @staticmethod
-    def _time_dimension_in_model(
-        time_dimension_reference: TimeDimensionReference, semantic_model: SemanticModel
-    ) -> bool:
-        for dimension in semantic_model.dimensions:
-            if dimension.type == DimensionType.TIME and dimension.name == time_dimension_reference.element_name:
-                return True
-        return False
-
-    @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for a semantic model")
     def _validate_semantic_model(semantic_model: SemanticModel) -> List[ValidationIssue]:
         issues: List[ValidationIssue] = []
@@ -53,8 +41,8 @@ class AggregationTimeDimensionRule(SemanticManifestValidationRule[SemanticManife
                 element_type=SemanticModelElementType.MEASURE,
             )
             agg_time_dimension_reference = measure.checked_agg_time_dimension
-            if not AggregationTimeDimensionRule._time_dimension_in_model(
-                time_dimension_reference=agg_time_dimension_reference, semantic_model=semantic_model
+            if not SemanticModelValidationHelpers.time_dimension_in_model(
+                time_dimension_name=agg_time_dimension_reference.element_name, semantic_model=semantic_model
             ):
                 issues.append(
                     ValidationError(

--- a/dbt_semantic_interfaces/validations/semantic_manifest_validator.py
+++ b/dbt_semantic_interfaces/validations/semantic_manifest_validator.py
@@ -31,6 +31,7 @@ from dbt_semantic_interfaces.validations.metrics import (
 from dbt_semantic_interfaces.validations.non_empty import NonEmptyRule
 from dbt_semantic_interfaces.validations.reserved_keywords import ReservedKeywordsRule
 from dbt_semantic_interfaces.validations.semantic_models import (
+    SemanticModelDefaultsRule,
     SemanticModelTimeDimensionWarningsRule,
     SemanticModelValidityWindowRule,
 )
@@ -78,6 +79,7 @@ class SemanticManifestValidator(Generic[SemanticManifestT]):
         AggregationTimeDimensionRule[SemanticManifestT](),
         ReservedKeywordsRule[SemanticManifestT](),
         MeasuresNonAdditiveDimensionRule[SemanticManifestT](),
+        SemanticModelDefaultsRule[SemanticManifestT](),
     )
 
     def __init__(

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, Extra
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
 from dbt_semantic_interfaces.protocols.metadata import Metadata
 from dbt_semantic_interfaces.protocols.semantic_manifest import SemanticManifestT
+from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     MetricModelReference,
     SemanticModelElementReference,
@@ -403,3 +404,14 @@ class SemanticManifestValidationException(Exception):
     def __init__(self, issues: Tuple[ValidationIssue, ...]) -> None:  # noqa: D
         issues_str = "\n".join([x.as_readable_str(verbose=True) for x in issues])
         super().__init__(f"Error validating model. Issues:\n{issues_str}")
+
+
+class SemanticModelValidationHelpers:
+    """Class containing all the helpers related to semantic model validations."""
+
+    @classmethod
+    def time_dimension_in_model(cls, time_dimension_name: str, semantic_model: SemanticModel) -> bool:  # noqa: D
+        for dimension in semantic_model.dimensions:
+            if dimension.type == DimensionType.TIME and dimension.name == time_dimension_name:
+                return True
+        return False


### PR DESCRIPTION
Resolves https://github.com/dbt-labs/metricflow/issues/565

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Adds validation for checking the validity for `SemanticModel.defaults`. Currently, there's only `agg_time_dimension` which means it would validate whether the specified time dimension exists in the model.
 
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
