### PR TITLE
Flatten Metric YAML Schema and Use Typed Parameters for Different Metric Types

### DIFF
--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -202,9 +202,9 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
 
     @property
     @override
-    def simple_metric_parameters(self) -> Optional[PydanticSimpleMetricParameters]:
+    def simple_metric_parameters(self) -> PydanticSimpleMetricParameters:
         if self.type is not MetricType.SIMPLE:
-            return None
+            raise RuntimeError(f"The type of this metric is {self.type}, not {MetricType.SIMPLE}")
         if self._simple_metric_parameters is None:
             assert self.type_params.measure is not None
             self._simple_metric_parameters = PydanticSimpleMetricParameters(measure=self.type_params.measure)
@@ -212,8 +212,9 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
 
     @property
     @override
-    def ratio_metric_parameters(self) -> Optional[PydanticRatioMetricParameters]:
-        assert self.type is MetricType.RATIO
+    def ratio_metric_parameters(self) -> PydanticRatioMetricParameters:
+        if self.type is not MetricType.RATIO:
+            raise RuntimeError(f"The type of this metric is {self.type}, not {MetricType.RATIO}")
         if self._ratio_metric_parameters is None:
             assert self.type_params.numerator is not None
             assert self.type_params.denominator is not None
@@ -225,10 +226,10 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
 
     @property
     @override
-    def cumulative_metric_parameters(self) -> Optional[PydanticCumulativeMetricParameters]:
+    def cumulative_metric_parameters(self) -> PydanticCumulativeMetricParameters:
         """If this describes a cumulative metric, then return the associated parameters (exception otherwise)."""
         if self.type is not MetricType.CUMULATIVE:
-            return None
+            raise RuntimeError(f"The type of this metric is {self.type}, not {MetricType.CUMULATIVE}")
         if self._cumulative_metric_parameters is None:
             assert self.type_params.measure is not None
             self._cumulative_metric_parameters = PydanticCumulativeMetricParameters(
@@ -241,10 +242,10 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
 
     @property
     @override
-    def derived_metric_parameters(self) -> Optional[PydanticDerivedMetricParameters]:
+    def derived_metric_parameters(self) -> PydanticDerivedMetricParameters:
         """If this describes a derived metric, then return the associated parameters (exception otherwise)."""
         if self.type is not MetricType.DERIVED:
-            return None
+            raise RuntimeError(f"The type of this metric is {self.type}, not {MetricType.DERIVED}")
         if self._derived_metric_parameters is None:
             assert self.type_params.expr is not None
             assert self.type_params.metrics is not None

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -188,7 +188,6 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
     name: str
     description: Optional[str]
     type: MetricType
-    type_params: PydanticMetricTypeParams
     filter: Optional[PydanticWhereFilter]
     metadata: Optional[PydanticMetadata]
 

--- a/dbt_semantic_interfaces/parsing/dir_to_model.py
+++ b/dbt_semantic_interfaces/parsing/dir_to_model.py
@@ -176,8 +176,10 @@ def parse_yaml_files_to_validation_ready_semantic_manifest(
     try:
         if apply_transformations:
             model = PydanticSemanticManifestTransformer.transform(model)
-    except Exception as e:
-        transformation_issue_results = SemanticManifestValidationResults(errors=(ValidationError(message=str(e)),))
+    except Exception:
+        transformation_issue_results = SemanticManifestValidationResults(
+            errors=(ValidationError(message=traceback.format_exc()),)
+        )
         build_issues = SemanticManifestValidationResults.merge([build_issues, transformation_issue_results])
 
     if raise_issues_as_exceptions and build_issues.has_blocking_issues:

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -216,7 +216,6 @@
                     "type": "string"
                 },
                 {
-                    "additionalProperties": false,
                     "properties": {
                         "alias": {
                             "type": "string"
@@ -234,7 +233,6 @@
         },
         "metric_input_schema": {
             "$id": "metric_input_schema",
-            "additionalProperties": false,
             "properties": {
                 "alias": {
                     "type": "string"
@@ -256,8 +254,98 @@
         },
         "metric_schema": {
             "$id": "metric_schema",
-            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "properties": {
+                        "measure": {
+                            "$ref": "#/definitions/metric_input_measure_schema"
+                        },
+                        "type": {
+                            "enum": [
+                                "SIMPLE",
+                                "simple"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "measure"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "denominator": {
+                            "$ref": "#/definitions/metric_input_measure_schema"
+                        },
+                        "numerator": {
+                            "$ref": "#/definitions/metric_input_measure_schema"
+                        },
+                        "type": {
+                            "enum": [
+                                "RATIO",
+                                "ratio"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "numerator",
+                        "denominator"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "grain_to_date": {
+                            "type": "string"
+                        },
+                        "measure": {
+                            "$ref": "#/definitions/metric_input_measure_schema"
+                        },
+                        "type": {
+                            "enum": [
+                                "CUMULATIVE",
+                                "cumulative"
+                            ]
+                        },
+                        "window": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "measure"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "expr": {
+                            "type": [
+                                "string",
+                                "boolean"
+                            ]
+                        },
+                        "metrics": {
+                            "items": {
+                                "$ref": "#/definitions/metric_input_schema"
+                            },
+                            "type": "array"
+                        },
+                        "type": {
+                            "enum": [
+                                "DERIVED",
+                                "derived"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "expr",
+                        "metrics"
+                    ],
+                    "type": "object"
+                }
+            ],
             "properties": {
+                "__parsing_context__": {},
                 "description": {
                     "type": "string"
                 },
@@ -271,25 +359,22 @@
                 "type": {
                     "enum": [
                         "SIMPLE",
-                        "RATIO",
-                        "CUMULATIVE",
-                        "DERIVED",
                         "simple",
+                        "RATIO",
                         "ratio",
+                        "CUMULATIVE",
                         "cumulative",
+                        "DERIVED",
                         "derived"
                     ]
-                },
-                "type_params": {
-                    "$ref": "#/definitions/metric_type_params"
                 }
             },
             "required": [
                 "name",
-                "type",
-                "type_params"
+                "type"
             ],
-            "type": "object"
+            "type": "object",
+            "unevaluatedProperties": false
         },
         "metric_type_params": {
             "$id": "metric_type_params",

--- a/dbt_semantic_interfaces/parsing/schema_validator.py
+++ b/dbt_semantic_interfaces/parsing/schema_validator.py
@@ -1,6 +1,6 @@
 import re
 
-from jsonschema import Draft7Validator, ValidationError
+from jsonschema import Draft202012Validator, ValidationError
 from jsonschema._utils import extras_msg
 from jsonschema.validators import extend
 
@@ -66,4 +66,6 @@ def customAdditionalProperties(validator, aP, instance, schema):  # type: ignore
 
 # Extend takes a given validator, and overrides/adds the specified validators for the validator
 # Thus here we are overriding Draft7Validator's `additionalProperties` validator
-SchemaValidator = extend(validator=Draft7Validator, validators={"additionalProperties": customAdditionalProperties})
+SchemaValidator = extend(
+    validator=Draft202012Validator, validators={"additionalProperties": customAdditionalProperties}
+)

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -220,11 +220,6 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def type_params(self) -> MetricTypeParams:  # noqa: D
-        pass
-
-    @property
-    @abstractmethod
     def simple_metric_parameters(self) -> SimpleMetricParameters:
         """If this describes a simple metric, return the relevant parameters (exception otherwise)."""
         pass

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -225,26 +225,26 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def simple_metric_parameters(self) -> Optional[SimpleMetricParameters]:
-        """If this describes a simple metric, return the relevant parameters (None otherwise)."""
+    def simple_metric_parameters(self) -> SimpleMetricParameters:
+        """If this describes a simple metric, return the relevant parameters (exception otherwise)."""
         pass
 
     @property
     @abstractmethod
-    def ratio_metric_parameters(self) -> Optional[RatioMetricParameters]:
-        """If this describes a ratio metric, then return the associated parameters (None otherwise)."""
+    def ratio_metric_parameters(self) -> RatioMetricParameters:
+        """If this describes a ratio metric, then return the associated parameters (exception otherwise)."""
         pass
 
     @property
     @abstractmethod
-    def cumulative_metric_parameters(self) -> Optional[CumulativeMetricParameters]:
-        """If this describes a cumulative metric, then return the associated parameters (None otherwise)."""
+    def cumulative_metric_parameters(self) -> CumulativeMetricParameters:
+        """If this describes a cumulative metric, then return the associated parameters (exception otherwise)."""
         pass
 
     @property
     @abstractmethod
-    def derived_metric_parameters(self) -> Optional[DerivedMetricParameters]:
-        """If this describes a derived metric, then return the associated parameters (None otherwise)."""
+    def derived_metric_parameters(self) -> DerivedMetricParameters:
+        """If this describes a derived metric, then return the associated parameters (exception otherwise)."""
         pass
 
     @property

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -144,6 +144,62 @@ class MetricTypeParams(Protocol):
         pass
 
 
+class SimpleMetricParameters(Protocol):
+    """Parameters used to define a simple metric."""
+
+    @property
+    @abstractmethod
+    def measure(self) -> MetricInputMeasure:  # noqa: D
+        pass
+
+
+class RatioMetricParameters(Protocol):
+    """Parameters used to define a ratio metric."""
+
+    @property
+    @abstractmethod
+    def numerator(self) -> MetricInput:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def denominator(self) -> MetricInput:  # noqa: D
+        pass
+
+
+class CumulativeMetricParameters(Protocol):
+    """Parameters used to define a cumulative metric."""
+
+    @property
+    @abstractmethod
+    def measure(self) -> MetricInputMeasure:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def grain_to_date(self) -> Optional[TimeGranularity]:  # noqa: D
+        pass
+
+
+class DerivedMetricParameters(Protocol):
+    """Parameters used to define a derived metric."""
+
+    @property
+    @abstractmethod
+    def expr(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def metrics(self) -> Sequence[MetricInput]:  # noqa: D
+        pass
+
+
 class Metric(Protocol):
     """Describes a metric."""
 
@@ -165,6 +221,30 @@ class Metric(Protocol):
     @property
     @abstractmethod
     def type_params(self) -> MetricTypeParams:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def simple_metric_parameters(self) -> Optional[SimpleMetricParameters]:
+        """If this describes a simple metric, return the relevant parameters (None otherwise)."""
+        pass
+
+    @property
+    @abstractmethod
+    def ratio_metric_parameters(self) -> Optional[RatioMetricParameters]:
+        """If this describes a ratio metric, then return the associated parameters (None otherwise)."""
+        pass
+
+    @property
+    @abstractmethod
+    def cumulative_metric_parameters(self) -> Optional[CumulativeMetricParameters]:
+        """If this describes a cumulative metric, then return the associated parameters (None otherwise)."""
+        pass
+
+    @property
+    @abstractmethod
+    def derived_metric_parameters(self) -> Optional[DerivedMetricParameters]:
+        """If this describes a derived metric, then return the associated parameters (None otherwise)."""
         pass
 
     @property

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -17,7 +17,9 @@ from dbt_semantic_interfaces.implementations.metadata import (
 )
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
-    PydanticMetricTypeParams,
+    PydanticMetricInput,
+    PydanticMetricInputMeasure,
+    PydanticMetricTimeWindow,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -27,7 +29,7 @@ from dbt_semantic_interfaces.implementations.semantic_model import (
     PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
-from dbt_semantic_interfaces.type_enums import MetricType
+from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -123,7 +125,13 @@ def default_meta() -> PydanticMetadata:
 def metric_with_guaranteed_meta(
     name: str,
     type: MetricType,
-    type_params: PydanticMetricTypeParams,
+    measure: Optional[PydanticMetricInputMeasure] = None,
+    numerator: Optional[PydanticMetricInput] = None,
+    denominator: Optional[PydanticMetricInput] = None,
+    window: Optional[PydanticMetricTimeWindow] = None,
+    grain_to_date: Optional[TimeGranularity] = None,
+    expr: Optional[str] = None,
+    metrics: Optional[Sequence[PydanticMetricInput]] = None,
     where_filter: Optional[PydanticWhereFilter] = None,
     metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
@@ -136,7 +144,13 @@ def metric_with_guaranteed_meta(
         name=name,
         description=description,
         type=type,
-        type_params=type_params,
+        measure=measure,
+        numerator=numerator,
+        denominator=denominator,
+        window=window,
+        grain_to_date=grain_to_date,
+        expr=expr,
+        metrics=list(metrics) if metrics is not None else [],
         filter=where_filter,
         metadata=metadata,
     )

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -55,7 +55,7 @@ class AddInputMetricMeasuresRule(ProtocolHint[SemanticManifestTransformRule[Pyda
     def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for metric in semantic_manifest.metrics:
             measures = AddInputMetricMeasuresRule._get_measures_for_metric(semantic_manifest, metric.name)
-            assert len(metric.type_params.input_measures) == 0, f"{metric} should not have measures predefined"
-            metric.type_params.input_measures = list(measures)
+            assert len(metric.input_measures) == 0, f"{metric} should not have measures predefined"
+            metric.input_measures = list(measures)
 
         return semantic_manifest

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -32,11 +32,14 @@ class AddInputMetricMeasuresRule(ProtocolHint[SemanticManifestTransformRule[Pyda
             iter((metric for metric in semantic_manifest.metrics if metric.name == metric_name)), None
         )
         if matched_metric:
-            if matched_metric.type is MetricType.SIMPLE or matched_metric.type is MetricType.CUMULATIVE:
-                assert (
-                    matched_metric.type_params.measure is not None
-                ), f"{matched_metric} should have a measure defined, but it does not."
-                measures.add(matched_metric.type_params.measure)
+            if matched_metric.type is MetricType.SIMPLE:
+                simple_metric_parameters = matched_metric.simple_metric_parameters
+                assert simple_metric_parameters is not None
+                measures.add(simple_metric_parameters.measure)
+            elif matched_metric.type is MetricType.CUMULATIVE:
+                cumulative_metric_parameters = matched_metric.cumulative_metric_parameters
+                assert cumulative_metric_parameters is not None
+                measures.add(cumulative_metric_parameters.measure)
             elif matched_metric.type is MetricType.DERIVED or matched_metric.type is MetricType.RATIO:
                 for input_metric in matched_metric.input_metrics:
                     measures.update(

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -6,7 +6,6 @@ from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
     PydanticMetricInputMeasure,
-    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -57,10 +56,7 @@ class CreateProxyMeasureRule(ProtocolHint[SemanticManifestTransformRule[Pydantic
                         PydanticMetric(
                             name=measure.name,
                             type=MetricType.SIMPLE,
-                            type_params=PydanticMetricTypeParams(
-                                measure=PydanticMetricInputMeasure(name=measure.name),
-                                expr=measure.name,
-                            ),
+                            measure=PydanticMetricInputMeasure(name=measure.name),
                         )
                     )
 

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -30,7 +30,9 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
         issues: List[ValidationIssue] = []
 
         if metric.type == MetricType.CUMULATIVE:
-            if metric.type_params.window and metric.type_params.grain_to_date:
+            cumulative_metric_parameters = metric.cumulative_metric_parameters
+            assert cumulative_metric_parameters is not None
+            if cumulative_metric_parameters.window and cumulative_metric_parameters.grain_to_date:
                 issues.append(
                     ValidationError(
                         context=MetricContext(
@@ -41,9 +43,10 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
                     )
                 )
 
-            if metric.type_params.window:
+            window = cumulative_metric_parameters.window
+            if window is not None:
                 try:
-                    window_str = f"{metric.type_params.window.count} {metric.type_params.window.granularity.value}"
+                    window_str = f"{window.count} {window.granularity.value}"
                     # TODO: Should not call an implementation class.
                     PydanticMetricTimeWindow.parse(window_str)
                 except ParsingException as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic~=1.10.8",
-  "jsonschema==3.2.0",
+  "jsonschema~=4.17.3",
   "PyYAML~=6.0",
   "more-itertools==8.10.0",
   "Jinja2==3.1.2",

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -135,7 +135,7 @@ metric:
   type: cumulative
   measure:
     name: txn_revenue
-    window: 2 month
+  window: 2 month
 ---
 metric:
   name: "revenue_all_time"
@@ -150,7 +150,7 @@ metric:
   type: cumulative
   measure:
     name: bookers
-    window: 2 days
+  window: 2 days
 ---
 metric:
   name: "revenue_mtd"
@@ -158,7 +158,7 @@ metric:
   type: cumulative
   measure:
     name: txn_revenue
-    grain_to_date: month
+  grain_to_date: month
 ---
 metric:
   name: booking_fees
@@ -449,7 +449,7 @@ metric:
   metrics:
     - name: bookings
     - name: bookings
-      offset_to_grain: month month
+      offset_to_grain: month
       alias: bookings_at_start_of_month
 ---
 metric:
@@ -461,7 +461,7 @@ metric:
   expr: month_start_bookings - bookings_1_month_ago
   metrics:
     - name: bookings
-      offset_to_grain: month month
+      offset_to_grain: month
       alias: month_start_bookings
     - name: bookings
       offset_window: 1 month

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -3,269 +3,238 @@ metric:
   name: "bookings"
   description: "bookings metric"
   type: simple
-  type_params:
-    measure:
-      name: bookings
+  measure:
+    name: bookings
 ---
 metric:
   name: "average_booking_value"
   description: "average booking value metric"
   type: simple
-  type_params:
-    measure:
-      name: average_booking_value
+  measure:
+    name: average_booking_value
 ---
 metric:
   name: "instant_bookings"
   description: "instant bookings"
   type: simple
-  type_params:
-    measure:
-      name: instant_bookings
+  measure:
+    name: instant_bookings
 ---
 metric:
   name: "booking_value"
   description: "booking value"
   type: simple
-  type_params:
-    measure:
-      name: booking_value
+  measure:
+    name: booking_value
 ---
 metric:
   name: "max_booking_value"
   description: "max booking value"
   type: simple
-  type_params:
-    measure:
-      name: max_booking_value
+  measure:
+    name: max_booking_value
 ---
 metric:
   name: "min_booking_value"
   description: "min booking value"
   type: simple
-  type_params:
-    measure:
-      name: min_booking_value
+  measure:
+    name: min_booking_value
 ---
 metric:
   name: "instant_booking_value"
   description: "booking value of instant bookings"
   type: simple
-  type_params:
-    measure:
-      name: booking_value
+  measure:
+    name: booking_value
   filter: "{{ dimension('is_instant') }}"
 ---
 metric:
   name: "average_instant_booking_value"
   description: "average booking value of instant bookings"
   type: simple
-  type_params:
-    measure:
-      name: average_booking_value
+  measure:
+    name: average_booking_value
   filter:  "{{ dimension('is_instant') }}"
 ---
 metric:
   name: "booking_value_for_non_null_listing_id"
   description: "booking value of instant bookings"
   type: simple
-  type_params:
-    measure:
-      name: booking_value
+  measure:
+    name: booking_value
   filter: "{{ entity('listing') }} IS NOT NULL"
 ---
 metric:
   name: "bookers"
   description: "bookers"
   type: simple
-  type_params:
-    measure:
-      name: bookers
+  measure:
+    name: bookers
 ---
 metric:
   name: "booking_payments"
   description: "Booking payments."
   type: simple
-  type_params:
-    measure:
-      name: booking_payments
+  measure:
+    name: booking_payments
 ---
 metric:
   name: "views"
   description: "views"
   type: simple
-  type_params:
-    measure:
-      name: views
+  measure:
+    name: views
 ---
 metric:
   name: "listings"
   description: "listings"
   type: simple
-  type_params:
-    measure:
-      name: listings
+  measure:
+    name: listings
 ---
 metric:
   name: "lux_listings"
   description: "lux_listings"
   type: simple
-  type_params:
-    measure:
-      name: listings
+  measure:
+    name: listings
   filter: "{{ dimension('is_lux_latest') }}"
 ---
 metric:
   name: "smallest_listing"
   description: "smallest listing"
   type: simple
-  type_params:
-    measure:
-      name: smallest_listing
+  measure:
+    name: smallest_listing
 ---
 metric:
   name: "largest_listing"
   description: "largest listing"
   type: simple
-  type_params:
-    measure:
-      name: largest_listing
+  measure:
+    name: largest_listing
 ---
 metric:
   name: "identity_verifications"
   description: "identity_verifications"
   type: simple
-  type_params:
-    measure:
-      name: identity_verifications
+  measure:
+    name: identity_verifications
 ---
 metric:
   name: "revenue"
   description: "revenue"
   type: simple
-  type_params:
-    measure:
-      name: txn_revenue
+  measure:
+    name: txn_revenue
 ---
 metric:
   name: "trailing_2_months_revenue"
   description: "trailing_2_months_revenue"
   type: cumulative
-  type_params:
-    measure:
-      name: txn_revenue
+  measure:
+    name: txn_revenue
     window: 2 month
 ---
 metric:
   name: "revenue_all_time"
   description: "revenue_all_time"
   type: cumulative
-  type_params:
-    measure:
-      name: txn_revenue
+  measure:
+    name: txn_revenue
 ---
 metric:
   name: "every_two_days_bookers" # because the bookings test data only spans 3 days
   description: "every_two_days_bookers"
   type: cumulative
-  type_params:
-    measure:
-      name: bookers
+  measure:
+    name: bookers
     window: 2 days
 ---
 metric:
   name: "revenue_mtd"
   description: "revenue mtd"
   type: cumulative
-  type_params:
-    measure:
-      name: txn_revenue
+  measure:
+    name: txn_revenue
     grain_to_date: month
 ---
 metric:
   name: booking_fees
   description: Booking value multiplied by constant - simple expr metric test
   type: derived
-  type_params:
-    expr: "booking_value * 0.05"
-    metrics:
-      - name: booking_value
+  expr: "booking_value * 0.05"
+  metrics:
+    - name: booking_value
 ---
 metric:
   name: booking_fees_per_booker
   description: booking_fees divided by bookers - single source multi measure expr test
   type: derived
-  type_params:
-    expr: "booking_value * 0.05 / bookers"
-    metrics:
-      - name: booking_value
-      - name: bookers
+  expr: "booking_value * 0.05 / bookers"
+  metrics:
+    - name: booking_value
+    - name: bookers
 ---
 metric:
   name: views_times_booking_value
   description: Booking_value multiplied by views - expr metric test
   type: derived
-  type_params:
-    expr: "booking_value * views"
-    metrics:
-      - name: booking_value
-      - name: views
+  expr: "booking_value * views"
+  metrics:
+    - name: booking_value
+    - name: views
 ---
 metric:
   name: bookings_per_booker
   description: bookings divided by bookers - single semantic model ratio metric test
   type: ratio
-  type_params:
-    numerator:
-      name: bookings
-    denominator:
-      name: bookers
+  numerator:
+    name: bookings
+  denominator:
+    name: bookers
 ---
 metric:
   name: bookings_per_view
   description: Bookings divided by views - ratio metric test
   type: ratio
-  type_params:
-    numerator:
-      name: bookings
-    denominator:
-      name: views
+  numerator:
+    name: bookings
+  denominator:
+    name: views
 ---
 metric:
   name: bookings_per_listing
   description: Bookings divided by listings - ratio with primary identifier test
   type: ratio
-  type_params:
-    numerator:
-      name: bookings
-    denominator:
-      name: listings
+  numerator:
+    name: bookings
+  denominator:
+    name: listings
 ---
 metric:
   name: bookings_per_dollar
   description: Number of bookings per dollar of value
   type: ratio
-  type_params:
-    numerator:
-      name: bookings
-    denominator:
-      name: booking_value
+  numerator:
+    name: bookings
+  denominator:
+    name: booking_value
 ---
 metric:
   name: "total_account_balance_first_day"
   description: "total_account_balance_first_day"
   type: simple
-  type_params:
-    measure:
-      name: total_account_balance_first_day
+  measure:
+    name: total_account_balance_first_day
 ---
 metric:
   name: "current_account_balance_by_user"
   description: "current_account_balance_by_user"
   type: simple
-  type_params:
-    measure:
-      name: current_account_balance_by_user
+  measure:
+    name: current_account_balance_by_user
 ---
 metric:
   name: instant_booking_fraction_of_max_value
@@ -273,12 +242,11 @@ metric:
     Average instant booking value as a ratio of overall max booking value.
     Tests constrained ratio measure.
   type: ratio
-  type_params:
-    numerator:
-      name: average_booking_value
-      filter: "{{ dimension('is_instant') }}"
-    denominator:
-      name: max_booking_value
+  numerator:
+    name: average_booking_value
+    filter: "{{ dimension('is_instant') }}"
+  denominator:
+    name: max_booking_value
 ---
 metric:
   name: lux_booking_fraction_of_max_value
@@ -286,12 +254,11 @@ metric:
     Average lux booking value as a ratio of overall max booking value.
     Tests constrained ratio measure with external dimension join.
   type: ratio
-  type_params:
-    numerator:
-      name: average_booking_value
-      filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
-    denominator:
-      name: max_booking_value
+  numerator:
+    name: average_booking_value
+    filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
+  denominator:
+    name: max_booking_value
 ---
 metric:
   name: lux_booking_value_rate_expr
@@ -299,14 +266,13 @@ metric:
     Lux booking value defined as an expr with lux booking value, lux bookings, and total value as inputs.
     Tests constrained measure expr metric with external dimension join.
   type: derived
-  type_params:
-    expr: "average_booking_value * bookings / NULLIF(booking_value, 0)"
-    metrics:
-      - name: average_booking_value
-        filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
-      - name: bookings
-        filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
-      - name: booking_value
+  expr: "average_booking_value * bookings / NULLIF(booking_value, 0)"
+  metrics:
+    - name: average_booking_value
+      filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
+    - name: bookings
+      filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
+    - name: booking_value
 ---
 metric:
   name: instant_booking_value_ratio
@@ -314,13 +280,12 @@ metric:
     Instant booking value defined as a ratio metric of instant booking value / booking value
     Tests constrained measure ratio metric with re-use of the same base measure
   type: ratio
-  type_params:
-    numerator:
-      name: booking_value
-      filter: "{{ dimension('is_instant') }}"
-      alias: booking_value_with_is_instant_constraint
-    denominator:
-      name: booking_value
+  numerator:
+    name: booking_value
+    filter: "{{ dimension('is_instant') }}"
+    alias: booking_value_with_is_instant_constraint
+  denominator:
+    name: booking_value
 ---
 metric:
   name: regional_starting_balance_ratios
@@ -328,77 +293,70 @@ metric:
     First day account balance ratio of western vs eastern region starting balance ratios,
     used to test interaction between semi-additive measures and measure constraints
   type: ratio
-  type_params:
-    numerator:
-      name: total_account_balance_first_day
-      filter: "{{ dimension('home_state_latest', entity_path=['user']) }} IN ('CA', 'HI', 'WA')"
-      alias: west_coast_balance_first_day
-    denominator:
-      name: total_account_balance_first_day
-      filter: "{{ dimension('home_state_latest', entity_path=['user']) }} IN ('MD', 'NY', 'TX')"
-      alias: east_coast_balance_first_dat
+  numerator:
+    name: total_account_balance_first_day
+    filter: "{{ dimension('home_state_latest', entity_path=['user']) }} IN ('CA', 'HI', 'WA')"
+    alias: west_coast_balance_first_day
+  denominator:
+    name: total_account_balance_first_day
+    filter: "{{ dimension('home_state_latest', entity_path=['user']) }} IN ('MD', 'NY', 'TX')"
+    alias: east_coast_balance_first_dat
 ---
 metric:
   name: double_counted_delayed_bookings
   description: |
     Minimal repro case for an expr with a single constrained and aliased measure as input.
   type: derived
-  type_params:
-    expr: delayed_bookings * 2
-    metrics:
-      - name: bookings
-        filter: "NOT {{ dimension('is_instant') }}"
-        alias: delayed_bookings
+  expr: delayed_bookings * 2
+  metrics:
+    - name: bookings
+      filter: "NOT {{ dimension('is_instant') }}"
+      alias: delayed_bookings
 ---
 metric:
   name: "referred_bookings"
   description: "bookings made through a referral"
   type: simple
-  type_params:
-    measure:
-      name: referred_bookings
+  measure:
+    name: referred_bookings
 ---
 metric:
   name: "non_referred_bookings_pct"
   description: "percentage of bookings that are not made through a referral"
   type: derived
-  type_params:
-    expr: (bookings - ref_bookings) * 1.0 / bookings
-    metrics:
-      - name: referred_bookings
-        alias: ref_bookings
-      - name: bookings
+  expr: (bookings - ref_bookings) * 1.0 / bookings
+  metrics:
+    - name: referred_bookings
+      alias: ref_bookings
+    - name: bookings
 ---
 metric:
   name: "booking_value_sub_instant"
   description: "booking_value - instant_booking_value"
   type: derived
-  type_params:
-    expr: booking_value - instant_booking_value
-    metrics:
-      - name: instant_booking_value
-      - name: booking_value
+  expr: booking_value - instant_booking_value
+  metrics:
+    - name: instant_booking_value
+    - name: booking_value
 ---
 metric:
   name: "booking_value_sub_instant_add_10"
   description: "Add 10 to booking_value - instant_booking_value"
   type: derived
-  type_params:
-    expr: booking_value_sub_instant + 10
-    metrics:
-      - name: booking_value_sub_instant
+  expr: booking_value_sub_instant + 10
+  metrics:
+    - name: booking_value_sub_instant
 ---
 metric:
   name: bookings_per_lux_listing_derived
   description: Bookings divided by listings - using derived metric type
   type: derived
-  type_params:
-    expr: bookings * 1.0 / NULLIF(lux_listing, 0)
-    metrics:
-      - name: bookings
-      - name: listings
-        alias: lux_listing
-        filter: "{{ dimension('is_lux_latest') }}"
+  expr: bookings * 1.0 / NULLIF(lux_listing, 0)
+  metrics:
+    - name: bookings
+    - name: listings
+      alias: lux_listing
+      filter: "{{ dimension('is_lux_latest') }}"
 ---
 metric:
   name: "instant_plus_non_referred_bookings_pct"
@@ -406,75 +364,67 @@ metric:
     percentage of bookings that are not made through a referral + instant booking pct,
     used to test nested derived metrics.
   type: derived
-  type_params:
-    expr: non_referred + (instant * 1.0 / bookings)
-    metrics:
-      - name: non_referred_bookings_pct
-        alias: non_referred
-      - name: instant_bookings
-        alias: instant
-      - name: bookings
+  expr: non_referred + (instant * 1.0 / bookings)
+  metrics:
+    - name: non_referred_bookings_pct
+      alias: non_referred
+    - name: instant_bookings
+      alias: instant
+    - name: bookings
 ---
 metric:
   name: "trailing_2_months_revenue_sub_10"
   description: |
     Test derived metric with a cumulative metric
   type: derived
-  type_params:
-    expr: t2mr - 10
-    metrics:
-      - name: trailing_2_months_revenue
-        alias: t2mr
+  expr: t2mr - 10
+  metrics:
+    - name: trailing_2_months_revenue
+      alias: t2mr
 ---
 metric:
   name: booking_value_per_view
   description: proportion of booking value per view, which allows us to test joins to listings with null values
   type: derived
-  type_params:
-    expr: booking_value / NULLIF(views, 0)
-    metrics:
-      - name: booking_value
-      - name: views
+  expr: booking_value / NULLIF(views, 0)
+  metrics:
+    - name: booking_value
+    - name: views
 ---
 metric:
   name: "median_booking_value"
   description: "median booking value"
   type: simple
-  type_params:
-    measure:
-      name: median_booking_value
+  measure:
+    name: median_booking_value
 ---
 metric:
   name: "booking_value_p99"
   description: "p99 booking value"
   type: simple
-  type_params:
-    measure:
-      name: booking_value_p99
+  measure:
+    name: booking_value_p99
 ---
 metric:
   name: "discrete_booking_value_p99"
   description: "discrete p99 booking value"
   type: simple
-  type_params:
-    measure:
-      name: discrete_booking_value_p99
+  measure:
+    name: discrete_booking_value_p99
 ---
 metric:
   name: "approximate_continuous_booking_value_p99"
   description: "approximate continuous p99 booking value"
   type: simple
-  type_params:
-    measure:
-      name: approximate_continuous_booking_value_p99
+  measure:
+    name: approximate_continuous_booking_value_p99
 ---
 metric:
   name: "approximate_discrete_booking_value_p99"
   description: "approximate discrete p99 booking value"
   type: simple
-  type_params:
-    measure:
-      name: approximate_discrete_booking_value_p99
+  measure:
+    name: approximate_discrete_booking_value_p99
 ---
 metric:
   name: "bookings_growth_2_weeks"
@@ -482,13 +432,12 @@ metric:
     percentage growth of bookings compared to bookings 2 weeks prior,
     used to test derived metrics with an offset_window.
   type: derived
-  type_params:
-    expr: bookings - bookings_2_weeks_ago
-    metrics:
-      - name: bookings
-      - name: bookings
-        offset_window: 14 days
-        alias: bookings_2_weeks_ago
+  expr: bookings - bookings_2_weeks_ago
+  metrics:
+    - name: bookings
+    - name: bookings
+      offset_window: 14 days
+      alias: bookings_2_weeks_ago
 ---
 metric:
   name: "bookings_growth_since_start_of_month"
@@ -496,13 +445,12 @@ metric:
     percentage growth of bookings since the start of the month,
     used to test derived metrics with an offset_to_grain.
   type: derived
-  type_params:
-    expr: bookings - bookings_at_start_of_month
-    metrics:
-      - name: bookings
-      - name: bookings
-        offset_to_grain: month
-        alias: bookings_at_start_of_month
+  expr: bookings - bookings_at_start_of_month
+  metrics:
+    - name: bookings
+    - name: bookings
+      offset_to_grain: month month
+      alias: bookings_at_start_of_month
 ---
 metric:
   name: "bookings_month_start_compared_to_1_month_prior"
@@ -510,15 +458,14 @@ metric:
     percentage growth of bookings compared to bookings 2 weeks prior,
     used to test derived metrics with an offset_window.
   type: derived
-  type_params:
-    expr: month_start_bookings - bookings_1_month_ago
-    metrics:
-      - name: bookings
-        offset_to_grain: month
-        alias: month_start_bookings
-      - name: bookings
-        offset_window: 1 month
-        alias: bookings_1_month_ago
+  expr: month_start_bookings - bookings_1_month_ago
+  metrics:
+    - name: bookings
+      offset_to_grain: month month
+      alias: month_start_bookings
+    - name: bookings
+      offset_window: 1 month
+      alias: bookings_1_month_ago
 ---
 metric:
   name: "bookings_5_day_lag"
@@ -526,9 +473,8 @@ metric:
     number of bookings 5 days ago. used to test derived metric offset
     with only one input metric.
   type: derived
-  type_params:
-    expr: bookings_5_days_ago
-    metrics:
-      - name: bookings
-        offset_window: 5 days
-        alias: bookings_5_days_ago
+  expr: bookings_5_days_ago
+  metrics:
+    - name: bookings
+      offset_window: 5 days
+      alias: bookings_5_days_ago

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -344,7 +344,7 @@ def test_invalid_metric_type_parsing_error() -> None:
 
     build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
     assert build_result.issues.has_blocking_issues
-    assert "'this is not a valid type' is not one of" in str(
+    assert "YAML document did not conform to metric spec" in str(
         SemanticManifestValidationException(build_result.issues.all_issues)
     )
 

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -1,3 +1,4 @@
+import logging
 import textwrap
 
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
@@ -20,6 +21,8 @@ from tests.example_project_configuration import (
     EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def test_legacy_measure_metric_parsing() -> None:
     """Test for parsing a simple metric specification with the `measure` parameter instead of `measures`."""
@@ -28,8 +31,7 @@ def test_legacy_measure_metric_parsing() -> None:
         metric:
           name: legacy_test
           type: simple
-          type_params:
-            measure: legacy_measure
+          measure: legacy_measure
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -50,10 +52,9 @@ def test_legacy_metric_input_measure_object_parsing() -> None:
         metric:
           name: legacy_test
           type: simple
-          type_params:
-            measure:
-              name: legacy_measure_from_object
-              filter: "{{ dimension('some_bool') }}"
+          measure:
+            name: legacy_measure_from_object
+            filter: "{{ dimension('some_bool') }}"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -75,9 +76,8 @@ def test_metric_metadata_parsing() -> None:
         metric:
           name: metadata_test
           type: simple
-          type_params:
-            measure:
-              name: metadata_test_measure
+          measure:
+            name: metadata_test_measure
         """
     )
     file = YamlConfigFile(filepath="test_dir/inline_for_test", contents=yaml_contents)
@@ -93,9 +93,8 @@ def test_metric_metadata_parsing() -> None:
         """\
         name: metadata_test
         type: simple
-        type_params:
-          measure:
-            name: metadata_test_measure
+        measure:
+          name: metadata_test_measure
         """
     )
     assert metric.metadata.file_slice.content == expected_metadata_content
@@ -108,11 +107,10 @@ def test_ratio_metric_parsing() -> None:
         metric:
           name: ratio_test
           type: ratio
-          type_params:
-            numerator:
-              name: numerator_metric
-            denominator:
-              name: denominator_metric
+          numerator:
+            name: numerator_metric
+          denominator:
+            name: denominator_metric
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -134,12 +132,11 @@ def test_ratio_metric_input_measure_object_parsing() -> None:
         metric:
           name: ratio_test
           type: ratio
-          type_params:
-            numerator:
-              name: numerator_metric_from_object
-              filter: "some_number > 5"
-            denominator:
-              name: denominator_metric_from_object
+          numerator:
+            name: numerator_metric_from_object
+            filter: "some_number > 5"
+          denominator:
+            name: denominator_metric_from_object
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -164,10 +161,9 @@ def test_cumulative_window_metric_parsing() -> None:
         metric:
           name: cumulative_test
           type: cumulative
-          type_params:
-            measure:
-              name: cumulative_measure
-            window: "7 days"
+          measure:
+            name: cumulative_measure
+          window: "7 days"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -191,10 +187,9 @@ def test_grain_to_date_metric_parsing() -> None:
         metric:
           name: grain_to_date_test
           type: cumulative
-          type_params:
-            measure:
-              name: cumulative_measure
-            grain_to_date: "week"
+          measure:
+            name: cumulative_measure
+          grain_to_date: "week"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -217,13 +212,12 @@ def test_derived_metric_offset_window_parsing() -> None:
         metric:
           name: derived_offset_test
           type: derived
-          type_params:
-            expr: bookings / bookings_2_weeks_ago
-            metrics:
-              - name: bookings
-              - name: bookings
-                offset_window: 14 days
-                alias: bookings_2_weeks_ago
+          expr: bookings / bookings_2_weeks_ago
+          metrics:
+            - name: bookings
+            - name: bookings
+              offset_window: 14 days
+              alias: bookings_2_weeks_ago
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -251,13 +245,12 @@ def test_derive_metric_offset_to_grain_parsing() -> None:
         metric:
           name: derived_offset_to_grain_test
           type: derived
-          type_params:
-            expr: bookings / bookings_at_start_of_month
-            metrics:
-              - name: bookings
-              - name: bookings
-                offset_to_grain: month
-                alias: bookings_at_start_of_month
+          expr: bookings / bookings_at_start_of_month
+          metrics:
+            - name: bookings
+            - name: bookings
+              offset_to_grain: month
+              alias: bookings_at_start_of_month
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -285,9 +278,8 @@ def test_constraint_metric_parsing() -> None:
         metric:
           name: constraint_test
           type: simple
-          type_params:
-            measure:
-              name: input_measure
+          measure:
+            name: input_measure
           filter: "{{ dimension('some_dimension') }} IN ('value1', 'value2')"
         """
     )
@@ -311,13 +303,12 @@ def test_derived_metric_input_parsing() -> None:
         metric:
           name: derived_metric_test
           type: derived
-          type_params:
-            expr: sum(constrained_input_metric) / input_metric
-            metrics:
-              - name: input_metric
-              - name: input_metric
-                alias: constrained_input_metric
-                filter: input_metric < 10
+          expr: sum(constrained_input_metric) / input_metric
+          metrics:
+            - name: input_metric
+            - name: input_metric
+              alias: constrained_input_metric
+              filter: input_metric < 10
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -345,9 +336,8 @@ def test_invalid_metric_type_parsing_error() -> None:
         metric:
           name: invalid_type_test
           type: this is not a valid type
-          type_params:
-            measure:
-              name: input_measure
+          measure:
+            name: input_measure
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -366,10 +356,9 @@ def test_invalid_cumulative_metric_window_format_parsing_error() -> None:
         metric:
           name: invalid_cumulative_format_test
           type: cumulative
-          type_params:
-            measure:
-              name: cumulative_measure
-            window: "7 days long"
+          measure:
+            name: cumulative_measure
+          window: "7 days long"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -386,10 +375,9 @@ def test_invalid_cumulative_metric_window_granularity_parsing_error() -> None:
         metric:
           name: invalid_cumulative_granularity_test
           type: cumulative
-          type_params:
-            measure:
-              name: cumulative_measure
-            window: "7 moons"
+          measure:
+            name: cumulative_measure
+          window: "7 moons"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -406,10 +394,9 @@ def test_invalid_cumulative_metric_window_count_parsing_error() -> None:
         metric:
           name: invalid_cumulative_count_test
           type: cumulative
-          type_params:
-            measure:
-              name: cumulative_measure
-            window: "six days"
+          measure:
+            name: cumulative_measure
+          window: "six days"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -14,7 +14,6 @@ from dbt_semantic_interfaces.implementations.metadata import (
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
     PydanticMetricInputMeasure,
-    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -63,7 +62,7 @@ def test_semantic_manifest_protocol() -> None:  # noqa: D
     metric = PydanticMetric(
         name="test_metric",
         type=MetricType.SIMPLE,
-        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name="test_measure")),
+        measure=PydanticMetricInputMeasure(name="test_measure"),
     )
     semantic_manifest = PydanticSemanticManifest(
         semantic_models=[semantic_model],
@@ -101,13 +100,18 @@ class RuntimeCheckableMetric(MetricProtocol, Protocol):
     pass
 
 
+def check_metric_protocol(metric: MetricProtocol) -> None:
+    """If the given metric does not satisfy the protocol, then this will fail the type check."""
+    pass
+
+
 def test_metric_protocol() -> None:  # noqa: D
     test_metric = PydanticMetric(
         name="test_metric",
         type=MetricType.SIMPLE,
-        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name="test_measure")),
+        measure=PydanticMetricInputMeasure(name="test_measure"),
     )
-    assert isinstance(test_metric, RuntimeCheckableMetric)
+    check_metric_protocol(test_metric)
 
 
 @runtime_checkable

--- a/tests/validations/test_configurable_rules.py
+++ b/tests/validations/test_configurable_rules.py
@@ -2,10 +2,7 @@ import copy
 
 import pytest
 
-from dbt_semantic_interfaces.implementations.metric import (
-    PydanticMetricInput,
-    PydanticMetricTypeParams,
-)
+from dbt_semantic_interfaces.implementations.metric import PydanticMetricInput
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
@@ -25,10 +22,8 @@ def test_can_configure_model_validator_rules(  # noqa: D
         metric_with_guaranteed_meta(
             name="metric_doesnt_exist_squared",
             type=MetricType.DERIVED,
-            type_params=PydanticMetricTypeParams(
-                expr="metric_doesnt_exist * metric_doesnt_exist",
-                metrics=[PydanticMetricInput(name="metric_doesnt_exist")],
-            ),
+            expr="metric_doesnt_exist * metric_doesnt_exist",
+            metrics=[PydanticMetricInput(name="metric_doesnt_exist")],
         )
     )
 

--- a/tests/validations/test_dimension_const.py
+++ b/tests/validations/test_dimension_const.py
@@ -5,10 +5,7 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
     PydanticDimensionTypeParams,
 )
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
-from dbt_semantic_interfaces.implementations.metric import (
-    PydanticMetricInputMeasure,
-    PydanticMetricTypeParams,
-)
+from dbt_semantic_interfaces.implementations.metric import PydanticMetricInputMeasure
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
@@ -62,7 +59,7 @@ def test_incompatible_dimension_type() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name=measure_name,
                         type=MetricType.SIMPLE,
-                        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                        measure=PydanticMetricInputMeasure(name=measure_name),
                     )
                 ],
                 project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
@@ -110,7 +107,7 @@ def test_incompatible_dimension_is_partition() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name=measure_name,
                         type=MetricType.SIMPLE,
-                        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                        measure=PydanticMetricInputMeasure(name=measure_name),
                     )
                 ],
                 project_configuration=EXAMPLE_PROJECT_CONFIGURATION,

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -45,9 +45,8 @@ def test_metric_missing_measure() -> None:
           name: "{metric_name}"
           description: "Metric with invalid measure"
           type: simple
-          type_params:
-            measure:
-              name: {measure_name}
+          measure:
+            name: {measure_name}
         """
     )
     metric_missing_measure_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -10,7 +10,6 @@ from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInput,
     PydanticMetricInputMeasure,
     PydanticMetricTimeWindow,
-    PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -79,7 +78,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                 metric_with_guaranteed_meta(
                     name="metric_with_no_time_dim",
                     type=MetricType.SIMPLE,
-                    type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                    measure=PydanticMetricInputMeasure(name=measure_name),
                 )
             ],
             project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
@@ -110,7 +109,7 @@ def test_metric_no_time_dim() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name="metric_with_no_time_dim",
                         type=MetricType.SIMPLE,
-                        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                        measure=PydanticMetricInputMeasure(name=measure_name),
                     )
                 ],
                 project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
@@ -152,7 +151,7 @@ def test_metric_multiple_primary_time_dims() -> None:  # noqa:D
                     metric_with_guaranteed_meta(
                         name="foo",
                         type=MetricType.SIMPLE,
-                        type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                        measure=PydanticMetricInputMeasure(name=measure_name),
                     )
                 ],
                 project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
@@ -226,59 +225,52 @@ def test_derived_metric() -> None:  # noqa: D
                 metric_with_guaranteed_meta(
                     name="random_metric",
                     type=MetricType.SIMPLE,
-                    type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                    measure=PydanticMetricInputMeasure(name=measure_name),
                 ),
                 metric_with_guaranteed_meta(
                     name="random_metric2",
                     type=MetricType.SIMPLE,
-                    type_params=PydanticMetricTypeParams(measure=PydanticMetricInputMeasure(name=measure_name)),
+                    measure=PydanticMetricInputMeasure(name=measure_name),
                 ),
                 metric_with_guaranteed_meta(
                     name="alias_collision",
                     type=MetricType.DERIVED,
-                    type_params=PydanticMetricTypeParams(
-                        expr="random_metric2 * 2",
-                        metrics=[
-                            PydanticMetricInput(name="random_metric", alias="random_metric2"),
-                            PydanticMetricInput(name="random_metric2"),
-                        ],
-                    ),
+                    expr="random_metric2 * 2",
+                    metrics=[
+                        PydanticMetricInput(name="random_metric", alias="random_metric2"),
+                        PydanticMetricInput(name="random_metric2"),
+                    ],
                 ),
                 metric_with_guaranteed_meta(
                     name="doesntexist",
                     type=MetricType.DERIVED,
-                    type_params=PydanticMetricTypeParams(
-                        expr="notexist * 2", metrics=[PydanticMetricInput(name="notexist")]
-                    ),
+                    expr="notexist * 2",
+                    metrics=[PydanticMetricInput(name="notexist")],
                 ),
                 metric_with_guaranteed_meta(
                     name="has_valid_time_window_params",
                     type=MetricType.DERIVED,
-                    type_params=PydanticMetricTypeParams(
-                        expr="random_metric / random_metric3",
-                        metrics=[
-                            PydanticMetricInput(
-                                name="random_metric", offset_window=PydanticMetricTimeWindow.parse("3 weeks")
-                            ),
-                            PydanticMetricInput(
-                                name="random_metric", offset_to_grain=TimeGranularity.MONTH, alias="random_metric3"
-                            ),
-                        ],
-                    ),
+                    expr="random_metric / random_metric3",
+                    metrics=[
+                        PydanticMetricInput(
+                            name="random_metric", offset_window=PydanticMetricTimeWindow.parse("3 weeks")
+                        ),
+                        PydanticMetricInput(
+                            name="random_metric", offset_to_grain=TimeGranularity.MONTH, alias="random_metric3"
+                        ),
+                    ],
                 ),
                 metric_with_guaranteed_meta(
                     name="has_both_time_offset_params_on_same_input_metric",
                     type=MetricType.DERIVED,
-                    type_params=PydanticMetricTypeParams(
-                        expr="random_metric * 2",
-                        metrics=[
-                            PydanticMetricInput(
-                                name="random_metric",
-                                offset_window=PydanticMetricTimeWindow.parse("3 weeks"),
-                                offset_to_grain=TimeGranularity.MONTH,
-                            )
-                        ],
-                    ),
+                    expr="random_metric * 2",
+                    metrics=[
+                        PydanticMetricInput(
+                            name="random_metric",
+                            offset_window=PydanticMetricTimeWindow.parse("3 weeks"),
+                            offset_to_grain=TimeGranularity.MONTH,
+                        )
+                    ],
                 ),
             ],
             project_configuration=EXAMPLE_PROJECT_CONFIGURATION,


### PR DESCRIPTION
### Description

Currently, metrics are defined in YAML using the following format:

```
metric:
  name: booking_fees
  description: Booking value multiplied by constant - simple expr metric test
  type: derived
  type_params:
    expr: "booking_value * 0.05"
    metrics:
      - name: booking_value
```

with the corresponding Pydantic implementation as
```
class PydanticMetricTypeParams(HashableBaseModel):
    """Type params add additional context to certain metric types (the context depends on the metric type)."""

    measure: Optional[PydanticMetricInputMeasure]
    numerator: Optional[PydanticMetricInput]
    denominator: Optional[PydanticMetricInput]
    expr: Optional[str]
    window: Optional[PydanticMetricTimeWindow]
    grain_to_date: Optional[TimeGranularity]
    metrics: Optional[List[PydanticMetricInput]]
    ...


class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing):
    """Describes a metric."""

    name: str
    description: Optional[str]
    type: MetricType
    type_params: PydanticMetricTypeParams
    filter: Optional[PydanticWhereFilter]
    metadata: Optional[PydanticMetadata]
    ...
```

The challenges with the above approach is that the `type_params` field increases nesting and the optional fields in `PydanticMetricTypeParams` make it hard to use correctly. The proposal is to flatten the format and update the JSON schema to enable the correct type-ahead / autocomplete based on the value of the type field. The new YAML format would look like:

```
metric:
  name: booking_fees
  description: Booking value multiplied by constant - simple expr metric test
  type: derived
  expr: "booking_value * 0.05"
  metrics:
    - name: booking_value
```

and there would be typed parameter objects that could be accessed from `PydanticMetric` to get the correct fields for each metric type. Debating whether there should be separate `PydanticMetric*` types for each type of metric.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
