### PR TITLE
Drop `create_metric` from the `Measure` protocol

### DIFF
--- a/.changes/unreleased/Under the Hood-20230629-090156.yaml
+++ b/.changes/unreleased/Under the Hood-20230629-090156.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove `create_metric` from measure protocol
+time: 2023-06-29T09:01:56.627715-07:00
+custom:
+  Author: QMalcolm
+  Issue: "99"

--- a/dbt_semantic_interfaces/protocols/measure.py
+++ b/dbt_semantic_interfaces/protocols/measure.py
@@ -69,11 +69,6 @@ class Measure(Protocol):
 
     @property
     @abstractmethod
-    def create_metric(self) -> Optional[bool]:  # noqa: D
-        pass
-
-    @property
-    @abstractmethod
     def expr(self) -> Optional[str]:  # noqa: D
         pass
 


### PR DESCRIPTION
Resolves #99

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

The attribute `create_metric` is a parse time convenience attribute. It's not something that MetricFlow will take action on. That is to say for those implementing parsing, they may want to have something akin to `create_metric` for the ergonomics of their parsing schema, but is not something actionable when passing the objects to other systems because the action that should be caused should have already resulted in the creation of a metric before a manifest gets passed.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
