### PR TITLE
Fix minor issues with semantic model defaults validation

### DIFF
--- a/.changes/unreleased/Fixes-20230630-100007.yaml
+++ b/.changes/unreleased/Fixes-20230630-100007.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix false positive error in semantic model defaults validation
+time: 2023-06-30T10:00:07.114321-07:00
+custom:
+  Author: tlento
+  Issue: None

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -197,11 +197,10 @@ class SemanticModelDefaultsRule(SemanticManifestValidationRule[SemanticManifestT
     def _validate_default_agg_time_dimension(semantic_model: SemanticModel) -> List[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
-        if semantic_model.defaults is None:
+        if semantic_model.defaults is None or semantic_model.defaults.agg_time_dimension is None:
             return []
 
         default_agg_time_dimension = semantic_model.defaults.agg_time_dimension
-        assert default_agg_time_dimension is not None, "should not be None"
 
         if not SemanticModelValidationHelpers.time_dimension_in_model(
             time_dimension_name=default_agg_time_dimension, semantic_model=semantic_model

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -407,8 +407,8 @@ class SemanticManifestValidationException(Exception):
 class SemanticModelValidationHelpers:
     """Class containing all the helpers related to semantic model validations."""
 
-    @classmethod
-    def time_dimension_in_model(cls, time_dimension_name: str, semantic_model: SemanticModel) -> bool:  # noqa: D
+    @staticmethod
+    def time_dimension_in_model(time_dimension_name: str, semantic_model: SemanticModel) -> bool:  # noqa: D
         for dimension in semantic_model.dimensions:
             if dimension.type == DimensionType.TIME and dimension.name == time_dimension_name:
                 return True


### PR DESCRIPTION
The validation hook associated with SemanticModelDefaults would
register an error state if the optional agg_time_dimension property
was not set.

There was also a stray classmethod that really ought to be a staticmethod.
Forgive the "while I'm here" fixing but it doesn't seem worth a separate
commit.
