### PR TITLE
Repin ruff to `0.0.260`

### DIFF
--- a/.changes/unreleased/Dependencies-20230712-141113.yaml
+++ b/.changes/unreleased/Dependencies-20230712-141113.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Repinning ruff because we need to do work to move off of 0.0.260
+time: 2023-07-12T14:11:13.375068-07:00
+custom:
+  Author: QMalcolm
+  PR: None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
   "pre-commit~=3.2",
   "isort~=5.12",
   "black~=23.3",
-  "ruff~=0.0.260",
+  "ruff==0.0.260",
   "mypy~=1.3",
   "pytest~=7.3",
   "types-Jinja2~=2.11",


### PR DESCRIPTION
### Description
When it became unpinned, ruff began choking on our current `/# noqa: D` pattern. Repinning it solves the issue. We'll have to do some further investigation before unpinning `ruff`

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
