### PR TITLE
Fix `traceback.format_exception_only` calls for python 3.10+

### DIFF
--- a/.changes/unreleased/Fixes-20230714-130338.yaml
+++ b/.changes/unreleased/Fixes-20230714-130338.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Ensuring calls to `format_exception_only` aren't breaking in python 3.10+
+time: 2023-07-14T13:03:38.117362-07:00
+custom:
+  Author: QMalcolm
+  Issue: "117"

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -10,11 +10,21 @@ on:
       - synchronize
 
 jobs:
-  pre-commit:
-    name: Run Python Tests
+  pytest:
+    name: Run Tests / Python ${{ matrix.python-version }}
+
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-python-env
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Hatch
+        shell: bash
+        run: pip3 install hatch
       - name: Run Python Tests
         run: hatch run dev-env:pytest tests

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -53,7 +53,7 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
                                 file_context=FileContext.from_metadata(metadata=metric.metadata),
                                 metric=MetricModelReference(metric_name=metric.name),
                             ),
-                            message="".join(traceback.format_exception_only(etype=type(e), value=e)),
+                            message="".join(traceback.format_exception_only(type(e), value=e)),
                             extra_detail="".join(traceback.format_tb(e.__traceback__)),
                         )
                     )

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -340,7 +340,7 @@ def generate_exception_issue(
     return ValidationError(
         context=context,
         message=f"An error occurred while {what_was_being_done} - "
-        f"{''.join(traceback.format_exception_only(etype=type(e), value=e))}",
+        f"{''.join(traceback.format_exception_only(type(e), value=e))}",
         extra_detail="\n".join([f"{key}: {value}" for key, value in extras.items()]),
     )
 

--- a/tests/validations/test_validator_helpers.py
+++ b/tests/validations/test_validator_helpers.py
@@ -20,6 +20,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
     ValidationIssue,
     ValidationIssueLevel,
     ValidationWarning,
+    validate_safely,
 )
 
 
@@ -136,3 +137,14 @@ def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssue
     assert merged.warnings == validation_results.warnings + validation_results_dup.warnings
     assert merged.future_errors == validation_results.future_errors + validation_results_dup.future_errors
     assert merged.errors == validation_results.errors + validation_results_dup.errors
+
+
+def test_validate_safely_handles_exceptions():  # noqa: D
+    @validate_safely("testing validate safely handles exceptions gracefully")
+    def checking_validate_safely() -> List[ValidationIssue]:
+        raise (Exception("Oh no an exception!"))
+        return []
+
+    # We shouldn't get an unhandled exception from this
+    validation_issues = checking_validate_safely()
+    assert len(validation_issues) == 1


### PR DESCRIPTION
Resolves #117 

### Description
This PR does a few things. It's primary function is to resolve #117. As side affect of that, we're now testing against python 3.8, 3.9, 3.10, and 3.11 in our github CI which feels just as important, or perhaps even more important in a long term perspective.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
