### PR TITLE
Ensure `WhereFilterParser` uses a `SandboxedEnvironment` for jinja invocations

### DIFF
--- a/.changes/unreleased/Under the Hood-20230720-104447.yaml
+++ b/.changes/unreleased/Under the Hood-20230720-104447.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Begin using SandboxedEnvironment for WhereFilterParser jinja usage
+time: 2023-07-20T10:44:47.429565-07:00
+custom:
+  Author: QMalcolm
+  Issue: "121"


### PR DESCRIPTION
Resolves #121

### Description

The use of non sandboxed environments for jinja invocations is considered bad practice. This change ensures we use a `SandboxedEnvironment` in the `WhereFilterParser`.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
