### PR TITLE
Default `validate_semantic_manifest` to operate synchronously

### DIFF
--- a/.changes/unreleased/Under the Hood-20230726-094145.yaml
+++ b/.changes/unreleased/Under the Hood-20230726-094145.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Switch `validate_semantic_manifest` to work in synchronous manner
+time: 2023-07-26T09:41:45.59555-07:00
+custom:
+  Author: QMalcolm
+  Issue: "125"


### PR DESCRIPTION
Resolves #125 

### Description

Having `validate_semantic_manifest` operate in a multi-process structure was problematic when used in a deamonic environment. We've altered the function to default to operating synchronously. There is also a new optional parameter that can be passed to `validate_semantic_manifest` for running through the multi-process workflow. This is a non breaking change because the function call has not changed, in that all current invocations of `validate_semantic_manifest` will continue working seamlessly.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
