### PR TITLE
Add `PrimaryEntityDimensionPairs` validation rule

### DIFF
--- a/.changes/unreleased/Features-20230727-161128.yaml
+++ b/.changes/unreleased/Features-20230727-161128.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add new `PrimaryEntityDimensionPairs` validation rule
+time: 2023-07-27T16:11:28.794732-07:00
+custom:
+  Author: QMalcolm
+  Issue: "103"

--- a/dbt_semantic_interfaces/validations/semantic_manifest_validator.py
+++ b/dbt_semantic_interfaces/validations/semantic_manifest_validator.py
@@ -29,7 +29,10 @@ from dbt_semantic_interfaces.validations.semantic_models import (
     SemanticModelDefaultsRule,
     SemanticModelValidityWindowRule,
 )
-from dbt_semantic_interfaces.validations.unique_valid_name import UniqueAndValidNameRule
+from dbt_semantic_interfaces.validations.unique_valid_name import (
+    PrimaryEntityDimensionPairs,
+    UniqueAndValidNameRule,
+)
 from dbt_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationException,
     SemanticManifestValidationResults,
@@ -73,6 +76,7 @@ class SemanticManifestValidator(Generic[SemanticManifestT]):
         MeasuresNonAdditiveDimensionRule[SemanticManifestT](),
         SemanticModelDefaultsRule[SemanticManifestT](),
         PrimaryEntityRule[SemanticManifestT](),
+        PrimaryEntityDimensionPairs[SemanticManifestT](),
     )
 
     def __init__(

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/user_sm_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/user_sm_source.yaml
@@ -8,10 +8,10 @@ semantic_model:
     alias: dim_users
 
   defaults:
-    agg_time_dimension: ds
+    agg_time_dimension: ds_source_date
 
   dimensions:
-    - name: ds
+    - name: ds_source_date
       type: time
       type_params:
         time_granularity: day

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -65,7 +65,7 @@ def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
                         )
                     ],
                     dimensions=[
-                        PydanticDimension(name=dim_name, type=DimensionType.CATEGORICAL),
+                        PydanticDimension(name=f"{dim_name}_dup", type=DimensionType.CATEGORICAL),
                         PydanticDimension(
                             name=dim2_name,
                             type=DimensionType.TIME,


### PR DESCRIPTION
Resolves #103

### Description

Adds a `PrimaryEntityDimensionPairs` validation rule which validates that there are no duplicate primary entity + dimension pairings across the semantic manifest.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
