### PR TITLE
Add Primary Entity Prefix When Specifying Dimensions in the WhereFilter

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230727-165005.yaml
+++ b/.changes/unreleased/Breaking Changes-20230727-165005.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Require primary entities when specifying dimensions in the WhereFilter.
+time: 2023-07-27T16:50:05.653782-07:00
+custom:
+  Author: plypaul
+  Issue: "123"

--- a/dbt_semantic_interfaces/naming/dundered.py
+++ b/dbt_semantic_interfaces/naming/dundered.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from dbt_semantic_interfaces.naming.keywords import DUNDER
+from dbt_semantic_interfaces.references import EntityReference
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class StructuredDunderedName:
+    """Group by items (e.g. dimensions / entities) in a query that are named using a double underscore as a seperator.
+
+    e.g. listing__ds__week ->
+    entity_links: ["listing"]
+    element_name: "ds"
+    granularity: TimeGranularity.WEEK
+
+    The time granularity is part of legacy query syntax and there are plans to migrate away from this format.
+    """
+
+    entity_links: Tuple[EntityReference, ...]
+    element_name: str
+    time_granularity: Optional[TimeGranularity] = None
+
+    @staticmethod
+    def parse_name(name: str) -> StructuredDunderedName:
+        """Construct from a string like 'listing__ds__month'."""
+        name_parts = name.split(DUNDER)
+
+        # No dunder, e.g. "ds"
+        if len(name_parts) == 1:
+            return StructuredDunderedName((), name_parts[0])
+
+        associated_granularity = None
+        granularity: TimeGranularity
+        for granularity in TimeGranularity:
+            if name_parts[-1] == granularity.value:
+                associated_granularity = granularity
+
+        # Has a time granularity
+        if associated_granularity:
+            #  e.g. "ds__month"
+            if len(name_parts) == 2:
+                return StructuredDunderedName((), name_parts[0], associated_granularity)
+            # e.g. "messages__ds__month"
+            return StructuredDunderedName(
+                entity_links=tuple(EntityReference(element_name=entity_name) for entity_name in name_parts[:-2]),
+                element_name=name_parts[-2],
+                time_granularity=associated_granularity,
+            )
+        # e.g. "messages__ds"
+        else:
+            return StructuredDunderedName(
+                entity_links=tuple(EntityReference(element_name=entity_name) for entity_name in name_parts[:-1]),
+                element_name=name_parts[-1],
+            )
+
+    @property
+    def dundered_name(self) -> str:
+        """Return the full name form. e.g. ds or listing__ds__month."""
+        items = [entity_reference.element_name for entity_reference in self.entity_links] + [self.element_name]
+        if self.time_granularity and self.time_granularity != TimeGranularity.DAY:
+            items.append(self.time_granularity.value)
+        return DUNDER.join(items)
+
+    @property
+    def dundered_name_without_granularity(self) -> str:
+        """Return the name without the time granularity. e.g. listing__ds__month -> listing__ds."""
+        return DUNDER.join(
+            tuple(entity_reference.element_name for entity_reference in self.entity_links) + (self.element_name,)
+        )
+
+    @property
+    def dundered_name_without_entity(self) -> str:
+        """Return the name without the entity. e.g. listing__ds__month -> ds__month."""
+        return DUNDER.join((self.element_name,) + ((self.time_granularity.value,) if self.time_granularity else ()))
+
+    @property
+    def entity_prefix(self) -> Optional[str]:
+        """Return the entity prefix. e.g. listing__ds__month -> listing."""
+        if len(self.entity_links) > 0:
+            return DUNDER.join(tuple(entity_reference.element_name for entity_reference in self.entity_links))
+
+        return None
+
+
+class DunderedNameFormatter:
+    """Helps to parse names into StructuredDunderedName and vice versa."""
+
+    @staticmethod
+    def parse_name(name: str) -> StructuredDunderedName:
+        """Construct from a string like 'listing__ds__month'."""
+        name_parts = name.split(DUNDER)
+
+        # No dunder, e.g. "ds"
+        if len(name_parts) == 1:
+            return StructuredDunderedName((), name_parts[0])
+
+        associated_granularity = None
+        granularity: TimeGranularity
+        for granularity in TimeGranularity:
+            if name_parts[-1] == granularity.value:
+                associated_granularity = granularity
+
+        # Has a time granularity
+        if associated_granularity:
+            #  e.g. "ds__month"
+            if len(name_parts) == 2:
+                return StructuredDunderedName((), name_parts[0], associated_granularity)
+            # e.g. "messages__ds__month"
+            return StructuredDunderedName(
+                entity_links=tuple(EntityReference(element_name=entity_name) for entity_name in name_parts[:-2]),
+                element_name=name_parts[-2],
+                time_granularity=associated_granularity,
+            )
+        # e.g. "messages__ds"
+        else:
+            return StructuredDunderedName(
+                entity_links=tuple(EntityReference(element_name=entity_name) for entity_name in name_parts[:-1]),
+                element_name=name_parts[-1],
+            )
+
+    @staticmethod
+    def create_structured_name(  # noqa: D
+        element_name: str,
+        entity_links: Tuple[EntityReference, ...] = (),
+        time_granularity: Optional[TimeGranularity] = None,
+    ) -> StructuredDunderedName:
+        return StructuredDunderedName(
+            entity_links=entity_links,
+            element_name=element_name,
+            time_granularity=time_granularity,
+        )

--- a/dbt_semantic_interfaces/naming/keywords.py
+++ b/dbt_semantic_interfaces/naming/keywords.py
@@ -1,0 +1,11 @@
+# A double underscore used as a seperator in group by item names.
+# e.g. user__country
+DUNDER = "__"
+
+# The name for the time dimension used to tabulate / plot metrics.
+METRIC_TIME_ELEMENT_NAME = "metric_time"
+
+
+def is_metric_time_name(element_name: str) -> bool:
+    """Returns True if the given element name corresponds to metric time."""
+    return element_name == METRIC_TIME_ELEMENT_NAME

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -54,7 +54,7 @@ metric:
   type_params:
     measure:
       name: booking_value
-  filter: "{{ dimension('is_instant') }}"
+  filter: "{{ dimension('booking__is_instant') }}"
 ---
 metric:
   name: "average_instant_booking_value"
@@ -63,7 +63,7 @@ metric:
   type_params:
     measure:
       name: average_booking_value
-  filter:  "{{ dimension('is_instant') }}"
+  filter:  "{{ dimension('booking__is_instant') }}"
 ---
 metric:
   name: "booking_value_for_non_null_listing_id"
@@ -113,7 +113,7 @@ metric:
   type_params:
     measure:
       name: listings
-  filter: "{{ dimension('is_lux_latest') }}"
+  filter: "{{ dimension('listing__is_lux_latest') }}"
 ---
 metric:
   name: "smallest_listing"
@@ -276,7 +276,7 @@ metric:
   type_params:
     numerator:
       name: average_booking_value
-      filter: "{{ dimension('is_instant') }}"
+      filter: "{{ dimension('booking__is_instant') }}"
     denominator:
       name: max_booking_value
 ---
@@ -289,7 +289,7 @@ metric:
   type_params:
     numerator:
       name: average_booking_value
-      filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
+      filter: "{{ dimension('listing__is_lux_latest', entity_path=['listing']) }}"
     denominator:
       name: max_booking_value
 ---
@@ -303,9 +303,9 @@ metric:
     expr: "average_booking_value * bookings / NULLIF(booking_value, 0)"
     metrics:
       - name: average_booking_value
-        filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
+        filter: "{{ dimension('listing__is_lux_latest', entity_path=['listing']) }}"
       - name: bookings
-        filter: "{{ dimension('is_lux_latest', entity_path=['listing']) }}"
+        filter: "{{ dimension('listing__is_lux_latest', entity_path=['listing']) }}"
       - name: booking_value
 ---
 metric:
@@ -317,7 +317,7 @@ metric:
   type_params:
     numerator:
       name: booking_value
-      filter: "{{ dimension('is_instant') }}"
+      filter: "{{ dimension('booking__is_instant') }}"
       alias: booking_value_with_is_instant_constraint
     denominator:
       name: booking_value
@@ -331,11 +331,11 @@ metric:
   type_params:
     numerator:
       name: total_account_balance_first_day
-      filter: "{{ dimension('home_state_latest', entity_path=['user']) }} IN ('CA', 'HI', 'WA')"
+      filter: "{{ dimension('user__home_state_latest') }} IN ('CA', 'HI', 'WA')"
       alias: west_coast_balance_first_day
     denominator:
       name: total_account_balance_first_day
-      filter: "{{ dimension('home_state_latest', entity_path=['user']) }} IN ('MD', 'NY', 'TX')"
+      filter: "{{ dimension('user__home_state_latest') }} IN ('MD', 'NY', 'TX')"
       alias: east_coast_balance_first_dat
 ---
 metric:
@@ -347,7 +347,7 @@ metric:
     expr: delayed_bookings * 2
     metrics:
       - name: bookings
-        filter: "NOT {{ dimension('is_instant') }}"
+        filter: "NOT {{ dimension('booking__is_instant') }}"
         alias: delayed_bookings
 ---
 metric:
@@ -398,7 +398,7 @@ metric:
       - name: bookings
       - name: listings
         alias: lux_listing
-        filter: "{{ dimension('is_lux_latest') }}"
+        filter: "{{ dimension('listing__is_lux_latest') }}"
 ---
 metric:
   name: "instant_plus_non_referred_bookings_pct"

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -22,7 +22,10 @@ logger = logging.getLogger(__name__)
 def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
     parse_result = PydanticWhereFilter(
         where_sql_template=(
-            """{{ dimension('is_instant') }} AND {{ dimension('country', entity_path=['listing']) }} == 'US'"""
+            """\
+                {{ dimension('booking__is_instant') }} \
+                AND {{ dimension('user__country', entity_path=['listing']) }} == 'US'\
+                """
         )
     ).call_parameter_sets
 
@@ -30,11 +33,14 @@ def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
         dimension_call_parameter_sets=(
             DimensionCallParameterSet(
                 dimension_reference=DimensionReference(element_name="is_instant"),
-                entity_path=(),
+                entity_path=(EntityReference("booking"),),
             ),
             DimensionCallParameterSet(
-                entity_path=(EntityReference(element_name="listing"),),
                 dimension_reference=DimensionReference(element_name="country"),
+                entity_path=(
+                    EntityReference("listing"),
+                    EntityReference("user"),
+                ),
             ),
         ),
         entity_call_parameter_sets=(),
@@ -43,14 +49,35 @@ def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
 
 def test_extract_time_dimension_call_parameter_sets() -> None:  # noqa: D
     parse_result = PydanticWhereFilter(
-        where_sql_template="""{{ time_dimension('created_at', 'month', entity_path=['listing']) }} = '2020-01-01'"""
+        where_sql_template=(
+            """{{ time_dimension('user__created_at', 'month', entity_path=['listing']) }} = '2020-01-01'"""
+        )
     ).call_parameter_sets
 
     assert parse_result == FilterCallParameterSets(
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
                 time_dimension_reference=TimeDimensionReference(element_name="created_at"),
-                entity_path=(EntityReference(element_name="listing"),),
+                entity_path=(
+                    EntityReference("listing"),
+                    EntityReference("user"),
+                ),
+                time_granularity=TimeGranularity.MONTH,
+            ),
+        )
+    )
+
+
+def test_extract_metric_time_dimension_call_parameter_sets() -> None:  # noqa: D
+    parse_result = PydanticWhereFilter(
+        where_sql_template=("""{{ time_dimension('metric_time', 'month') }} = '2020-01-01'""")
+    ).call_parameter_sets
+
+    assert parse_result == FilterCallParameterSets(
+        time_dimension_call_parameter_sets=(
+            TimeDimensionCallParameterSet(
+                time_dimension_reference=TimeDimensionReference(element_name="metric_time"),
+                entity_path=(),
                 time_granularity=TimeGranularity.MONTH,
             ),
         )


### PR DESCRIPTION
Resolves #123

### Description

With the invariant that all dimensions are associated with a primary entity, require the specification of the entity when using dimensions in the where filter.

e.g.

```
dimension('capacity_latest') > 10

->

dimension('listing__capacity_latest') > 10
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
