### PR TITLE
Improve Error Message for `metric_time` Issues in `WhereFilter`

### DIFF
--- a/dbt_semantic_interfaces/parsing/where_filter_parser.py
+++ b/dbt_semantic_interfaces/parsing/where_filter_parser.py
@@ -51,6 +51,12 @@ class WhereFilterParser:
         def _dimension_call(dimension_name: str, entity_path: Sequence[str] = ()) -> str:
             """Gets called by Jinja when rendering {{ dimension(...) }}."""
             group_by_item_name = DunderedNameFormatter.parse_name(dimension_name)
+            if is_metric_time_name(group_by_item_name.element_name):
+                raise ParseWhereFilterException(
+                    f"{METRIC_TIME_ELEMENT_NAME} is a time dimension, so it should be referenced using "
+                    f"TimeDimension(...)"
+                )
+
             if len(group_by_item_name.entity_links) != 1:
                 raise ParseWhereFilterException(
                     WhereFilterParser._exception_message_for_incorrect_format(dimension_name)
@@ -78,12 +84,9 @@ class WhereFilterParser:
             if is_metric_time_name(group_by_item_name.element_name):
                 if len(group_by_item_name.entity_links) != 0 or group_by_item_name.time_granularity is not None:
                     raise ParseWhereFilterException(
-                        WhereFilterParser._exception_message_for_incorrect_format(
-                            f"Name is in an incorrect format: {time_dimension_name} "
-                            f"When referencing {METRIC_TIME_ELEMENT_NAME}, the name should not have any dunders."
-                        )
+                        f"Name is in an incorrect format: {time_dimension_name} "
+                        f"When referencing {METRIC_TIME_ELEMENT_NAME}, the name should not have any dunders."
                     )
-
             else:
                 if len(group_by_item_name.entity_links) != 1 or group_by_item_name.time_granularity is not None:
                     raise ParseWhereFilterException(

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -1,9 +1,12 @@
 import logging
 
+import pytest
+
 from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     EntityCallParameterSet,
     FilterCallParameterSets,
+    ParseWhereFilterException,
     TimeDimensionCallParameterSet,
 )
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
@@ -104,3 +107,11 @@ def test_extract_entity_call_parameter_sets() -> None:  # noqa: D
             ),
         ),
     )
+
+
+def test_metric_time_in_dimension_call_error() -> None:  # noqa: D
+    with pytest.raises(ParseWhereFilterException, match="so it should be referenced using TimeDimension"):
+        assert (
+            PydanticWhereFilter(where_sql_template="{{ Dimension('metric_time') }} > '2020-01-01'").call_parameter_sets
+            is not None
+        )


### PR DESCRIPTION
### Description

`metric_time` is a time dimension, so it should be used with `TimeDimension` instead of `Dimension` in the `WhereFilter`. This improves the exception error message to make it easier for debugging.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
