### PR TITLE
Allow jsonschema 4 as a dependency

### DIFF
--- a/.changes/unreleased/Dependencies-20230814-191550.yaml
+++ b/.changes/unreleased/Dependencies-20230814-191550.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Allow jsonschema 4 as a dependency
+time: 2023-08-14T19:15:50.336500297+02:00
+custom:
+  Author: der-eismann
+  PR: "136"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic~=1.10",
-  "jsonschema~=3.0",
+  "jsonschema>=3.0,<5",
   "PyYAML~=6.0",
   "more-itertools~=8.0",
   "Jinja2~=3.0",


### PR DESCRIPTION
Resolves #135

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

This allows using this project with jsonschema 4 as well as 3. 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
