### PR TITLE
Bump main to 0.3.0a1 and clean up changelog

### DIFF
--- a/.changes/unreleased/Breaking Changes-20230516-160112.yaml
+++ b/.changes/unreleased/Breaking Changes-20230516-160112.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: The `objects` lib is now `implementations`
-time: 2023-05-16T16:01:12.470866-07:00
-custom:
-  Author: QMalcolm
-  Issue: None

--- a/.changes/unreleased/Breaking Changes-20230529-190627.yaml
+++ b/.changes/unreleased/Breaking Changes-20230529-190627.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Rename MetricType.MEASURE_PROXY -> MetricType.SIMPLE.
-time: 2023-05-29T19:06:27.182941-07:00
-custom:
-  Author: plypaul
-  Issue: "7"

--- a/.changes/unreleased/Breaking Changes-20230529-190835.yaml
+++ b/.changes/unreleased/Breaking Changes-20230529-190835.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Add a defaults section for SemanticModel and remove Dimension.is_primary.
-time: 2023-05-29T19:08:35.894545-07:00
-custom:
-  Author: plypaul
-  Issue: "50"

--- a/.changes/unreleased/Breaking Changes-20230615-152905.yaml
+++ b/.changes/unreleased/Breaking Changes-20230615-152905.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Replace EXPR metric type with DERIVED metric type.
-time: 2023-06-15T15:29:05.14149-07:00
-custom:
-  Author: plypaul
-  Issue: "54"

--- a/.changes/unreleased/Breaking Changes-20230615-153301.yaml
+++ b/.changes/unreleased/Breaking Changes-20230615-153301.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Change ratio metrics to be configured with input metrics instead of measures.
-time: 2023-06-15T15:33:01.417121-07:00
-custom:
-  Author: plypaul
-  Issue: "67"

--- a/.changes/unreleased/Breaking Changes-20230711-131951.yaml
+++ b/.changes/unreleased/Breaking Changes-20230711-131951.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Add call_parameter_sets to the WhereFilter Protocol
-time: 2023-07-11T13:19:51.806399-07:00
-custom:
-  Author: plypaul
-  Issue: "109"

--- a/.changes/unreleased/Breaking Changes-20230711-162541.yaml
+++ b/.changes/unreleased/Breaking Changes-20230711-162541.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Migrate from `checked_agg_time_dimension` to `checked_agg_time_dimension_for_measure`
-time: 2023-07-11T16:25:41.337984-07:00
-custom:
-  Author: QMalcolm
-  Issue: None

--- a/.changes/unreleased/Breaking Changes-20230724-135614.yaml
+++ b/.changes/unreleased/Breaking Changes-20230724-135614.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Add Primary Entity Field For Local Dimensions
-time: 2023-07-24T13:56:14.924647-07:00
-custom:
-  Author: plypaul
-  Issue: "123"

--- a/.changes/unreleased/Breaking Changes-20230727-165005.yaml
+++ b/.changes/unreleased/Breaking Changes-20230727-165005.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Require primary entities when specifying dimensions in the WhereFilter.
-time: 2023-07-27T16:50:05.653782-07:00
-custom:
-  Author: plypaul
-  Issue: "123"

--- a/.changes/unreleased/Breaking Changes-20230727-170535.yaml
+++ b/.changes/unreleased/Breaking Changes-20230727-170535.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Use CamelCase in the `WhereFilter` Template Calls
-time: 2023-07-27T17:05:35.447535-07:00
-custom:
-  Author: plypaul
-  Issue: "129"

--- a/.changes/unreleased/Dependencies-20230711-141108.yaml
+++ b/.changes/unreleased/Dependencies-20230711-141108.yaml
@@ -1,6 +1,0 @@
-kind: Dependencies
-body: elax Dependencies for Better Compatibility with Other Projects
-time: 2023-07-11T14:11:08.034583-07:00
-custom:
-  Author: plypaul
-  PR: "111"

--- a/.changes/unreleased/Dependencies-20230712-141113.yaml
+++ b/.changes/unreleased/Dependencies-20230712-141113.yaml
@@ -1,6 +1,0 @@
-kind: Dependencies
-body: Repinning ruff because we need to do work to move off of 0.0.260
-time: 2023-07-12T14:11:13.375068-07:00
-custom:
-  Author: QMalcolm
-  PR: None

--- a/.changes/unreleased/Features-20230515-155013.yaml
+++ b/.changes/unreleased/Features-20230515-155013.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Adding measure protocol and mixin
-time: 2023-05-15T15:50:13.828196-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "14"

--- a/.changes/unreleased/Features-20230515-161320.yaml
+++ b/.changes/unreleased/Features-20230515-161320.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: adding entity protocol
-time: 2023-05-15T16:13:20.492456-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "15"

--- a/.changes/unreleased/Features-20230516-100539.yaml
+++ b/.changes/unreleased/Features-20230516-100539.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add protocol for semantic manifest
-time: 2023-05-16T10:05:39.478821-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "17"

--- a/.changes/unreleased/Features-20230516-112250.yaml
+++ b/.changes/unreleased/Features-20230516-112250.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Adding metric protocol
-time: 2023-05-16T11:22:50.448901-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "18"

--- a/.changes/unreleased/Features-20230516-150352.yaml
+++ b/.changes/unreleased/Features-20230516-150352.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add Dimension and Metadata protocols
-time: 2023-05-16T15:03:52.645846-07:00
-custom:
-  Author: QMalcolm
-  Issue: "16"

--- a/.changes/unreleased/Features-20230516-162909.yaml
+++ b/.changes/unreleased/Features-20230516-162909.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add SemanticManifest protocol
-time: 2023-05-16T16:29:09.440525-07:00
-custom:
-  Author: QMalcolm
-  Issue: "19"

--- a/.changes/unreleased/Features-20230517-103947.yaml
+++ b/.changes/unreleased/Features-20230517-103947.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Adding DSI version number to semantic manifest
-time: 2023-05-17T10:39:47.542969-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "30"

--- a/.changes/unreleased/Features-20230606-130140.yaml
+++ b/.changes/unreleased/Features-20230606-130140.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Added new validation rule for validating SemanticModel.defaults
-time: 2023-06-06T13:01:40.461195-04:00
-custom:
-  Author: WilliamDee
-  Issue: metricflow#565

--- a/.changes/unreleased/Features-20230623-114625.yaml
+++ b/.changes/unreleased/Features-20230623-114625.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add Configuration Object to Semantic Manifest
-time: 2023-06-23T11:46:25.858497-07:00
-custom:
-  Author: plypaul
-  Issue: "94"

--- a/.changes/unreleased/Features-20230727-161128.yaml
+++ b/.changes/unreleased/Features-20230727-161128.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add new `PrimaryEntityDimensionPairs` validation rule
-time: 2023-07-27T16:11:28.794732-07:00
-custom:
-  Author: QMalcolm
-  Issue: "103"

--- a/.changes/unreleased/Features-20230728-090857.yaml
+++ b/.changes/unreleased/Features-20230728-090857.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add `WhereFiltersAreParseable` validation rule
-time: 2023-07-28T09:08:57.463411-07:00
-custom:
-  Author: QMalcolm
-  Issue: "120"

--- a/.changes/unreleased/Fixes-20230516-172635.yaml
+++ b/.changes/unreleased/Fixes-20230516-172635.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Updating measure protocol for new design. Goodbye mixins!
-time: 2023-05-16T17:26:35.770026-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "35"

--- a/.changes/unreleased/Fixes-20230516-175643.yaml
+++ b/.changes/unreleased/Fixes-20230516-175643.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Adding support for semantic model protocols
-time: 2023-05-16T17:56:43.638129-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "17"

--- a/.changes/unreleased/Fixes-20230630-100007.yaml
+++ b/.changes/unreleased/Fixes-20230630-100007.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Fix false positive error in semantic model defaults validation
-time: 2023-06-30T10:00:07.114321-07:00
-custom:
-  Author: tlento
-  Issue: None

--- a/.changes/unreleased/Fixes-20230714-130338.yaml
+++ b/.changes/unreleased/Fixes-20230714-130338.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Ensuring calls to `format_exception_only` aren't breaking in python 3.10+
-time: 2023-07-14T13:03:38.117362-07:00
-custom:
-  Author: QMalcolm
-  Issue: "117"

--- a/.changes/unreleased/Under the Hood-20230424-152251.yaml
+++ b/.changes/unreleased/Under the Hood-20230424-152251.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Adding Changie!
-time: 2023-04-24T15:22:51.939134-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "3"

--- a/.changes/unreleased/Under the Hood-20230501-154838.yaml
+++ b/.changes/unreleased/Under the Hood-20230501-154838.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Adding pre-commit
-time: 2023-05-01T15:48:38.323869-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "2"

--- a/.changes/unreleased/Under the Hood-20230501-162818.yaml
+++ b/.changes/unreleased/Under the Hood-20230501-162818.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Adding CONTRIBUTING.md
-time: 2023-05-01T16:28:18.436478-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "8"

--- a/.changes/unreleased/Under the Hood-20230501-164142.yaml
+++ b/.changes/unreleased/Under the Hood-20230501-164142.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Adding PR Template (& lint make command)
-time: 2023-05-01T16:41:42.359071-05:00
-custom:
-  Author: callum-mcdata
-  Issue: 25

--- a/.changes/unreleased/Under the Hood-20230505-120359.yaml
+++ b/.changes/unreleased/Under the Hood-20230505-120359.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Updating README
-time: 2023-05-05T12:03:59.520014-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "0"

--- a/.changes/unreleased/Under the Hood-20230515-124059.yaml
+++ b/.changes/unreleased/Under the Hood-20230515-124059.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Moving type enums to type_enums folder
-time: 2023-05-15T12:40:59.280851-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "0"

--- a/.changes/unreleased/Under the Hood-20230515-125335.yaml
+++ b/.changes/unreleased/Under the Hood-20230515-125335.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Adding a pytest ci flow
-time: 2023-05-15T12:53:35.607154-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "0"

--- a/.changes/unreleased/Under the Hood-20230516-102858.yaml
+++ b/.changes/unreleased/Under the Hood-20230516-102858.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Updating hatch build targets
-time: 2023-05-16T10:28:58.962876-05:00
-custom:
-  Author: callum-mcdata
-  Issue: "0"

--- a/.changes/unreleased/Under the Hood-20230523-125933.yaml
+++ b/.changes/unreleased/Under the Hood-20230523-125933.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Fix test fixture naming to use `semantic manifest`
-time: 2023-05-23T12:59:33.274243-07:00
-custom:
-  Author: QMalcolm
-  Issue: None

--- a/.changes/unreleased/Under the Hood-20230525-103207.yaml
+++ b/.changes/unreleased/Under the Hood-20230525-103207.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Update mypy to 1.3.0 and fix type issues.
-time: 2023-05-25T10:32:07.354916-07:00
-custom:
-  Author: plypaul
-  Issue: "70"

--- a/.changes/unreleased/Under the Hood-20230612-184706.yaml
+++ b/.changes/unreleased/Under the Hood-20230612-184706.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Better type_enums and protocols packaging for easier imports
-time: 2023-06-12T18:47:06.358724-07:00
-custom:
-  Author: QMalcolm
-  Issue: None

--- a/.changes/unreleased/Under the Hood-20230629-090156.yaml
+++ b/.changes/unreleased/Under the Hood-20230629-090156.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Remove `create_metric` from measure protocol
-time: 2023-06-29T09:01:56.627715-07:00
-custom:
-  Author: QMalcolm
-  Issue: "99"

--- a/.changes/unreleased/Under the Hood-20230720-104447.yaml
+++ b/.changes/unreleased/Under the Hood-20230720-104447.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Begin using SandboxedEnvironment for WhereFilterParser jinja usage
-time: 2023-07-20T10:44:47.429565-07:00
-custom:
-  Author: QMalcolm
-  Issue: "121"

--- a/.changes/unreleased/Under the Hood-20230726-094145.yaml
+++ b/.changes/unreleased/Under the Hood-20230726-094145.yaml
@@ -1,6 +1,0 @@
-kind: Under the Hood
-body: Switch `validate_semantic_manifest` to work in synchronous manner
-time: 2023-07-26T09:41:45.59555-07:00
-custom:
-  Author: QMalcolm
-  Issue: "125"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.1.0rc1"
+version = "0.3.0a1"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
### Description

Since we now have a 0.2.latest branch, we should update main to begin working towards the new alpha for any breaking changes. Additionally I've cleaned out the changelog. We probably should have compiled the changelog for 0.2.0 release which would have done this as part of that, but I don't know how to do that yet 🙃 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
