### PR TITLE
Fix TimeDimension parameter ordering

### DIFF
--- a/.changes/unreleased/Fixes-20230926-092650.yaml
+++ b/.changes/unreleased/Fixes-20230926-092650.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Change ordering of TimeDimension parameters to be backward compatible
+time: 2023-09-26T09:26:50.684682-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/dbt_semantic_interfaces/parsing/where_filter/where_filter_time_dimension.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/where_filter_time_dimension.py
@@ -42,9 +42,9 @@ class WhereFilterTimeDimensionFactory(ProtocolHint[QueryInterfaceTimeDimensionFa
         self,
         time_dimension_name: str,
         time_granularity_name: str,
+        entity_path: Sequence[str] = (),
         descending: Optional[bool] = None,
         date_part_name: Optional[str] = None,
-        entity_path: Sequence[str] = (),
     ) -> TimeDimensionStub:
         """Gets called by Jinja when rendering {{ TimeDimension(...) }}."""
         if descending is not None:

--- a/dbt_semantic_interfaces/protocols/query_interface.py
+++ b/dbt_semantic_interfaces/protocols/query_interface.py
@@ -61,9 +61,9 @@ class QueryInterfaceTimeDimensionFactory(Protocol):
         self,
         time_dimension_name: str,
         time_granularity_name: str,
+        entity_path: Sequence[str] = (),
         descending: Optional[bool] = None,
         date_part_name: Optional[str] = None,
-        entity_path: Sequence[str] = (),
     ) -> QueryInterfaceTimeDimension:
         """Create a TimeDimension."""
         pass


### PR DESCRIPTION
### Description

This PR fixes the ordering of the TimeDimension parameters so that entity_path is in the same position as it has been, right after time_granularity_name. This will prevent errors if a user attempts to use positional parameters to pass in entity_path, especially in the Jinja sandbox.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
