### PR TITLE
Migrate from JsonSchema 3 to JsonSchema 4 (#160)

### DIFF
--- a/.changes/unreleased/Dependencies-20230927-234903.yaml
+++ b/.changes/unreleased/Dependencies-20230927-234903.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Migrated jsonschema.RefResolver to referencing.Registry for jsonschema 4 compatibility
+time: 2023-09-27T23:49:03.729376567-04:00
+custom:
+  Author: 'codecae'
+  PR: "160"

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -1,4 +1,7 @@
-from jsonschema import RefResolver
+from typing import List, Tuple
+
+from referencing import Registry, Resource
+from referencing.jsonschema import DRAFT7
 
 from dbt_semantic_interfaces.parsing.schema_validator import SchemaValidator
 
@@ -315,8 +318,8 @@ schema_store = {
     time_spine_table_configuration_schema["$id"]: time_spine_table_configuration_schema,
 }
 
-
-resolver = RefResolver.from_schema(schema=metric_schema, store=schema_store)
-semantic_model_validator = SchemaValidator(semantic_model_schema, resolver=resolver)
-metric_validator = SchemaValidator(metric_schema, resolver=resolver)
-project_configuration_validator = SchemaValidator(project_configuration_schema, resolver=resolver)
+resources: List[Tuple[str, Resource]] = [(str(k), DRAFT7.create_resource(v)) for k, v in schema_store.items()]
+registry: Registry = Registry().with_resources(resources)
+semantic_model_validator = SchemaValidator(semantic_model_schema, registry=registry)
+metric_validator = SchemaValidator(metric_schema, registry=registry)
+project_configuration_validator = SchemaValidator(project_configuration_schema, registry=registry)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
   "pydantic~=1.10",
-  "jsonschema~=3.0",
+  "jsonschema~=4.0",
   "PyYAML~=6.0",
   "more-itertools~=8.0",
   "Jinja2~=3.0",


### PR DESCRIPTION
Resolves #135 

### Description

We're backporting jsonschema 4 to unblock people migrating from dbt-core 1.5 to 1.6. Most packages require jsonschema 4.x, something like 90% of people are using jsonschema 4.x, not migrating to it is actively blocking people. 

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
