### PR TITLE
Fixed error message for entity in filter spec and where clause

### DIFF
--- a/.changes/unreleased/Under the Hood-20231006-100304.yaml
+++ b/.changes/unreleased/Under the Hood-20231006-100304.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Fix error message for entity in filter spec and where parameter
+time: 2023-10-06T10:03:04.514682-05:00
+custom:
+  Author: DevonFulcher
+  Issue: None

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -84,10 +84,7 @@ class ParameterSetFactory:
         """Gets called by Jinja when rendering {{ Entity(...) }}."""
         group_by_item_name = DunderedNameFormatter.parse_name(entity_name)
         if len(group_by_item_name.entity_links) > 0 or group_by_item_name.time_granularity is not None:
-            ParameterSetFactory._exception_message_for_incorrect_format(
-                f"Name is in an incorrect format: {entity_name} "
-                f"When referencing entities, the name should not have any dunders (double underscores, or __)."
-            )
+            ParameterSetFactory._exception_message_for_incorrect_format(entity_name)
 
         return EntityCallParameterSet(
             entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),


### PR DESCRIPTION
### Description

Fixed error message for entity in where parameter and filter spec. The error message before this change would be oddly nested & duplicative. (Main version)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
