### PR TITLE
Throw exceptions on invalid entity names in filter and group by expressions

### DIFF
--- a/.changes/unreleased/Fixes-20231009-211057.yaml
+++ b/.changes/unreleased/Fixes-20231009-211057.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Throw an exception when invalid entity names are encountered in filter/group
+  by parameters
+time: 2023-10-09T21:10:57.456012-07:00
+custom:
+  Author: tlento
+  Issue: "172"

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -84,7 +84,10 @@ class ParameterSetFactory:
         """Gets called by Jinja when rendering {{ Entity(...) }}."""
         group_by_item_name = DunderedNameFormatter.parse_name(entity_name)
         if len(group_by_item_name.entity_links) > 0 or group_by_item_name.time_granularity is not None:
-            ParameterSetFactory._exception_message_for_incorrect_format(entity_name)
+            raise ParseWhereFilterException(
+                f"Entity name is in an incorrect format: '{entity_name}'. "
+                f"It should not contain any dunders (double underscores, or __)."
+            )
 
         return EntityCallParameterSet(
             entity_path=tuple(EntityReference(element_name=arg) for arg in entity_path),

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -137,3 +137,11 @@ def test_metric_time_in_dimension_call_error() -> None:  # noqa: D
             PydanticWhereFilter(where_sql_template="{{ Dimension('metric_time') }} > '2020-01-01'").call_parameter_sets
             is not None
         )
+
+
+def test_invalid_entity_name_error() -> None:
+    """Test to ensure we throw an error if an entity name is invalid."""
+    bad_entity_filter = PydanticWhereFilter(where_sql_template="{{ Entity('order_id__is_food_order' )}}")
+
+    with pytest.raises(ParseWhereFilterException, match="Entity name is in an incorrect format"):
+        bad_entity_filter.call_parameter_sets


### PR DESCRIPTION
The previous logic was simply calling an error string formatting function,
and one which would return an incorrect error message at that. This raises
an exception with an entity-specific name formatting error message.