### PR TITLE
Allow specification of filters as either lists or strings

### DIFF
--- a/.changes/unreleased/Features-20231009-210737.yaml
+++ b/.changes/unreleased/Features-20231009-210737.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Allow metric filters and saved query where properties to accept lists of filter
+  expressions
+time: 2023-10-09T21:07:37.978465-07:00
+custom:
+  Author: tlento
+  Issue: "147"

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from typing import Callable, Generator, List
+
+from typing_extensions import Self
+
 from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
 from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
@@ -12,14 +16,17 @@ from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import (
 
 
 class PydanticWhereFilter(PydanticCustomInputParser, HashableBaseModel):
-    """A filter applied to the data set containing measures, dimensions, identifiers relevant to the query.
+    """Pydantic implementation of a WhereFilter.
 
-    TODO: Clarify whether the filter applies to aggregated or un-aggregated data sets.
+    This specifies a templated SQl where expression, with templates allowing for extraction of dimensions and
+    entities (and, eventually, measures and metrics) to include in the filter itself. This filter will then
+    be applied to an input data set, either from an original input source or an intermediate subquery output.
 
-    The data set will contain dimensions as required by the query and the dimensions that a referenced in any of the
-    filters that are used in the definition of metrics.
+    The data set will contain entities and dimensions as referenced in the query along with the entities and dimensions
+    that are referenced in any of these filters, whether they are part of the query request or metric definition.
     """
 
+    # The where_sql_template field is used in PydanticWhereFilterIntersection.convert_legacy_input. Remove with caution.
     where_sql_template: str
 
     @classmethod
@@ -40,3 +47,65 @@ class PydanticWhereFilter(PydanticCustomInputParser, HashableBaseModel):
     @property
     def call_parameter_sets(self) -> FilterCallParameterSets:  # noqa: D
         return WhereFilterParser.parse_call_parameter_sets(self.where_sql_template)
+
+
+class PydanticWhereFilterIntersection(HashableBaseModel):
+    """Pydantic implementation of a WhereFilterIntersection."""
+
+    # This class can not have a property named `where_sql_template` without a parsing logic update
+    __WHERE_SQL_TEMPLATE_FIELD__ = "where_sql_template"
+    __WHERE_FILTERS_FIELD__ = "where_filters"
+
+    where_filters: List[PydanticWhereFilter]
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable[[PydanticParseableValueType], Self], None, None]:
+        """Pydantic magic method for allowing handling of arbitrary input on parse_obj invocation.
+
+        This class requires more subtle handling of input deserialized object types (dicts), and so it cannot
+        extend the common interface via _from_yaml_values.
+        """
+        yield cls._convert_legacy_and_yaml_input
+
+    @classmethod
+    def _convert_legacy_and_yaml_input(cls, input: PydanticParseableValueType) -> Self:
+        """Specifies raw input conversion rules to ensure serialized semantic manifests will parse correctly.
+
+        The original spec for where filters relied on a raw WhereFilter object, but this has now been updated to
+        expect an object containing a collection of WhereFilters.
+
+        The inputs for the original PydanticWhereFilter could have been either a bare string, a PydanticWhereFilter,
+        or a partially deserialized json object (i.e., dict) representation of the PydanticWhereFilter.
+
+        Consequently, we must support a variety of inputs and coerce them into the appropriate form, which is in general
+        a List[valid_where_filter_input] with valid_where_filter_input being one of the types described above. Here
+        are the operations:
+
+        Sequence transforms:
+        1. str -> {"where_filters": [input]}
+        2. PydanticWhereFilter -> {"where_filters": [input]}
+        3. {"where_sql_template": str} -> {"where_filters": [input]}
+
+        Object initializations (inputs requiring standard initialization, validated via the next pydantic operation):
+        1. List -> PydanticWhereFilterIntersection(where_filters=input)
+        2. other dicts -> PydanticWhereFilterIntersection(**input)
+
+        Identity transforms (no-ops, as these represent PydanticWhereFilterIntersection objects):
+        1. PydanticWhereFilterIntersection
+        """
+        has_legacy_keys = isinstance(input, dict) and cls.__WHERE_SQL_TEMPLATE_FIELD__ in input.keys()
+        is_legacy_where_filter = isinstance(input, str) or isinstance(input, PydanticWhereFilter) or has_legacy_keys
+
+        if is_legacy_where_filter:
+            return cls(where_filters=[input])
+        elif isinstance(input, list):
+            return cls(where_filters=input)
+        elif isinstance(input, dict):
+            return cls(**input)
+        elif isinstance(input, cls):
+            return input
+        else:
+            raise ValueError(
+                f"Expected input to be of type string, list, PydanticWhereFilter, PydanticWhereFilterIntersection, "
+                f"or dict but got {type(input)} with value {input}"
+            )

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -13,7 +13,7 @@ from dbt_semantic_interfaces.implementations.base import (
     PydanticParseableValueType,
 )
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
-    PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
 )
 from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
@@ -28,7 +28,7 @@ class PydanticMetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):
     """
 
     name: str
-    filter: Optional[PydanticWhereFilter]
+    filter: Optional[PydanticWhereFilterIntersection]
     alias: Optional[str]
     join_to_timespine: bool = False
     fill_nulls_with: Optional[int] = None
@@ -118,7 +118,7 @@ class PydanticMetricInput(HashableBaseModel):
     """Provides a pointer to a metric along with the additional properties used on that metric."""
 
     name: str
-    filter: Optional[PydanticWhereFilter]
+    filter: Optional[PydanticWhereFilterIntersection]
     alias: Optional[str]
     offset_window: Optional[PydanticMetricTimeWindow]
     offset_to_grain: Optional[TimeGranularity]
@@ -155,7 +155,7 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing):
     description: Optional[str]
     type: MetricType
     type_params: PydanticMetricTypeParams
-    filter: Optional[PydanticWhereFilter]
+    filter: Optional[PydanticWhereFilterIntersection]
     metadata: Optional[PydanticMetadata]
     label: Optional[str] = None
 

--- a/dbt_semantic_interfaces/implementations/saved_query.py
+++ b/dbt_semantic_interfaces/implementations/saved_query.py
@@ -9,7 +9,7 @@ from dbt_semantic_interfaces.implementations.base import (
     ModelWithMetadataParsing,
 )
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
-    PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
 )
 from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
 from dbt_semantic_interfaces.protocols import ProtocolHint
@@ -26,7 +26,7 @@ class PydanticSavedQuery(HashableBaseModel, ModelWithMetadataParsing, ProtocolHi
     name: str
     metrics: List[str]
     group_bys: List[str] = []
-    where: List[PydanticWhereFilter] = []
+    where: Optional[PydanticWhereFilterIntersection] = None
 
     description: Optional[str] = None
     metadata: Optional[PydanticMetadata] = None

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -139,6 +139,20 @@
             ],
             "type": "object"
         },
+        "filter_schema": {
+            "$id": "filter_schema",
+            "oneOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            ]
+        },
         "is-time-dimension": {
             "properties": {
                 "type": {
@@ -234,7 +248,7 @@
                             "type": "integer"
                         },
                         "filter": {
-                            "type": "string"
+                            "$ref": "#/definitions/filter_schema"
                         },
                         "join_to_timespine": {
                             "type": "boolean"
@@ -255,7 +269,7 @@
                     "type": "string"
                 },
                 "filter": {
-                    "type": "string"
+                    "$ref": "#/definitions/filter_schema"
                 },
                 "name": {
                     "type": "string"
@@ -277,7 +291,7 @@
                     "type": "string"
                 },
                 "filter": {
-                    "type": "string"
+                    "$ref": "#/definitions/filter_schema"
                 },
                 "label": {
                     "type": "string"
@@ -435,10 +449,7 @@
                     "type": "string"
                 },
                 "where": {
-                    "items": {
-                        "type": "string"
-                    },
-                    "type": "array"
+                    "$ref": "#/definitions/filter_schema"
                 }
             },
             "required": [

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -39,6 +39,17 @@ dimension_type_values += [x.lower() for x in dimension_type_values]
 
 time_dimension_type_values = ["TIME", "time"]
 
+filter_schema = {
+    "$id": "filter_schema",
+    "oneOf": [
+        {"type": "string"},
+        {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+    ],
+}
+
 metric_input_measure_schema = {
     "$id": "metric_input_measure_schema",
     "oneOf": [
@@ -47,7 +58,7 @@ metric_input_measure_schema = {
             "type": "object",
             "properties": {
                 "name": {"type": "string"},
-                "filter": {"type": "string"},
+                "filter": {"$ref": "filter_schema"},
                 "alias": {"type": "string"},
                 "join_to_timespine": {"type": "boolean"},
                 "fill_nulls_with": {"type": "integer"},
@@ -62,7 +73,7 @@ metric_input_schema = {
     "type": "object",
     "properties": {
         "name": {"type": "string"},
-        "filter": {"type": "string"},
+        "filter": {"$ref": "filter_schema"},
         "alias": {"type": "string"},
         "offset_window": {"type": "string"},
         "offset_to_grain": {"type": "string"},
@@ -218,7 +229,7 @@ metric_schema = {
         },
         "type": {"enum": metric_types_enum_values},
         "type_params": {"$ref": "metric_type_params"},
-        "filter": {"type": "string"},
+        "filter": {"$ref": "filter_schema"},
         "description": {"type": "string"},
         "label": {"type": "string"},
     },
@@ -292,10 +303,7 @@ saved_query_schema = {
             "type": "array",
             "items": {"type": "string"},
         },
-        "where": {
-            "type": "array",
-            "items": {"type": "string"},
-        },
+        "where": {"$ref": "filter_schema"},
         "label": {"type": "string"},
     },
     "required": ["name", "metrics"],
@@ -333,6 +341,7 @@ schema_store = {
     project_configuration_schema["$id"]: project_configuration_schema,
     saved_query_schema["$id"]: saved_query_schema,
     # Sub-object schemas
+    filter_schema["$id"]: filter_schema,
     metric_input_measure_schema["$id"]: metric_input_measure_schema,
     metric_type_params_schema["$id"]: metric_type_params_schema,
     entity_schema["$id"]: entity_schema,

--- a/dbt_semantic_interfaces/protocols/__init__.py
+++ b/dbt_semantic_interfaces/protocols/__init__.py
@@ -28,4 +28,7 @@ from dbt_semantic_interfaces.protocols.semantic_model import (  # noqa:F401
     SemanticModelDefaults,
     SemanticModelT,
 )
-from dbt_semantic_interfaces.protocols.where_filter import WhereFilter  # noqa:F401
+from dbt_semantic_interfaces.protocols.where_filter import (  # noqa:F401
+    WhereFilter,
+    WhereFilterIntersection,
+)

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from typing import Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.protocols.metadata import Metadata
-from dbt_semantic_interfaces.protocols.where_filter import WhereFilter
+from dbt_semantic_interfaces.protocols.where_filter import WhereFilterIntersection
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
 
@@ -23,7 +23,8 @@ class MetricInputMeasure(Protocol):
 
     @property
     @abstractmethod
-    def filter(self) -> Optional[WhereFilter]:  # noqa: D
+    def filter(self) -> Optional[WhereFilterIntersection]:
+        """Return the set of filters to apply prior to aggregating this input measure."""
         pass
 
     @property
@@ -80,7 +81,8 @@ class MetricInput(Protocol):
 
     @property
     @abstractmethod
-    def filter(self) -> Optional[WhereFilter]:  # noqa: D
+    def filter(self) -> Optional[WhereFilterIntersection]:
+        """Return the set of filters to apply prior to calculating this input metric."""
         pass
 
     @property
@@ -181,7 +183,8 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def filter(self) -> Optional[WhereFilter]:  # noqa: D
+    def filter(self) -> Optional[WhereFilterIntersection]:
+        """Return the set of filters to apply prior to calculating this metric."""
         pass
 
     @property

--- a/dbt_semantic_interfaces/protocols/saved_query.py
+++ b/dbt_semantic_interfaces/protocols/saved_query.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from typing import Optional, Protocol, Sequence
 
 from dbt_semantic_interfaces.protocols.metadata import Metadata
-from dbt_semantic_interfaces.protocols.where_filter import WhereFilter
+from dbt_semantic_interfaces.protocols.where_filter import WhereFilterIntersection
 
 
 class SavedQuery(Protocol):
@@ -35,7 +35,8 @@ class SavedQuery(Protocol):
 
     @property
     @abstractmethod
-    def where(self) -> Sequence[WhereFilter]:  # noqa: D
+    def where(self) -> Optional[WhereFilterIntersection]:
+        """Returns the intersection class containing any where filters specified in the saved query."""
         pass
 
     @property

--- a/dbt_semantic_interfaces/protocols/where_filter.py
+++ b/dbt_semantic_interfaces/protocols/where_filter.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol
+from typing import Protocol, Sequence
 
 from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
 
@@ -17,4 +17,26 @@ class WhereFilter(Protocol):
     @abstractmethod
     def call_parameter_sets(self) -> FilterCallParameterSets:
         """Describe calls like 'dimension(...)' in the SQL template."""
+        pass
+
+
+class WhereFilterIntersection(Protocol):
+    """A collection of filters to be applied to an input dataset.
+
+    This is an intersection, meaning each input row must pass all filters to be included in the output. It is the
+    equivalent of using an " AND " expression to join each filter expression in the input set into a single SQL
+    statement.
+
+    Although there is no formal contract around this, the expectation is these filters will be applied in a manner
+    that will produce output equivalent to running the WHERE clause, after dimensional joins but before measure
+    aggregations.
+
+    We use a protocol class here, instead of a simple Sequence, partly to centralize any custom parsing and processing
+    logic and partly because it is more descriptive as to the relationship between the filter elements in the set.
+    """
+
+    @property
+    @abstractmethod
+    def where_filters(self) -> Sequence[WhereFilter]:
+        """The collection of WhereFilters to be applied to the input data set."""
         pass

--- a/dbt_semantic_interfaces/protocols/where_filter.py
+++ b/dbt_semantic_interfaces/protocols/where_filter.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Protocol, Sequence
+from typing import Protocol, Sequence, Tuple
 
 from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
 
@@ -39,4 +39,14 @@ class WhereFilterIntersection(Protocol):
     @abstractmethod
     def where_filters(self) -> Sequence[WhereFilter]:
         """The collection of WhereFilters to be applied to the input data set."""
+        pass
+
+    @property
+    @abstractmethod
+    def filter_expression_parameter_sets(self) -> Sequence[Tuple[str, FilterCallParameterSets]]:
+        """Mapping from distinct filter expressions to the call parameter sets associated with them.
+
+        We use a tuple, rather than a Mapping, in case the call parameter sets may vary between
+        filter expression specifications.
+        """
         pass

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -8,9 +8,6 @@ import dateutil.parser
 from dbt_semantic_interfaces.implementations.elements.dimension import PydanticDimension
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
-from dbt_semantic_interfaces.implementations.filters.where_filter import (
-    PydanticWhereFilter,
-)
 from dbt_semantic_interfaces.implementations.metadata import (
     PydanticFileSlice,
     PydanticMetadata,
@@ -124,7 +121,6 @@ def metric_with_guaranteed_meta(
     name: str,
     type: MetricType,
     type_params: PydanticMetricTypeParams,
-    where_filter: Optional[PydanticWhereFilter] = None,
     metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
 ) -> PydanticMetric:
@@ -137,7 +133,7 @@ def metric_with_guaranteed_meta(
         description=description,
         type=type,
         type_params=type_params,
-        filter=where_filter,
+        filter=None,
         metadata=metadata,
     )
 

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -172,7 +172,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
 
         if metric.filter is not None:
             try:
-                metric.filter.call_parameter_sets
+                metric.filter.filter_expression_parameter_sets
             except Exception as e:
                 issues.append(
                     generate_exception_issue(
@@ -181,7 +181,6 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
                         context=context,
                         extras={
                             "traceback": "".join(traceback.format_tb(e.__traceback__)),
-                            "filter": metric.filter.where_sql_template,
                         },
                     )
                 )
@@ -190,7 +189,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
             measure = metric.type_params.measure
             if measure is not None and measure.filter is not None:
                 try:
-                    measure.filter.call_parameter_sets
+                    measure.filter.filter_expression_parameter_sets
                 except Exception as e:
                     issues.append(
                         generate_exception_issue(
@@ -200,7 +199,6 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
                             context=context,
                             extras={
                                 "traceback": "".join(traceback.format_tb(e.__traceback__)),
-                                "filter": measure.filter.where_sql_template,
                             },
                         )
                     )
@@ -208,7 +206,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
             numerator = metric.type_params.numerator
             if numerator is not None and numerator.filter is not None:
                 try:
-                    numerator.filter.call_parameter_sets
+                    numerator.filter.filter_expression_parameter_sets
                 except Exception as e:
                     issues.append(
                         generate_exception_issue(
@@ -217,7 +215,6 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
                             context=context,
                             extras={
                                 "traceback": "".join(traceback.format_tb(e.__traceback__)),
-                                "filter": numerator.filter.where_sql_template,
                             },
                         )
                     )
@@ -225,7 +222,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
             denominator = metric.type_params.denominator
             if denominator is not None and denominator.filter is not None:
                 try:
-                    denominator.filter.call_parameter_sets
+                    denominator.filter.filter_expression_parameter_sets
                 except Exception as e:
                     issues.append(
                         generate_exception_issue(
@@ -234,7 +231,6 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
                             context=context,
                             extras={
                                 "traceback": "".join(traceback.format_tb(e.__traceback__)),
-                                "filter": denominator.filter.where_sql_template,
                             },
                         )
                     )
@@ -242,7 +238,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
             for input_metric in metric.type_params.metrics or []:
                 if input_metric.filter is not None:
                     try:
-                        input_metric.filter.call_parameter_sets
+                        input_metric.filter.filter_expression_parameter_sets
                     except Exception as e:
                         issues.append(
                             generate_exception_issue(
@@ -252,7 +248,6 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
                                 context=context,
                                 extras={
                                     "traceback": "".join(traceback.format_tb(e.__traceback__)),
-                                    "filter": input_metric.filter.where_sql_template,
                                 },
                             )
                         )

--- a/dbt_semantic_interfaces/validations/saved_query.py
+++ b/dbt_semantic_interfaces/validations/saved_query.py
@@ -101,7 +101,9 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
     @validate_safely("Validate the where field in a saved query.")
     def _check_where(saved_query: SavedQuery) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
-        for where_filter in saved_query.where:
+        if saved_query.where is None:
+            return issues
+        for where_filter in saved_query.where.where_filters:
             try:
                 where_filter.call_parameter_sets
             except Exception as e:

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -2,6 +2,7 @@ import textwrap
 
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
 )
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInput,
@@ -66,7 +67,9 @@ def test_legacy_metric_input_measure_object_parsing() -> None:
     metric = build_result.semantic_manifest.metrics[0]
     assert metric.type_params.measure == PydanticMetricInputMeasure(
         name="legacy_measure_from_object",
-        filter=PydanticWhereFilter(where_sql_template="""{{ dimension('some_bool') }}"""),
+        filter=PydanticWhereFilterIntersection(
+            where_filters=[PydanticWhereFilter(where_sql_template="""{{ dimension('some_bool') }}""")]
+        ),
         join_to_timespine=True,
         fill_nulls_with=1,
     )
@@ -181,8 +184,12 @@ def test_ratio_metric_input_measure_object_parsing() -> None:
     metric = build_result.semantic_manifest.metrics[0]
     assert metric.type_params.numerator == PydanticMetricInput(
         name="numerator_metric_from_object",
-        filter=PydanticWhereFilter(
-            where_sql_template="some_number > 5",
+        filter=PydanticWhereFilterIntersection(
+            where_filters=[
+                PydanticWhereFilter(
+                    where_sql_template="some_number > 5",
+                )
+            ],
         ),
     )
     assert metric.type_params.denominator == PydanticMetricInput(name="denominator_metric_from_object")
@@ -328,8 +335,10 @@ def test_constraint_metric_parsing() -> None:
     metric = build_result.semantic_manifest.metrics[0]
     assert metric.name == "constraint_test"
     assert metric.type is MetricType.SIMPLE
-    assert metric.filter == PydanticWhereFilter(
-        where_sql_template="{{ dimension('some_dimension') }} IN ('value1', 'value2')"
+    assert metric.filter == PydanticWhereFilterIntersection(
+        where_filters=[
+            PydanticWhereFilter(where_sql_template="{{ dimension('some_dimension') }} IN ('value1', 'value2')")
+        ]
     )
 
 
@@ -364,7 +373,9 @@ def test_derived_metric_input_parsing() -> None:
     assert metric.type_params.metrics[1] == PydanticMetricInput(
         name="input_metric",
         alias="constrained_input_metric",
-        filter=PydanticWhereFilter(where_sql_template="input_metric < 10"),
+        filter=PydanticWhereFilterIntersection(
+            where_filters=[PydanticWhereFilter(where_sql_template="input_metric < 10")]
+        ),
     )
 
 

--- a/tests/parsing/test_saved_query_parsing.py
+++ b/tests/parsing/test_saved_query_parsing.py
@@ -131,5 +131,6 @@ def test_saved_query_where() -> None:
     build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
     assert len(build_result.semantic_manifest.saved_queries) == 1
     saved_query = build_result.semantic_manifest.saved_queries[0]
-    assert len(saved_query.where) == 1
-    assert where == saved_query.where[0].where_sql_template
+    assert saved_query.where is not None
+    assert len(saved_query.where.where_filters) == 1
+    assert where == saved_query.where.where_filters[0].where_sql_template

--- a/tests/parsing/test_where_filter_parsing.py
+++ b/tests/parsing/test_where_filter_parsing.py
@@ -3,6 +3,9 @@
 WhereFilter parsing operations can be fairly complex, as they must be able to accept input that is
 either a bare string filter expression or some partially or fully deserialized filter object type.
 
+In addition, due to the migration from WhereFilter to WhereFilterIntersection types, this tests the
+various conversion operations we will need to perform on semantic manifests defined out in the world.
+
 This module tests the various combinations we might encounter in the wild, with a particular focus
 on inputs to parse_obj or parse_raw, as that is what the pydantic models will generally encounter.
 """
@@ -11,6 +14,7 @@ on inputs to parse_obj or parse_raw, as that is what the pydantic models will ge
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
 )
 
 __BOOLEAN_EXPRESSION__ = "1 > 0"
@@ -20,6 +24,16 @@ class ModelWithWhereFilter(HashableBaseModel):
     """Defines a test model to allow for evaluation of different parsing modes for where filter expressions."""
 
     where_filter: PydanticWhereFilter
+
+
+class ModelWithWhereFilterIntersection(HashableBaseModel):
+    """Defines a test model to allow for evaluation of different parsing modes for where filter intersections.
+
+    This has the same schema, apart from the filter type, as the ModelWithWhereFilter in order to allow for
+    testing conversion from a WhereFilter to a WhereFilterIntersection.
+    """
+
+    where_filter: PydanticWhereFilterIntersection
 
 
 def test_partially_deserialized_object_string_parsing() -> None:
@@ -64,3 +78,60 @@ def test_serialize_deserialize_operations() -> None:
     deserialized = ModelWithWhereFilter.parse_raw(serialized)
 
     assert deserialized == base_obj
+
+
+def test_conversion_from_partially_deserialized_where_filter_string() -> None:
+    """Tests converting a partially deserialized ModelWithWhereFilter into a ModelWithWhereFilterIntersection.
+
+    This covers the case where the input is still a bare string, such as might happen in a raw YAML read.
+    """
+    obj = {"where_filter": __BOOLEAN_EXPRESSION__}
+    expected_conversion_output = PydanticWhereFilterIntersection(
+        where_filters=[PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)]
+    )
+
+    parsed_model = ModelWithWhereFilterIntersection.parse_obj(obj)
+
+    assert parsed_model.where_filter == expected_conversion_output
+
+
+def test_conversion_from_partially_deserialized_where_filter_object() -> None:
+    """Tests converting a partially deserialized WhereFilter into a WhereFilterIntersection."""
+    obj = {"where_filter": {"where_sql_template": __BOOLEAN_EXPRESSION__}}
+    expected_conversion_output = PydanticWhereFilterIntersection(
+        where_filters=[PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)]
+    )
+
+    parsed_model = ModelWithWhereFilterIntersection.parse_obj(obj)
+
+    assert parsed_model.where_filter == expected_conversion_output
+
+
+def test_conversion_from_injected_where_filter_object() -> None:
+    """Tests conversion from a PydanticWhereFilter instance, such as one inserted via a raw validator."""
+    obj = {"where_filter": PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)}
+    expected_conversion_output = PydanticWhereFilterIntersection(
+        where_filters=[PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)]
+    )
+
+    parsed_model = ModelWithWhereFilterIntersection.parse_obj(obj)
+
+    assert parsed_model.where_filter == expected_conversion_output
+
+
+def test_where_filter_intersection_from_partially_deserialized_list_of_strings() -> None:
+    """Tests parsing a PydanticWhereFilterIntersection when the input is a list of strings.
+
+    This simulates handling YAML input, which may be a list or other sequence of filters.
+    """
+    obj = {"where_filter": [__BOOLEAN_EXPRESSION__, "0 < 1"]}
+    expected_parsed_output = PydanticWhereFilterIntersection(
+        where_filters=[
+            PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__),
+            PydanticWhereFilter(where_sql_template="0 < 1"),
+        ]
+    )
+
+    parsed_model = ModelWithWhereFilterIntersection.parse_obj(obj)
+
+    assert parsed_model.where_filter == expected_parsed_output

--- a/tests/parsing/test_where_filter_parsing.py
+++ b/tests/parsing/test_where_filter_parsing.py
@@ -1,0 +1,66 @@
+"""Tests various where filter parsing conditions.
+
+WhereFilter parsing operations can be fairly complex, as they must be able to accept input that is
+either a bare string filter expression or some partially or fully deserialized filter object type.
+
+This module tests the various combinations we might encounter in the wild, with a particular focus
+on inputs to parse_obj or parse_raw, as that is what the pydantic models will generally encounter.
+"""
+
+
+from dbt_semantic_interfaces.implementations.base import HashableBaseModel
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+)
+
+__BOOLEAN_EXPRESSION__ = "1 > 0"
+
+
+class ModelWithWhereFilter(HashableBaseModel):
+    """Defines a test model to allow for evaluation of different parsing modes for where filter expressions."""
+
+    where_filter: PydanticWhereFilter
+
+
+def test_partially_deserialized_object_string_parsing() -> None:
+    """Tests parsing a where filter specified as a string within partially deserialized json object."""
+    obj = {"where_filter": __BOOLEAN_EXPRESSION__}
+
+    parsed_model = ModelWithWhereFilter.parse_obj(obj)
+
+    assert parsed_model.where_filter == PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)
+
+
+def test_partially_deserialized_object_parsing() -> None:
+    """Tests parsing a where filter that was serialized and then json decoded, but not fully parsed."""
+    obj = {"where_filter": {"where_sql_template": __BOOLEAN_EXPRESSION__}}
+
+    parsed_model = ModelWithWhereFilter.parse_obj(obj)
+
+    assert parsed_model.where_filter == PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)
+
+
+def test_injected_object_parsing() -> None:
+    """Tests parsing where, for some reason, a PydanticWhereFilter has been injected into the object.
+
+    This covers the (hopefully vanishingly rare) cases where some raw validator in a pydantic implementation
+    is updating the input object to convert something to a PydanticWhereFilter.
+    """
+    obj = {"where_filter": PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)}
+
+    parsed_model = ModelWithWhereFilter.parse_obj(obj)
+
+    assert parsed_model.where_filter == PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__)
+
+
+def test_serialize_deserialize_operations() -> None:
+    """Tests serializing and deserializing an object with a WhereFilter.
+
+    This should cover the most common scenarios, where we need to parse a serialized SemanticManifest.
+    """
+    base_obj = ModelWithWhereFilter(where_filter=PydanticWhereFilter(where_sql_template=__BOOLEAN_EXPRESSION__))
+
+    serialized = base_obj.json()
+    deserialized = ModelWithWhereFilter.parse_raw(serialized)
+
+    assert deserialized == base_obj

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -8,12 +8,15 @@ from dbt_semantic_interfaces.implementations.elements.dimension import (
 )
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
+)
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetricInput,
     PydanticMetricInputMeasure,
     PydanticMetricTimeWindow,
     PydanticMetricTypeParams,
-    PydanticWhereFilter,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -323,7 +326,8 @@ def test_where_filter_validations_bad_base_filter(  # noqa: D
 
     metric, _ = find_metric_with(manifest, lambda metric: metric.filter is not None)
     assert metric.filter is not None
-    metric.filter.where_sql_template = "{{ dimension('too', 'many', 'variables', 'to', 'handle') }}"
+    assert len(metric.filter.where_filters) > 0
+    metric.filter.where_filters[0].where_sql_template = "{{ dimension('too', 'many', 'variables', 'to', 'handle') }}"
     validator = SemanticManifestValidator[PydanticSemanticManifest]([WhereFiltersAreParseable()])
     with pytest.raises(SemanticManifestValidationException, match=f"trying to parse filter of metric `{metric.name}`"):
         validator.checked_validations(manifest)
@@ -338,8 +342,10 @@ def test_where_filter_validations_bad_measure_filter(  # noqa: D
         manifest, lambda metric: metric.type_params is not None and metric.type_params.measure is not None
     )
     assert metric.type_params.measure is not None
-    metric.type_params.measure.filter = PydanticWhereFilter(
-        where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}"
+    metric.type_params.measure.filter = PydanticWhereFilterIntersection(
+        where_filters=[
+            PydanticWhereFilter(where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}")
+        ]
     )
     validator = SemanticManifestValidator[PydanticSemanticManifest]([WhereFiltersAreParseable()])
     with pytest.raises(
@@ -358,8 +364,10 @@ def test_where_filter_validations_bad_numerator_filter(  # noqa: D
         manifest, lambda metric: metric.type_params is not None and metric.type_params.numerator is not None
     )
     assert metric.type_params.numerator is not None
-    metric.type_params.numerator.filter = PydanticWhereFilter(
-        where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}"
+    metric.type_params.numerator.filter = PydanticWhereFilterIntersection(
+        where_filters=[
+            PydanticWhereFilter(where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}")
+        ]
     )
     validator = SemanticManifestValidator[PydanticSemanticManifest]([WhereFiltersAreParseable()])
     with pytest.raises(
@@ -377,8 +385,10 @@ def test_where_filter_validations_bad_denominator_filter(  # noqa: D
         manifest, lambda metric: metric.type_params is not None and metric.type_params.denominator is not None
     )
     assert metric.type_params.denominator is not None
-    metric.type_params.denominator.filter = PydanticWhereFilter(
-        where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}"
+    metric.type_params.denominator.filter = PydanticWhereFilterIntersection(
+        where_filters=[
+            PydanticWhereFilter(where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}")
+        ]
     )
     validator = SemanticManifestValidator[PydanticSemanticManifest]([WhereFiltersAreParseable()])
     with pytest.raises(
@@ -400,8 +410,10 @@ def test_where_filter_validations_bad_input_metric_filter(  # noqa: D
     )
     assert metric.type_params.metrics is not None
     input_metric = metric.type_params.metrics[0]
-    input_metric.filter = PydanticWhereFilter(
-        where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}"
+    input_metric.filter = PydanticWhereFilterIntersection(
+        where_filters=[
+            PydanticWhereFilter(where_sql_template="{{ dimension('too', 'many', 'variables', 'to', 'handle') }}")
+        ]
     )
     validator = SemanticManifestValidator[PydanticSemanticManifest]([WhereFiltersAreParseable()])
     with pytest.raises(

--- a/tests/validations/test_saved_query.py
+++ b/tests/validations/test_saved_query.py
@@ -3,6 +3,7 @@ import logging
 
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
 )
 from dbt_semantic_interfaces.implementations.saved_query import PydanticSavedQuery
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
@@ -44,7 +45,9 @@ def test_invalid_metric_in_saved_query(  # noqa: D
             description="Example description.",
             metrics=["invalid_metric"],
             group_bys=["Dimension('booking__is_instant')"],
-            where=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
+            where=PydanticWhereFilterIntersection(
+                where_filters=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
+            ),
         ),
     ]
 
@@ -64,7 +67,9 @@ def test_invalid_where_in_saved_query(  # noqa: D
             description="Example description.",
             metrics=["bookings"],
             group_bys=["Dimension('booking__is_instant')"],
-            where=[PydanticWhereFilter(where_sql_template="{{ invalid_jinja }}")],
+            where=PydanticWhereFilterIntersection(
+                where_filters=[PydanticWhereFilter(where_sql_template="{{ invalid_jinja }}")],
+            ),
         ),
     ]
 
@@ -85,7 +90,9 @@ def test_invalid_group_by_element_in_saved_query(  # noqa: D
             description="Example description.",
             metrics=["bookings"],
             group_bys=["Dimension('booking__invalid_dimension')"],
-            where=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
+            where=PydanticWhereFilterIntersection(
+                where_filters=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
+            ),
         ),
     ]
 
@@ -106,7 +113,9 @@ def test_invalid_group_by_format_in_saved_query(  # noqa: D
             description="Example description.",
             metrics=["bookings"],
             group_bys=["invalid_format"],
-            where=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
+            where=PydanticWhereFilterIntersection(
+                where_filters=[PydanticWhereFilter(where_sql_template="{{ Dimension('booking__is_instant') }}")],
+            ),
         ),
     ]
 


### PR DESCRIPTION
In order to support more advanced forms of filter rendering for things like
predicate pushdown (see https://github.com/dbt-labs/metricflow/issues/747),
we need a way for users to indicate that a given subset of a complex filter
expression can be treated as an independent part of an intersection of
multiple filters.

Providing a construct that can accept, at the config level, a list as well as a string
gives us the flexibility we need to operate on sub-filters as independent entities
while maintaining backwards compatibility with the existing bare string filter
expressions in the wild today.

This PR does all of the necessary work for enabling filter lists in the interface
itself, by adding a filter container protocol class and corresponding Pydantic
implementation, along with test cases and json schema updates to allow
either list or string input in our sample YAML spec.

This does not appear to be backport-eligible, as the output property change
will not be backwards compatible in dbt-core 1.6 even though the Pydantic
object stack that MetricFlow uses internally should cover the discrepancy
in the query runtime.