### PR TITLE
Begin Validating Metric Names

### DIFF
--- a/.changes/unreleased/Breaking Changes-20231023-103143.yaml
+++ b/.changes/unreleased/Breaking Changes-20231023-103143.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Fixes bug where we weren't validating the names of metrics (which may break peoples current metric names)
+time: 2023-10-23T10:31:43.522179-07:00
+custom:
+  Author: QMalcolm
+  Issue: "181"

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -171,29 +171,25 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     @validate_safely(whats_being_done="checking model top level element names are sufficiently unique")
     def _validate_top_level_objects(semantic_manifest: SemanticManifest) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
-        object_info_tuples = []
         issues: List[ValidationIssue] = []
         if semantic_manifest.semantic_models:
+            semantic_model_names = set()
             for semantic_model in semantic_manifest.semantic_models:
                 context = SemanticModelContext(
                     file_context=FileContext.from_metadata(metadata=semantic_model.metadata),
                     semantic_model=SemanticModelReference(semantic_model_name=semantic_model.name),
                 )
-                object_info_tuples.append((semantic_model.name, "semantic model", context))
                 issues += UniqueAndValidNameRule.check_valid_name(name=semantic_model.name, context=context)
-
-        name_to_type: Dict[str, str] = {}
-        for name, type_, context in object_info_tuples:
-            if name in name_to_type:
-                issues.append(
-                    ValidationError(
-                        context=context,
-                        message=f"Can't use name `{name}` for a {type_} when it was already used for a "
-                        f"{name_to_type[name]}",
+                if semantic_model.name in semantic_model_names:
+                    issues.append(
+                        ValidationError(
+                            context=context,
+                            message=f"Can't use name `{semantic_model.name}` for a semantic model when it was already "
+                            "used for a semantic model",
+                        )
                     )
-                )
-            else:
-                name_to_type[name] = type_
+                else:
+                    semantic_model_names.add(semantic_model.name)
 
         if semantic_manifest.metrics:
             metric_names = set()

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -172,23 +172,17 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     def _validate_top_level_objects(semantic_manifest: SemanticManifest) -> List[ValidationIssue]:
         """Checks names of objects that are not nested."""
         object_info_tuples = []
+        issues: List[ValidationIssue] = []
         if semantic_manifest.semantic_models:
             for semantic_model in semantic_manifest.semantic_models:
-                object_info_tuples.append(
-                    (
-                        semantic_model.name,
-                        "semantic model",
-                        SemanticModelContext(
-                            file_context=FileContext.from_metadata(metadata=semantic_model.metadata),
-                            semantic_model=SemanticModelReference(semantic_model_name=semantic_model.name),
-                        ),
-                    )
+                context = SemanticModelContext(
+                    file_context=FileContext.from_metadata(metadata=semantic_model.metadata),
+                    semantic_model=SemanticModelReference(semantic_model_name=semantic_model.name),
                 )
+                object_info_tuples.append((semantic_model.name, "semantic model", context))
+                issues += UniqueAndValidNameRule.check_valid_name(name=semantic_model.name, context=context)
 
         name_to_type: Dict[str, str] = {}
-
-        issues: List[ValidationIssue] = []
-
         for name, type_, context in object_info_tuples:
             if name in name_to_type:
                 issues.append(
@@ -217,9 +211,6 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
                     )
                 else:
                     metric_names.add(metric.name)
-
-        for name, _, context in object_info_tuples:
-            issues += UniqueAndValidNameRule.check_valid_name(name=name, context=context)
 
         return issues
 

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -198,13 +198,15 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
         if semantic_manifest.metrics:
             metric_names = set()
             for metric in semantic_manifest.metrics:
+                metric_context = MetricContext(
+                    file_context=FileContext.from_metadata(metadata=metric.metadata),
+                    metric=MetricModelReference(metric_name=metric.name),
+                )
+                issues += UniqueAndValidNameRule.check_valid_name(name=metric.name, context=metric_context)
                 if metric.name in metric_names:
                     issues.append(
                         ValidationError(
-                            context=MetricContext(
-                                file_context=FileContext.from_metadata(metadata=metric.metadata),
-                                metric=MetricModelReference(metric_name=metric.name),
-                            ),
+                            context=metric_context,
                             message=f"Can't use name `{metric.name}` for a metric when it was already used for "
                             "a metric",
                         )

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -24,12 +24,10 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
     Top level elements include
     - Semantic Models
     - Metrics
-    - PydanticMetric Sets
-    - Dimension Sets
 
-    A name for any of these elements must be unique to all other top level elements
-    except metrics. PydanticMetric names only need to be unique in comparison to other metric
-    names.
+    For each top level element type we test for
+    - Name validity checking
+    - Name uniquness checking
 """
 
 

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -33,6 +33,27 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 """
 
 
+def test_semantic_model_name_validity(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+):
+    validator = SemanticManifestValidator[PydanticSemanticManifest](
+        [UniqueAndValidNameRule[PydanticSemanticManifest]()]
+    )
+
+    # Shouldn't raise an exception
+    validator.checked_validations(simple_semantic_manifest__with_primary_transforms)
+
+    # Should raise an exception
+    copied_manifest = deepcopy(simple_semantic_manifest__with_primary_transforms)
+    semantic_model = copied_manifest.semantic_models[0]
+    semantic_model.name = f"@{semantic_model.name}"
+    with pytest.raises(
+        SemanticManifestValidationException,
+        match=rf"Invalid name `{semantic_model.name}",
+    ):
+        validator.checked_validations(copied_manifest)
+
+
 def test_duplicate_semantic_model_name(  # noqa: D
     simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -61,7 +61,7 @@ def test_duplicate_semantic_model_name(  # noqa: D
     with pytest.raises(
         SemanticManifestValidationException,
         match=rf"Can't use name `{duplicated_semantic_model.name}` for a semantic model when it was already used for "
-        "a semantic model",
+        "another semantic model",
     ):
         SemanticManifestValidator[PydanticSemanticManifest](
             [UniqueAndValidNameRule[PydanticSemanticManifest]()]
@@ -97,7 +97,7 @@ def test_duplicate_metric_name(  # noqa:D
     model.metrics.append(duplicated_metric)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for a metric",
+        match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for another metric",
     ):
         SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -70,6 +70,27 @@ def test_duplicate_semantic_model_name(  # noqa: D
         ).checked_validations(model)
 
 
+def test_metric_name_validity(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+):
+    validator = SemanticManifestValidator[PydanticSemanticManifest](
+        [UniqueAndValidNameRule[PydanticSemanticManifest]()]
+    )
+
+    # Shouldn't raise an exception
+    validator.checked_validations(simple_semantic_manifest__with_primary_transforms)
+
+    # Should raise an exception
+    copied_manifest = deepcopy(simple_semantic_manifest__with_primary_transforms)
+    metric = copied_manifest.metrics[0]
+    metric.name = f"@{metric.name}"
+    with pytest.raises(
+        SemanticManifestValidationException,
+        match=rf"Invalid name `{metric.name}",
+    ):
+        validator.checked_validations(copied_manifest)
+
+
 def test_duplicate_metric_name(  # noqa:D
     simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:


### PR DESCRIPTION
Resolves #181

### Description

We've been saying that we require metric names to match the regex (must start with a letter, must be lower case, can't contain dunders, and etc), but we haven't actually been validating this. This PR updates the `UniqueAndValidNameRule` to actually begin validating metric names. It's worth noting that we plan on backporting this to 0.3.latest as not validating the name doesn't cause issues in this repo, but will cause issues in the semantic layer.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
