### PR TITLE
Validate Saved Query Names

### DIFF
--- a/.changes/unreleased/Features-20231023-102225.yaml
+++ b/.changes/unreleased/Features-20231023-102225.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Begin validating `SavedQuery` names
+time: 2023-10-23T10:22:25.686081-07:00
+custom:
+  Author: QMalcolm
+  Issue: "180"

--- a/dbt_semantic_interfaces/type_enums/__init__.py
+++ b/dbt_semantic_interfaces/type_enums/__init__.py
@@ -4,6 +4,7 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import (  # noqa:F401
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType  # noqa:F401
+from dbt_semantic_interfaces.type_enums.node_type import NodeType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.time_granularity import (  # noqa:F401
     TimeGranularity,
 )

--- a/dbt_semantic_interfaces/type_enums/__init__.py
+++ b/dbt_semantic_interfaces/type_enums/__init__.py
@@ -4,7 +4,9 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import (  # noqa:F401
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType  # noqa:F401
-from dbt_semantic_interfaces.type_enums.node_type import NodeType  # noqa:F401
+from dbt_semantic_interfaces.type_enums.semantic_manifest_node_type import (  # noqa:F401
+    SemanticManifestNodeType,
+)
 from dbt_semantic_interfaces.type_enums.time_granularity import (  # noqa:F401
     TimeGranularity,
 )

--- a/dbt_semantic_interfaces/type_enums/node_type.py
+++ b/dbt_semantic_interfaces/type_enums/node_type.py
@@ -1,0 +1,9 @@
+from dbt_semantic_interfaces.enum_extension import ExtendedEnum
+
+
+class NodeType(ExtendedEnum):
+    """Currently supported node types."""
+
+    METRIC = "metric"
+    SAVED_QUERY = "saved_query"
+    SEMANTIC_MODEL = "semantic_model"

--- a/dbt_semantic_interfaces/type_enums/semantic_manifest_node_type.py
+++ b/dbt_semantic_interfaces/type_enums/semantic_manifest_node_type.py
@@ -1,7 +1,7 @@
 from dbt_semantic_interfaces.enum_extension import ExtendedEnum
 
 
-class NodeType(ExtendedEnum):
+class SemanticManifestNodeType(ExtendedEnum):
     """Currently supported node types."""
 
     METRIC = "metric"

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -16,7 +16,7 @@ from dbt_semantic_interfaces.references import (
     ElementReference,
     SemanticModelElementReference,
 )
-from dbt_semantic_interfaces.type_enums import EntityType, TimeGranularity
+from dbt_semantic_interfaces.type_enums import EntityType, NodeType, TimeGranularity
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     SemanticManifestValidationRule,
@@ -170,7 +170,7 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     @validate_safely(whats_being_done="checking top level elements of a specific type have unique and valid names")
     def _validate_top_level_objects_of_type(
         objects: Union[List[SemanticModel], List[Metric], List[SavedQuery]],
-        object_type: str,
+        object_type: NodeType,
     ) -> List[ValidationIssue]:
         """Validates uniqeness and validaty of top level objects of singular type."""
         issues: List[ValidationIssue] = []
@@ -180,7 +180,7 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
             context = ValidationIssueContext(
                 file_context=FileContext.from_metadata(object.metadata),
                 object_name=object.name,
-                object_type=object_type,
+                object_type=object_type.value,
             )
             issues += UniqueAndValidNameRule.check_valid_name(name=object.name, context=context)
             if object.name in object_names:
@@ -203,14 +203,18 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
 
         issues.extend(
             UniqueAndValidNameRule._validate_top_level_objects_of_type(
-                semantic_manifest.semantic_models, "semantic model"
+                semantic_manifest.semantic_models, NodeType.SEMANTIC_MODEL
             )
         )
 
-        issues.extend(UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.metrics, "metric"))
+        issues.extend(
+            UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.metrics, NodeType.METRIC)
+        )
 
         issues.extend(
-            UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.saved_queries, "saved query")
+            UniqueAndValidNameRule._validate_top_level_objects_of_type(
+                semantic_manifest.saved_queries, NodeType.SAVED_QUERY
+            )
         )
 
         return issues

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -201,24 +201,17 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
         """Checks names of objects that are not nested."""
         issues: List[ValidationIssue] = []
 
-        if semantic_manifest.semantic_models:
-            issues.extend(
-                UniqueAndValidNameRule._validate_top_level_objects_of_type(
-                    semantic_manifest.semantic_models, "semantic model"
-                )
+        issues.extend(
+            UniqueAndValidNameRule._validate_top_level_objects_of_type(
+                semantic_manifest.semantic_models, "semantic model"
             )
+        )
 
-        if semantic_manifest.metrics:
-            issues.extend(
-                UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.metrics, "metric")
-            )
+        issues.extend(UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.metrics, "metric"))
 
-        if semantic_manifest.saved_queries:
-            issues.extend(
-                UniqueAndValidNameRule._validate_top_level_objects_of_type(
-                    semantic_manifest.saved_queries, "saved query"
-                )
-            )
+        issues.extend(
+            UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.saved_queries, "saved query")
+        )
 
         return issues
 

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -16,7 +16,11 @@ from dbt_semantic_interfaces.references import (
     ElementReference,
     SemanticModelElementReference,
 )
-from dbt_semantic_interfaces.type_enums import EntityType, NodeType, TimeGranularity
+from dbt_semantic_interfaces.type_enums import (
+    EntityType,
+    SemanticManifestNodeType,
+    TimeGranularity,
+)
 from dbt_semantic_interfaces.validations.validator_helpers import (
     FileContext,
     SemanticManifestValidationRule,
@@ -170,7 +174,7 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     @validate_safely(whats_being_done="checking top level elements of a specific type have unique and valid names")
     def _validate_top_level_objects_of_type(
         objects: Union[List[SemanticModel], List[Metric], List[SavedQuery]],
-        object_type: NodeType,
+        object_type: SemanticManifestNodeType,
     ) -> List[ValidationIssue]:
         """Validates uniqeness and validaty of top level objects of singular type."""
         issues: List[ValidationIssue] = []
@@ -203,17 +207,19 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
 
         issues.extend(
             UniqueAndValidNameRule._validate_top_level_objects_of_type(
-                semantic_manifest.semantic_models, NodeType.SEMANTIC_MODEL
+                semantic_manifest.semantic_models, SemanticManifestNodeType.SEMANTIC_MODEL
             )
         )
 
         issues.extend(
-            UniqueAndValidNameRule._validate_top_level_objects_of_type(semantic_manifest.metrics, NodeType.METRIC)
+            UniqueAndValidNameRule._validate_top_level_objects_of_type(
+                semantic_manifest.metrics, SemanticManifestNodeType.METRIC
+            )
         )
 
         issues.extend(
             UniqueAndValidNameRule._validate_top_level_objects_of_type(
-                semantic_manifest.saved_queries, NodeType.SAVED_QUERY
+                semantic_manifest.saved_queries, SemanticManifestNodeType.SAVED_QUERY
             )
         )
 

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -98,6 +98,18 @@ class FileContext(BaseModel):
         )
 
 
+class ValidationIssueContext(BaseModel):
+    """Generic validation Context."""
+
+    file_context: FileContext
+    object_type: str
+    object_name: str
+
+    def context_str(self) -> str:
+        """Human-readable stringified representation of the context."""
+        return f"with {self.object_type} `{self.object_name}` {self.file_context.context_str()}"
+
+
 class MetricContext(BaseModel):
     """The context class for validation issues involving metrics."""
 

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -176,6 +176,7 @@ ValidationContext = Union[
     SemanticModelContext,
     SemanticModelElementContext,
     SavedQueryContext,
+    ValidationIssueContext,
 ]
 
 

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -7,7 +7,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
-from dbt_semantic_interfaces.type_enums import NodeType
+from dbt_semantic_interfaces.type_enums import SemanticManifestNodeType
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
     SemanticManifestValidator,
 )
@@ -62,8 +62,9 @@ def test_duplicate_semantic_model_name(  # noqa: D
     model.semantic_models.append(duplicated_semantic_model)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_semantic_model.name}` for a {NodeType.SEMANTIC_MODEL} when it was "
-        f"already used for another {NodeType.SEMANTIC_MODEL}",
+        match=rf"Can't use name `{duplicated_semantic_model.name}` for a "
+        f"{SemanticManifestNodeType.SEMANTIC_MODEL} when it was "
+        f"already used for another {SemanticManifestNodeType.SEMANTIC_MODEL}",
     ):
         SemanticManifestValidator[PydanticSemanticManifest](
             [UniqueAndValidNameRule[PydanticSemanticManifest]()]
@@ -99,8 +100,9 @@ def test_duplicate_metric_name(  # noqa:D
     model.metrics.append(duplicated_metric)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_metric.name}` for a {NodeType.METRIC} when it was already used for "
-        f"another {NodeType.METRIC}",
+        match=rf"Can't use name `{duplicated_metric.name}` for a "
+        f"{SemanticManifestNodeType.METRIC} when it was already used for "
+        f"another {SemanticManifestNodeType.METRIC}",
     ):
         SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 
@@ -148,8 +150,9 @@ def test_duplicate_saved_query_name(  # noqa: D
     manifest.saved_queries.append(duplicated_saved_query)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_saved_query.name}` for a {NodeType.SAVED_QUERY} when it was already used "
-        f"for another {NodeType.SAVED_QUERY}",
+        match=rf"Can't use name `{duplicated_saved_query.name}` for a "
+        f"{SemanticManifestNodeType.SAVED_QUERY} when it was already used "
+        f"for another {SemanticManifestNodeType.SAVED_QUERY}",
     ):
         SemanticManifestValidator[PydanticSemanticManifest](
             [UniqueAndValidNameRule[PydanticSemanticManifest]()]

--- a/tests/validations/test_unique_valid_name.py
+++ b/tests/validations/test_unique_valid_name.py
@@ -7,6 +7,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
+from dbt_semantic_interfaces.type_enums import NodeType
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
     SemanticManifestValidator,
 )
@@ -61,8 +62,8 @@ def test_duplicate_semantic_model_name(  # noqa: D
     model.semantic_models.append(duplicated_semantic_model)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_semantic_model.name}` for a semantic model when it was already used for "
-        "another semantic model",
+        match=rf"Can't use name `{duplicated_semantic_model.name}` for a {NodeType.SEMANTIC_MODEL} when it was "
+        f"already used for another {NodeType.SEMANTIC_MODEL}",
     ):
         SemanticManifestValidator[PydanticSemanticManifest](
             [UniqueAndValidNameRule[PydanticSemanticManifest]()]
@@ -98,7 +99,8 @@ def test_duplicate_metric_name(  # noqa:D
     model.metrics.append(duplicated_metric)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_metric.name}` for a metric when it was already used for another metric",
+        match=rf"Can't use name `{duplicated_metric.name}` for a {NodeType.METRIC} when it was already used for "
+        f"another {NodeType.METRIC}",
     ):
         SemanticManifestValidator[PydanticSemanticManifest]([UniqueAndValidNameRule()]).checked_validations(model)
 
@@ -146,8 +148,8 @@ def test_duplicate_saved_query_name(  # noqa: D
     manifest.saved_queries.append(duplicated_saved_query)
     with pytest.raises(
         SemanticManifestValidationException,
-        match=rf"Can't use name `{duplicated_saved_query.name}` for a saved query when it was already used for "
-        "another saved query",
+        match=rf"Can't use name `{duplicated_saved_query.name}` for a {NodeType.SAVED_QUERY} when it was already used "
+        f"for another {NodeType.SAVED_QUERY}",
     ):
         SemanticManifestValidator[PydanticSemanticManifest](
             [UniqueAndValidNameRule[PydanticSemanticManifest]()]


### PR DESCRIPTION
Resolves #180

### Description

In #148 which went out in [0.3.0](https://github.com/dbt-labs/dbt-semantic-interfaces/releases/tag/v0.3.0), we forgot to add a validation for the saved query name. This PR adds that validation.

We plan on backporting this to 0.3.latest, which would break people who have saved queries defined with invalid name. Luckily the main thing that uses DSI is dbt-core, and dbt-core's latest production version (1.6.5) uses DSI 0.2.latest. DSI 0.3.0 is being used by dbt-core 1.7.0r1, but not many people are using that yet. Thus it's unlikely that many people have defined saved queries, and only a subset of those who have will have defined invalid names.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
