### PR TITLE
Revert "Update DSI version to 0.2.3 for backport release"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.2.3"
+version = "0.2.2"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Reverts dbt-labs/dbt-semantic-interfaces#201

There's a missing backport we need to pull in for 0.2.3