### PR TITLE
Backport typing extensions version update to 0.4

### DIFF
--- a/.changes/unreleased/Dependencies-20231026-122748.yaml
+++ b/.changes/unreleased/Dependencies-20231026-122748.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add typing-extensions>=4.0 requirement
+time: 2023-10-26T12:27:48.865653+03:00
+custom:
+  Author: Fatal1ty
+  PR: "194"

--- a/.changes/unreleased/Dependencies-20231026-161207.yaml
+++ b/.changes/unreleased/Dependencies-20231026-161207.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Restrict typing dependencies to 4.x
+time: 2023-10-26T16:12:07.392758-07:00
+custom:
+  Author: tlento
+  PR: "200"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "click>=7.0,<9.0",
   "python-dateutil~=2.0",
   "importlib_metadata~=6.0",
-  "typing-extensions~=4.0",
+  "typing-extensions>=4.4",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "click>=7.0,<9.0",
   "python-dateutil~=2.0",
   "importlib_metadata~=6.0",
-  "typing-extensions>=4.4",
+  "typing-extensions~=4.4",
 ]
 
 [build-system]


### PR DESCRIPTION
- Update typing-extensions to require versions >=4.4 (#194)
- Prevent typing-extensions from auto-updating to 5.x (#200)
