### PR TITLE
Update version to 0.4.1 for patch release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.4.0"
+version = "0.4.1"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
0.4.0 has a faulty dependency specification, so we need to deploy
0.4.1 with the relevant fix.
