### PR TITLE
Bug fix: compatible granularities for date_part

### DIFF
--- a/dbt_semantic_interfaces/type_enums/date_part.py
+++ b/dbt_semantic_interfaces/type_enums/date_part.py
@@ -54,4 +54,4 @@ class DatePart(ExtendedEnum):
     @property
     def compatible_granularities(self) -> List[TimeGranularity]:
         """Granularities that can be queried with this date part."""
-        return [granularity for granularity in TimeGranularity if granularity.to_int() >= self.to_int()]
+        return [granularity for granularity in TimeGranularity if granularity.to_int() <= self.to_int()]


### PR DESCRIPTION
### Description
Bug fix. This logic was reversed - we can only support granularities that are `<=` the date part requested. This did not cause any downstream issues because this method is only used in an error message.
I'll then need to put up a DSI dev release to get this change into MetricFlow.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
