### PR TITLE
Cleanup `main` and move to `0.5.0a1`

### DIFF
--- a/.changes/unreleased/Breaking Changes-20231023-103143.yaml
+++ b/.changes/unreleased/Breaking Changes-20231023-103143.yaml
@@ -1,6 +1,0 @@
-kind: Breaking Changes
-body: Fixes bug where we weren't validating the names of metrics (which may break peoples current metric names)
-time: 2023-10-23T10:31:43.522179-07:00
-custom:
-  Author: QMalcolm
-  Issue: "181"

--- a/.changes/unreleased/Features-20231023-102225.yaml
+++ b/.changes/unreleased/Features-20231023-102225.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Begin validating `SavedQuery` names
-time: 2023-10-23T10:22:25.686081-07:00
-custom:
-  Author: QMalcolm
-  Issue: "180"

--- a/.changes/unreleased/Features-20231024-162842.yaml
+++ b/.changes/unreleased/Features-20231024-162842.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Add exports configuration to YAML spec.
-time: 2023-10-24T16:28:42.013032-07:00
-custom:
-  Author: courtneyholcomb
-  Issue: "189"

--- a/.changes/unreleased/Features-20231024-171020.yaml
+++ b/.changes/unreleased/Features-20231024-171020.yaml
@@ -1,6 +1,0 @@
-kind: Features
-body: Support for date_part for Dimension & TimeDimension
-time: 2023-10-24T17:10:20.59653-05:00
-custom:
-  Author: DevonFulcher
-  Issue: "188"

--- a/.changes/unreleased/Fixes-20231025-173704.yaml
+++ b/.changes/unreleased/Fixes-20231025-173704.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Rename `SavedQuery.group_bys` to `SavedQuery.group_by`
-time: 2023-10-25T17:37:04.840909-07:00
-custom:
-  Author: plypaul
-  Issue: "192"

--- a/.changes/unreleased/Fixes-20231026-113940.yaml
+++ b/.changes/unreleased/Fixes-20231026-113940.yaml
@@ -1,6 +1,0 @@
-kind: Fixes
-body: Nest query params for saved queries.
-time: 2023-10-26T11:39:40.713149-07:00
-custom:
-  Author: courtneyholcomb
-  Issue: "197"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.4.0a1"
+version = "0.5.0a1"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Resolves #N/A

### Description
Main was in a confusing state in that its stated version was behind the latest released version. This was due to some laziness on my part 😬 After cutting the 0.4.latest branch for releasing `0.4.0`, main should have been updated in the ways that this PR does. 

*Note*
No changelog is required because this is essentially a metadata change. There is no feature, fix, external dependency bump, or under the hood logical change.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [ ] ~I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)~
