### PR TITLE
Added validations for conversion metrics

### DIFF
--- a/.changes/unreleased/Features-20231127-150021.yaml
+++ b/.changes/unreleased/Features-20231127-150021.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added validation for conversion metric configurations.
+time: 2023-11-27T15:00:21.734245-05:00
+custom:
+  Author: WilliamDee
+  Issue: "211"

--- a/dbt_semantic_interfaces/validations/semantic_manifest_validator.py
+++ b/dbt_semantic_interfaces/validations/semantic_manifest_validator.py
@@ -24,6 +24,7 @@ from dbt_semantic_interfaces.validations.measures import (
     SemanticModelMeasuresUniqueRule,
 )
 from dbt_semantic_interfaces.validations.metrics import (
+    ConversionMetricRule,
     CumulativeMetricRule,
     DerivedMetricRule,
     WhereFiltersAreParseable,
@@ -89,6 +90,7 @@ class SemanticManifestValidator(Generic[SemanticManifestT]):
         MetricLabelsRule[SemanticManifestT](),
         SemanticModelLabelsRule[SemanticManifestT](),
         EntityLabelsRule[SemanticManifestT](),
+        ConversionMetricRule[SemanticManifestT](),
     )
 
     def __init__(


### PR DESCRIPTION
Resolves #211

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Added validations for conversion metric configs.

#### Rules pulled from #211
1. entity must exist in both the semantic models that the base_measure and conversion_measure are in
2. base_measure and conversion_measure must be valid and can only be SUM(1) or COUNT or DISTINCT_COUNT measures
3. In constant_properties, both property that is stated must be referencing either an existing dimension/entity in the respective base/conversion semantic model

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
