### PR TITLE
fix: relax constraint on pydantic

### DIFF
--- a/.changes/unreleased/Dependencies-20231213-113016.yaml
+++ b/.changes/unreleased/Dependencies-20231213-113016.yaml
@@ -1,0 +1,7 @@
+kind: Dependencies
+body: Relax Pydantic dependency to allow DSI to be installed in environments alongside
+  Pydantic v1 or v2
+time: 2023-12-13T11:30:16.376387Z
+custom:
+  Author: bernardcooke53
+  PR: "227"

--- a/dbt_semantic_interfaces/dataclass_serialization.py
+++ b/dbt_semantic_interfaces/dataclass_serialization.py
@@ -19,8 +19,16 @@ from typing import (
     get_type_hints,
 )
 
-import pydantic
-from pydantic import BaseModel
+try:
+    import pydantic.v1 as pydantic
+except (ImportError, ModuleNotFoundError):
+    import pydantic
+
+try:
+    from pydantic.v1 import BaseModel  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import BaseModel  # pydantic v1
+
 from typing_extensions import TypeAlias
 
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects

--- a/dbt_semantic_interfaces/implementations/base.py
+++ b/dbt_semantic_interfaces/implementations/base.py
@@ -5,7 +5,10 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar, Generator, Generic, Type, TypeVar
 
-from pydantic import BaseModel, root_validator
+try:
+    from pydantic.v1 import BaseModel, root_validator  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import BaseModel, root_validator  # pydantic v1
 
 from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.parsing.yaml_loader import (

--- a/dbt_semantic_interfaces/implementations/export.py
+++ b/dbt_semantic_interfaces/implementations/export.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
+try:
+    from pydantic.v1 import Field  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import Field  # pydantic v1
+
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import List, Optional, Sequence
 
-from pydantic import Field
+try:
+    from pydantic.v1 import Field  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import Field  # pydantic v1
 
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.errors import ParsingException

--- a/dbt_semantic_interfaces/implementations/project_configuration.py
+++ b/dbt_semantic_interfaces/implementations/project_configuration.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import List, Optional
 
 from importlib_metadata import version
-from pydantic import validator
+
+try:
+    from pydantic.v1 import validator  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import validator  # pydantic v1
+
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import (

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Sequence
 
-from pydantic import validator
+try:
+    from pydantic.v1 import validator  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import validator  # pydantic v1
+
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import (

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -20,7 +20,11 @@ from typing import (
 )
 
 import click
-from pydantic import BaseModel, Extra
+
+try:
+    from pydantic.v1 import BaseModel, Extra  # pydantic v2
+except ModuleNotFoundError:
+    from pydantic import BaseModel, Extra  # pydantic v1
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
 from dbt_semantic_interfaces.protocols import Metadata, SemanticManifestT, SemanticModel

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
 plugins = pydantic.mypy
 
+[mypy-pydantic.*]
+ignore_missing_imports = True
+
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pydantic~=1.10",
+  "pydantic>=1.10,<3.0",
   "jsonschema~=4.0",
   "PyYAML~=6.0",
   "more-itertools>=8.0,<11.0",


### PR DESCRIPTION
This change allows DSI to be installed in environments alongside either pydantic v1 or v2

~Resolves~ Doesn't _resolve_ #134, but does make it less impactful to end users

### Description

Pydantic retained the v1 codebase in a `v1` namespace when upgrading to v2, per their [Migration Guide](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features). Therefore it's possible to make minimal code changes while allowing DSI to co-exist alongside either Pydantic v1 or v2.

According to the discussion on #217, this is an issue that might take some time to puzzle through fully given the need to support both Pydantic v1 and v2. This PR would alleviate the constraint on Pydantic without requiring additional testing or impact on end-users, so hopefully also relieves some pressure on the maintainers with regards to timescales. It might (I haven't checked for certain) enable a more gradual upgrade path, module-by-module.

The downside being that I've excluded pydantic from mypy checking for missing imports - I can change the code so that it isn't globally ignored, but I figured this would be an issue everywhere.
I completely understand if this gets closed as "not the right approach" - just thought I'd add what I can to help 🙂 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
