### PR TITLE
Add dependabot config for version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    groups:
+      all-dependencies:
+        # Dependabot uses a lot of heuristic matching, so it's not clear if we can separate prod from dev
+        exclude-patterns:
+          # We need to manually maintain all of our dbt and internal MetricFlow sub-package dependencies
+          - "dbt-*"
+          - "metricflow*"
+          # Manually exclude annoying-to-update dev dependencies
+          - "ruff"
+          - "pre-commit"
+          - "black"
+
+  # GitHub actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"


### PR DESCRIPTION
Instead of manually maintaining version dependencies, let's see
how the robot does.

This should be tuned to produce 1 big update PR per week. That
should minimize the initial noise while we figure out the
appropriate configurations for this tool.

Resolves #229 