### PR TITLE
Begin supporting Pydantic 2 (without dropping support for Pydantic 1)

### DIFF
--- a/.changes/unreleased/Dependencies-20231221-130418.yaml
+++ b/.changes/unreleased/Dependencies-20231221-130418.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Add support for pydantic 2 (and continue support for pydantic 1)
+time: 2023-12-21T13:04:18.792592-08:00
+custom:
+  Author: QMalcolm bernardcooke53 esciara
+  PR: "134"

--- a/.github/workflows/ci-pre-commit.yaml
+++ b/.github/workflows/ci-pre-commit.yaml
@@ -16,5 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python-env
+      # This step is necessary so long as we're allowing Pydantic 1 and Pydantic 2 via shimming
+      - name: Force Pydantic 1
+        run: hatch run dev-env:pip install "pydantic~=1.10"
       - name: Run Pre-commit Hooks
         run: hatch run dev-env:pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -11,11 +11,12 @@ on:
 
 jobs:
   pytest:
-    name: Run Tests / Python ${{ matrix.python-version }}
+    name: Run Tests / Python ${{ matrix.python-version }} / Pydantic ~= ${{ matrix.pydantic-version }}
 
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        pydantic-version: ["1.10", "2.0"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -26,5 +27,7 @@ jobs:
       - name: Install Hatch
         shell: bash
         run: pip3 install hatch
+      - name: Set pydantic Version ~= ${{ matrix.pydantic-version }}
+        run: hatch run dev-env:pip install "pydantic~=${{ matrix.pydantic-version }}"
       - name: Run Python Tests
         run: hatch run dev-env:pytest tests

--- a/dbt_semantic_interfaces/dataclass_serialization.py
+++ b/dbt_semantic_interfaces/dataclass_serialization.py
@@ -19,11 +19,10 @@ from typing import (
     get_type_hints,
 )
 
-import pydantic
-from pydantic import BaseModel
 from typing_extensions import TypeAlias
 
 from dbt_semantic_interfaces.pretty_print import pformat_big_objects
+from pydantic_shim import BaseModel, create_model
 
 logger = logging.getLogger(__name__)
 
@@ -347,7 +346,7 @@ class DataClassTypeToPydanticTypeConverter:  # noqa: D
         logger.debug(
             f"Creating Pydantic model {class_name} with fields:\n{pformat_big_objects(fields_for_pydantic_model)}"
         )
-        pydantic_model = pydantic.create_model(class_name, **fields_for_pydantic_model)  # type: ignore
+        pydantic_model = create_model(class_name, **fields_for_pydantic_model)  # type: ignore
         logger.debug(f"Finished creating Pydantic model {class_name}")
         logger.debug(f"Finished converting {dataclass_type.__name__} to a pydantic class")
         return pydantic_model

--- a/dbt_semantic_interfaces/implementations/base.py
+++ b/dbt_semantic_interfaces/implementations/base.py
@@ -5,13 +5,12 @@ import os
 from abc import ABC, abstractmethod
 from typing import Any, Callable, ClassVar, Generator, Generic, Type, TypeVar
 
-from pydantic import BaseModel, root_validator
-
 from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.parsing.yaml_loader import (
     PARSING_CONTEXT_KEY,
     ParsingContext,
 )
+from pydantic_shim import BaseModel, root_validator
 
 # Type alias for the implicit "Any" type used as input and output for Pydantic's parsing API
 PydanticParseableValueType = Any  # type: ignore[misc]

--- a/dbt_semantic_interfaces/implementations/export.py
+++ b/dbt_semantic_interfaces/implementations/export.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import Field
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
@@ -11,6 +10,7 @@ from dbt_semantic_interfaces.protocols.export import Export, ExportConfig
 from dbt_semantic_interfaces.type_enums.export_destination_type import (
     ExportDestinationType,
 )
+from pydantic_shim import Field
 
 
 class PydanticExportConfig(HashableBaseModel, ProtocolHint[ExportConfig]):

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import List, Optional, Sequence
 
-from pydantic import Field
-
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.errors import ParsingException
 from dbt_semantic_interfaces.implementations.base import (
@@ -22,6 +20,7 @@ from dbt_semantic_interfaces.type_enums import (
     MetricType,
     TimeGranularity,
 )
+from pydantic_shim import Field
 
 
 class PydanticMetricInputMeasure(PydanticCustomInputParser, HashableBaseModel):

--- a/dbt_semantic_interfaces/implementations/project_configuration.py
+++ b/dbt_semantic_interfaces/implementations/project_configuration.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import List, Optional
 
 from importlib_metadata import version
-from pydantic import validator
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import (
@@ -20,6 +19,7 @@ from dbt_semantic_interfaces.implementations.time_spine_table_configuration impo
 )
 from dbt_semantic_interfaces.protocols import ProtocolHint
 from dbt_semantic_interfaces.protocols.project_configuration import ProjectConfiguration
+from pydantic_shim import validator
 
 
 class PydanticProjectConfiguration(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[ProjectConfiguration]):

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, List, Optional, Sequence
 
-from pydantic import validator
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import (
@@ -25,6 +24,7 @@ from dbt_semantic_interfaces.references import (
     SemanticModelReference,
     TimeDimensionReference,
 )
+from pydantic_shim import validator
 
 
 class NodeRelation(HashableBaseModel):

--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -20,7 +20,6 @@ from typing import (
 )
 
 import click
-from pydantic import BaseModel, Extra
 
 from dbt_semantic_interfaces.implementations.base import FrozenBaseModel
 from dbt_semantic_interfaces.protocols import Metadata, SemanticManifestT, SemanticModel
@@ -30,6 +29,7 @@ from dbt_semantic_interfaces.references import (
     SemanticModelReference,
 )
 from dbt_semantic_interfaces.type_enums import DimensionType
+from pydantic_shim import BaseModel, Extra
 
 VALIDATE_SAFELY_ERROR_STR_TMPLT = ". Issue occurred in method `{method_name}` called with {arguments_str}"
 ValidationContextJSON = Dict[str, Union[str, int, None]]

--- a/pydantic_shim.py
+++ b/pydantic_shim.py
@@ -1,0 +1,26 @@
+from importlib.metadata import version
+
+pydantic_version = version("pydantic")
+# Pydantic uses semantic versioning, i.e. <major>.<minor>.<patch>, and we need to know the major
+pydantic_major = pydantic_version.split(".")[0]
+
+if pydantic_major == "1":
+    from pydantic import (  # type: ignore  # noqa
+        BaseModel,
+        Extra,
+        Field,
+        create_model,
+        root_validator,
+        validator,
+    )
+elif pydantic_major == "2":
+    from pydantic.v1 import (  # type: ignore  # noqa
+        BaseModel,
+        Extra,
+        Field,
+        create_model,
+        root_validator,
+        validator,
+    )
+else:
+    raise RuntimeError(f"Currently only pydantic 1 and 2 are supported, found pydantic {pydantic_version}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pydantic~=1.10",
+  "pydantic>=1.10,<3",
   "jsonschema~=4.0",
   "PyYAML~=6.0",
   "more-itertools>=8.0,<11.0",


### PR DESCRIPTION
Resolves #134 

### Description

After community and internal discussions we decided the best path forward was to support both Pydantic 1 and Pydantic 2 for the time being as we can't drop Pydantic 1 yet, but we also need to allow for Pydantic 2. We decided the tidiest way to do this would be via shimming. This PR adds the shim, directs pydantic imports to it, loosens the pydantic requirement to allow for pydantic 2, and ensure our testing checks both moving forward.

Also, I want shout out other PRs that worked to address this issue #217 and #227 as well as the people who worked on them (@esciara and @bernardcooke53 respectively). Their work was fundamental to making the changes that this PR contains, and they should be considered contributors on this effort.


### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
