### PR TITLE
Update CI to test Python 3.12 for dbt-semantic-interfaces

### DIFF
--- a/.changes/unreleased/Dependencies-20240213-203707.yaml
+++ b/.changes/unreleased/Dependencies-20240213-203707.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Increase test coverage to include Python 3.12
+time: 2024-02-13T20:37:07.912021-08:00
+custom:
+  Author: tlento
+  PR: "257"

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pydantic-version: ["1.10", "2.0"]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
In order to support Python 3.12 we need to ensure it is fully
tested on the local package, and that we can build and run all
of our tests as expected.

This updates the matrix test accordingly. Note no dependency
adjustment is required, as this package is already open-ended
with respect to maximum supported Python version. For now, we
leave it that way.
