### PR TITLE
Update developer CI actions and package metadata to include Python 3.12

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,13 +1,17 @@
 name: Setup Python env
 description: Install Python & Hatch
+inputs:
+  python-version:
+    description: Python version number to install
+    required: true
 
 runs:
   using: "composite"
   steps:
-  - name: Set up Python 3.9
+  - name: Set up Python ${{ inputs.python-version }}
     uses: actions/setup-python@v4
     with:
-      python-version: "3.9"
+      python-version: ${{ inputs.python-version }}
 
   - name: Install Hatch
     shell: bash

--- a/.github/workflows/ci-pre-commit.yaml
+++ b/.github/workflows/ci-pre-commit.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-python-env
+        with:
+          python-version: "3.9"
       # This step is necessary so long as we're allowing Pydantic 1 and Pydantic 2 via shimming
       - name: Force Pydantic 1
         run: hatch run dev-env:pip install "pydantic~=1.10"

--- a/.github/workflows/ci-pre-commit.yaml
+++ b/.github/workflows/ci-pre-commit.yaml
@@ -12,12 +12,16 @@ on:
 jobs:
   pre-commit:
     name: Run Pre-commit Hooks
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-python-env
+      - name: Setup Python ${{ matrix.python-version }} env
+        uses: ./.github/actions/setup-python-env
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
       # This step is necessary so long as we're allowing Pydantic 1 and Pydantic 2 via shimming
       - name: Force Pydantic 1
         run: hatch run dev-env:pip install "pydantic~=1.10"

--- a/.github/workflows/ci-pytest.yaml
+++ b/.github/workflows/ci-pytest.yaml
@@ -20,13 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Set up Python ${{ matrix.python-version }} env
+        uses: ./.github/actions/setup-python-env
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Hatch
-        shell: bash
-        run: pip3 install hatch
       - name: Set pydantic Version ~= ${{ matrix.pydantic-version }}
         run: hatch run dev-env:pip install "pydantic~=${{ matrix.pydantic-version }}"
       - name: Run Python Tests

--- a/.github/workflows/ci-schema-consistency.yaml
+++ b/.github/workflows/ci-schema-consistency.yaml
@@ -15,15 +15,18 @@ on:
 jobs:
   json-schema-consistency-check:
     name: Schema Consistency Check
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - name: Check-out the repo
         uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.python-version }} env
         uses: ./.github/actions/setup-python-env
         with:
-          python-version: "3.9"
+          python-version: ${{ matrix.python-version }}
 
       - name: Generate JSON Schema
         run: make json_schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]


### PR DESCRIPTION
The initial PR for updating to Python 3.12 was missing a metadata update
for publishing supported version ranges to package distributions.

While updating this I noticed that other actions were explicitly testing against
Python 3.9 due to a dependency on an old composite action hard-coded to
3.9 from way back when the Transform product only supported that Python version.
I've taken the liberty of updating all of these actions to use matrix strategies that
test either the complete set of supported Python versions (unit tests) or the min and
max supported Python versions (development-focused actions).