### PR TITLE
Update dbt-semantic-interfaces to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.5.0a3"
+version = "0.5.0"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
We're ready to release 0.5.0, so this updates the patch to remove the pre-release.