### PR TITLE
Update dbt-semantic-interfaces to 0.6.0dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.5.0a3"
+version = "0.6.0dev0"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
Now that 0.5.0 has been deployed from the 0.5.latest branch, we
should update the version on main to the next base dev target.

We use 0.6.0dev0 because starting at 0 or 1 makes sense but
starting at 2 does not, and I have no idea if the next person
will update the version before deployment.