### PR TITLE
Interface for `SavedQueryDependencyResolver`

### DIFF
--- a/dbt_semantic_interfaces/experimental/saved_query_dependency_resolver.py
+++ b/dbt_semantic_interfaces/experimental/saved_query_dependency_resolver.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from dbt_semantic_interfaces.protocols import SemanticManifest
+from dbt_semantic_interfaces.references import (
+    SavedQueryReference,
+    SemanticModelReference,
+)
+
+
+@dataclass(frozen=True)
+class SavedQueryDependencySet:
+    """The dependencies of a saved query.
+
+    The primary use case is to handle creation of the cache item associated with the saved query. The dependencies
+    listed in this class must be up-to-date before the cache associated with the saved query can be created. Otherwise,
+    running the export / creating the cache may create a cache item that is out-of-date / unusable.
+    """
+
+    # A human-readable description for logging purposes.
+    description: Optional[str]
+    # The semantic models that the saved query depends on.
+    semantic_model_references: Tuple[SemanticModelReference, ...]
+
+
+class SavedQueryDependencyResolver:
+    """Resolves the dependencies of a saved query. Also see `SavedQueryDependencySet`."""
+
+    def __init__(self, semantic_manifest: SemanticManifest) -> None:  # noqa: D
+        self._semantic_manifest = semantic_manifest
+
+    def resolve_dependencies(self, saved_query_reference: SavedQueryReference) -> SavedQueryDependencySet:
+        """Return the dependencies of the given saved query in the manifest."""
+        return SavedQueryDependencySet(
+            description=(
+                f"Dependencies for saved query {repr(saved_query_reference.saved_query_name)} include all semantic "
+                f"models as a temporary result until the complete implementation is in place."
+            ),
+            semantic_model_references=tuple(
+                sorted(semantic_model.reference for semantic_model in self._semantic_manifest.semantic_models)
+            ),
+        )

--- a/dbt_semantic_interfaces/references.py
+++ b/dbt_semantic_interfaces/references.py
@@ -66,7 +66,7 @@ class ModelReference(SerializableDataclass):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class SemanticModelReference(ModelReference):
     """A reference to a semantic model definition in the model."""
 
@@ -106,3 +106,10 @@ class MetricModelReference(ModelReference):
     """A reference to a metric definition in the model."""
 
     metric_name: str
+
+
+@dataclass(frozen=True, order=True)
+class SavedQueryReference:
+    """A reference to a saved query in the semantic manifest."""
+
+    saved_query_name: str

--- a/tests/experimental/test_saved_query_dependency_resolver.py
+++ b/tests/experimental/test_saved_query_dependency_resolver.py
@@ -1,0 +1,35 @@
+import pytest
+
+from dbt_semantic_interfaces.experimental.saved_query_dependency_resolver import (
+    SavedQueryDependencyResolver,
+)
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.references import (
+    SavedQueryReference,
+    SemanticModelReference,
+)
+
+
+@pytest.fixture(scope="session")
+def resolver(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> SavedQueryDependencyResolver:
+    return SavedQueryDependencyResolver(simple_semantic_manifest__with_primary_transforms)
+
+
+def test_saved_query_dependency_resolver(resolver: SavedQueryDependencyResolver) -> None:  # noqa: D
+    dependency_set = resolver.resolve_dependencies(SavedQueryReference("p0_booking"))
+    assert tuple(dependency_set.semantic_model_references) == (
+        SemanticModelReference(semantic_model_name="accounts_source"),
+        SemanticModelReference(semantic_model_name="bookings_source"),
+        SemanticModelReference(semantic_model_name="companies"),
+        SemanticModelReference(semantic_model_name="id_verifications"),
+        SemanticModelReference(semantic_model_name="listings_latest"),
+        SemanticModelReference(semantic_model_name="lux_listing_mapping"),
+        SemanticModelReference(semantic_model_name="revenue"),
+        SemanticModelReference(semantic_model_name="users_ds_source"),
+        SemanticModelReference(semantic_model_name="users_latest"),
+        SemanticModelReference(semantic_model_name="views_source"),
+    )


### PR DESCRIPTION
### Description

A resolver that can figure out the semantic models used by a saved query is useful for generating the execution DAG for exports / caching.

A complete dependency resolver for is complex due to recursive metric definitions, cascading filters, ambiguous group-by-items, etc. so cutting out this draft PR ahead of that to demonstrate the interface.

One of the potential longer-term solutions is a separate package that handles semantic-related resolution. The separate package would then be a dependency of the `metricflow` package.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
