### PR TITLE
Add sub-daily `TimeGranularity` options

### DIFF
--- a/.changes/unreleased/Features-20240531-145904.yaml
+++ b/.changes/unreleased/Features-20240531-145904.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add sub-daily TimeGranularity options.
+time: 2024-05-31T14:59:04.804239-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "280"

--- a/dbt_semantic_interfaces/naming/dundered.py
+++ b/dbt_semantic_interfaces/naming/dundered.py
@@ -64,7 +64,7 @@ class StructuredDunderedName:
     def dundered_name(self) -> str:
         """Return the full name form. e.g. ds or listing__ds__month."""
         items = [entity_reference.element_name for entity_reference in self.entity_links] + [self.element_name]
-        if self.time_granularity and self.time_granularity != TimeGranularity.DAY:
+        if self.time_granularity:
             items.append(self.time_granularity.value)
         return DUNDER.join(items)
 

--- a/dbt_semantic_interfaces/type_enums/time_granularity.py
+++ b/dbt_semantic_interfaces/type_enums/time_granularity.py
@@ -13,6 +13,12 @@ class TimeGranularity(ExtendedEnum):
 
     # Names are used in parameters to DATE_TRUNC, so don't change them.
     # Values are used to convert user supplied strings to enums.
+    NANOSECOND = "nanosecond"
+    MICROSECOND = "microsecond"
+    MILLISECOND = "millisecond"
+    SECOND = "second"
+    MINUTE = "minute"
+    HOUR = "hour"
     DAY = "day"
     WEEK = "week"
     MONTH = "month"
@@ -21,6 +27,18 @@ class TimeGranularity(ExtendedEnum):
 
     def to_int(self) -> int:
         """Convert to an int so that the size of the granularity can be easily compared."""
+        if self is TimeGranularity.NANOSECOND:
+            return 4
+        elif self is TimeGranularity.MICROSECOND:
+            return 5
+        elif self is TimeGranularity.MILLISECOND:
+            return 6
+        elif self is TimeGranularity.SECOND:
+            return 7
+        elif self is TimeGranularity.MINUTE:
+            return 8
+        elif self is TimeGranularity.HOUR:
+            return 9
         if self is TimeGranularity.DAY:
             return 10
         elif self is TimeGranularity.WEEK:


### PR DESCRIPTION
Resolves #280

### Description
Add support for sub-day `TimeGranularity` options: hour, minute, second, millisecond, microsecond, and nanosecond.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
