### PR TITLE
Add & validate cumulative type params & period agg

### DIFF
--- a/.changes/unreleased/Features-20240610-130344.yaml
+++ b/.changes/unreleased/Features-20240610-130344.yaml
@@ -1,0 +1,7 @@
+kind: Features
+body: Add period_agg for cumulative metrics and move cumulative type params into a
+  nested object.
+time: 2024-06-10T13:03:44.983419-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "289"

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -21,6 +21,7 @@ from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums import (
     ConversionCalculationType,
     MetricType,
+    PeriodAggregation,
     TimeGranularity,
 )
 from dsi_pydantic_shim import Field
@@ -158,6 +159,14 @@ class PydanticConversionTypeParams(HashableBaseModel):
     constant_properties: Optional[List[PydanticConstantPropertyInput]]
 
 
+class PydanticCumulativeTypeParams(HashableBaseModel):
+    """Type params to provide context for cumulative metrics properties."""
+
+    window: Optional[PydanticMetricTimeWindow]
+    grain_to_date: Optional[TimeGranularity]
+    period_agg: Optional[PeriodAggregation]
+
+
 class PydanticMetricTypeParams(HashableBaseModel):
     """Type params add additional context to certain metric types (the context depends on the metric type)."""
 
@@ -165,10 +174,11 @@ class PydanticMetricTypeParams(HashableBaseModel):
     numerator: Optional[PydanticMetricInput]
     denominator: Optional[PydanticMetricInput]
     expr: Optional[str]
-    window: Optional[PydanticMetricTimeWindow]
-    grain_to_date: Optional[TimeGranularity]
+    window: Optional[PydanticMetricTimeWindow]  # warn if set
+    grain_to_date: Optional[TimeGranularity]  # warn if set
     metrics: Optional[List[PydanticMetricInput]]
     conversion_type_params: Optional[PydanticConversionTypeParams]
+    cumulative_type_params: Optional[PydanticCumulativeTypeParams]
 
     input_measures: List[PydanticMetricInputMeasure] = Field(default_factory=list)
 

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -164,7 +164,7 @@ class PydanticCumulativeTypeParams(HashableBaseModel):
 
     window: Optional[PydanticMetricTimeWindow]
     grain_to_date: Optional[TimeGranularity]
-    period_agg: Optional[PeriodAggregation]
+    period_agg: PeriodAggregation = PeriodAggregation.FIRST
 
 
 class PydanticMetricTypeParams(HashableBaseModel):

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -174,8 +174,8 @@ class PydanticMetricTypeParams(HashableBaseModel):
     numerator: Optional[PydanticMetricInput]
     denominator: Optional[PydanticMetricInput]
     expr: Optional[str]
-    window: Optional[PydanticMetricTimeWindow]  # warn if set
-    grain_to_date: Optional[TimeGranularity]  # warn if set
+    window: Optional[PydanticMetricTimeWindow]
+    grain_to_date: Optional[TimeGranularity]
     metrics: Optional[List[PydanticMetricInput]]
     conversion_type_params: Optional[PydanticConversionTypeParams]
     cumulative_type_params: Optional[PydanticCumulativeTypeParams]

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -104,11 +104,11 @@
                 },
                 "period_agg": {
                     "enum": [
-                        "START",
-                        "END",
+                        "FIRST",
+                        "LAST",
                         "AVERAGE",
-                        "start",
-                        "end",
+                        "first",
+                        "last",
                         "average"
                     ]
                 },

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -72,6 +72,53 @@
             ],
             "type": "object"
         },
+        "cumulative_type_params_schema": {
+            "$id": "cumulative_type_params_schema",
+            "additionalProperties": false,
+            "properties": {
+                "grain_to_date": {
+                    "enum": [
+                        "NANOSECOND",
+                        "MICROSECOND",
+                        "MILLISECOND",
+                        "SECOND",
+                        "MINUTE",
+                        "HOUR",
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                        "nanosecond",
+                        "microsecond",
+                        "millisecond",
+                        "second",
+                        "minute",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                        "quarter",
+                        "year"
+                    ]
+                },
+                "period_agg": {
+                    "enum": [
+                        "START",
+                        "END",
+                        "AVERAGE",
+                        "start",
+                        "end",
+                        "average"
+                    ]
+                },
+                "window": {
+                    "type": "string"
+                }
+            },
+            "required": [],
+            "type": "object"
+        },
         "dimension_schema": {
             "$id": "dimension_schema",
             "additionalProperties": false,
@@ -455,6 +502,9 @@
             "properties": {
                 "conversion_type_params": {
                     "$ref": "#/definitions/conversion_type_params_schema"
+                },
+                "cumulative_type_params": {
+                    "$ref": "#/definitions/cumulative_type_params_schema"
                 },
                 "denominator": {
                     "$ref": "#/definitions/metric_input_measure_schema"

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -57,6 +57,9 @@ time_dimension_type_values = ["TIME", "time"]
 export_destination_type_values = ["TABLE", "VIEW"]
 export_destination_type_values += [x.lower() for x in export_destination_type_values]
 
+period_agg_values = ["START", "END", "AVERAGE"]
+period_agg_values += [x.lower() for x in period_agg_values]
+
 
 filter_schema = {
     "$id": "filter_schema",
@@ -115,6 +118,18 @@ conversion_type_params_schema = {
     "required": ["base_measure", "conversion_measure", "entity"],
 }
 
+cumulative_type_params_schema = {
+    "$id": "cumulative_type_params_schema",
+    "type": "object",
+    "properties": {
+        "window": {"type": "string"},
+        "grain_to_date": {"enum": time_granularity_values},
+        "period_agg": {"enum": period_agg_values},
+    },
+    "additionalProperties": False,
+    "required": [],
+}
+
 constant_property_input_schema = {
     "$id": "constant_property_input_schema",
     "type": "object",
@@ -141,6 +156,7 @@ metric_type_params_schema = {
             "items": {"$ref": "metric_input_schema"},
         },
         "conversion_type_params": {"$ref": "conversion_type_params_schema"},
+        "cumulative_type_params": {"$ref": "cumulative_type_params_schema"},
     },
     "additionalProperties": False,
 }
@@ -445,6 +461,7 @@ schema_store = {
     metric_input_measure_schema["$id"]: metric_input_measure_schema,
     metric_type_params_schema["$id"]: metric_type_params_schema,
     conversion_type_params_schema["$id"]: conversion_type_params_schema,
+    cumulative_type_params_schema["$id"]: cumulative_type_params_schema,
     constant_property_input_schema["$id"]: constant_property_input_schema,
     entity_schema["$id"]: entity_schema,
     measure_schema["$id"]: measure_schema,

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -57,7 +57,7 @@ time_dimension_type_values = ["TIME", "time"]
 export_destination_type_values = ["TABLE", "VIEW"]
 export_destination_type_values += [x.lower() for x in export_destination_type_values]
 
-period_agg_values = ["START", "END", "AVERAGE"]
+period_agg_values = ["FIRST", "LAST", "AVERAGE"]
 period_agg_values += [x.lower() for x in period_agg_values]
 
 

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -9,6 +9,7 @@ from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums import (
     ConversionCalculationType,
     MetricType,
+    PeriodAggregation,
     TimeGranularity,
 )
 
@@ -178,6 +179,25 @@ class ConversionTypeParams(Protocol):
         pass
 
 
+class CumulativeTypeParams(Protocol):
+    """Type params to provide context for cumulative metric properties."""
+
+    @property
+    @abstractmethod
+    def window(self) -> Optional[MetricTimeWindow]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def grain_to_date(self) -> Optional[TimeGranularity]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def period_agg(self) -> Optional[PeriodAggregation]:  # noqa: D
+        pass
+
+
 class MetricTypeParams(Protocol):
     """Type params add additional context to certain metric types (the context depends on the metric type)."""
 
@@ -225,6 +245,11 @@ class MetricTypeParams(Protocol):
     @property
     @abstractmethod
     def conversion_type_params(self) -> Optional[ConversionTypeParams]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def cumulative_type_params(self) -> Optional[CumulativeTypeParams]:  # noqa: D
         pass
 
 

--- a/dbt_semantic_interfaces/transformations/cumulative_type_params.py
+++ b/dbt_semantic_interfaces/transformations/cumulative_type_params.py
@@ -1,0 +1,41 @@
+from typing_extensions import override
+
+from dbt_semantic_interfaces.implementations.metric import PydanticCumulativeTypeParams
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.protocols import ProtocolHint
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
+from dbt_semantic_interfaces.type_enums import MetricType
+
+
+class SetCumulativeTypeParamsRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+    """Ensure cumulative type params are populated from deprecated type params fields.
+
+    All type params specific to cumulative metrics were originally set in `metric.type_params`. As we've added
+    more, they've been moved to `metric.type_params.cumulative_type_params`, and the old fields will eventually
+    be deprecated. In the meantime, here we populate the new fields with the old field values, if set, to ensure
+    backward compatibility.
+    Also populates cumulative_type_params for all cumulative metrics with PydanticCumulativeTypeParams if not set,
+    which ensures the default `period_agg` value is set.
+    """
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
+
+    @staticmethod
+    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
+        for metric in semantic_manifest.metrics:
+            if metric.type == MetricType.CUMULATIVE:
+                if not metric.type_params.cumulative_type_params:
+                    metric.type_params.cumulative_type_params = PydanticCumulativeTypeParams()
+
+            if metric.type_params.window and not metric.type_params.cumulative_type_params.window:
+                metric.type_params.cumulative_type_params.window = metric.type_params.window
+            if metric.type_params.grain_to_date and not metric.type_params.cumulative_type_params.grain_to_date:
+                metric.type_params.cumulative_type_params.grain_to_date = metric.type_params.grain_to_date
+
+        return semantic_manifest

--- a/dbt_semantic_interfaces/transformations/cumulative_type_params.py
+++ b/dbt_semantic_interfaces/transformations/cumulative_type_params.py
@@ -33,9 +33,9 @@ class SetCumulativeTypeParamsRule(ProtocolHint[SemanticManifestTransformRule[Pyd
                 if not metric.type_params.cumulative_type_params:
                     metric.type_params.cumulative_type_params = PydanticCumulativeTypeParams()
 
-            if metric.type_params.window and not metric.type_params.cumulative_type_params.window:
-                metric.type_params.cumulative_type_params.window = metric.type_params.window
-            if metric.type_params.grain_to_date and not metric.type_params.cumulative_type_params.grain_to_date:
-                metric.type_params.cumulative_type_params.grain_to_date = metric.type_params.grain_to_date
+                if metric.type_params.window and not metric.type_params.cumulative_type_params.window:
+                    metric.type_params.cumulative_type_params.window = metric.type_params.window
+                if metric.type_params.grain_to_date and not metric.type_params.cumulative_type_params.grain_to_date:
+                    metric.type_params.cumulative_type_params.grain_to_date = metric.type_params.grain_to_date
 
         return semantic_manifest

--- a/dbt_semantic_interfaces/type_enums/__init__.py
+++ b/dbt_semantic_interfaces/type_enums/__init__.py
@@ -7,6 +7,7 @@ from dbt_semantic_interfaces.type_enums.conversion_calculation_type import (  # 
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType  # noqa:F401
+from dbt_semantic_interfaces.type_enums.period_agg import PeriodAggregation  # noqa:F401
 from dbt_semantic_interfaces.type_enums.semantic_manifest_node_type import (  # noqa:F401
     SemanticManifestNodeType,
 )

--- a/dbt_semantic_interfaces/type_enums/period_agg.py
+++ b/dbt_semantic_interfaces/type_enums/period_agg.py
@@ -4,6 +4,6 @@ from dbt_semantic_interfaces.enum_extension import ExtendedEnum
 class PeriodAggregation(ExtendedEnum):
     """Options for how to aggregate across a time period."""
 
-    START = "start"
-    END = "end"
+    FIRST = "first"
+    LAST = "last"
     AVERAGE = "average"

--- a/dbt_semantic_interfaces/type_enums/period_agg.py
+++ b/dbt_semantic_interfaces/type_enums/period_agg.py
@@ -1,0 +1,9 @@
+from dbt_semantic_interfaces.enum_extension import ExtendedEnum
+
+
+class PeriodAggregation(ExtendedEnum):
+    """Options for how to aggregate across a time period."""
+
+    START = "start"
+    END = "end"
+    AVERAGE = "average"

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -174,7 +174,9 @@ metric:
   type_params:
     measure:
       name: bookers
-    window: 2 days
+    cumulative_type_params:
+      window: 2 days
+      period_agg: average
 ---
 metric:
   name: "revenue_mtd"
@@ -183,7 +185,8 @@ metric:
   type_params:
     measure:
       name: txn_revenue
-    grain_to_date: month
+    cumulative_type_params:
+      grain_to_date: month
 ---
 metric:
   name: booking_fees

--- a/tests/validations/test_configurable_rules.py
+++ b/tests/validations/test_configurable_rules.py
@@ -36,13 +36,15 @@ def test_can_configure_model_validator_rules(  # noqa: D
     validator = SemanticManifestValidator[PydanticSemanticManifest]()
     issues = SemanticManifestValidator[PydanticSemanticManifest]().validate_semantic_manifest(model)
     assert (
-        len(issues.all_issues) == 1
-    ), f"SemanticManifestValidator with default rules had unexpected number of issues {issues}"
+        len(issues.errors) == 1
+    ), f"SemanticManifestValidator with default rules had unexpected number of errors {issues.errors}"
 
     # confirm that a custom configuration excluding ValidMaterializationRule, no issue is raised
     rules = [rule for rule in validator.DEFAULT_RULES if rule.__class__ is not DerivedMetricRule]
     issues = SemanticManifestValidator[PydanticSemanticManifest](rules=rules).validate_semantic_manifest(model)
-    assert len(issues.all_issues) == 0, f"SemanticManifestValidator without DerivedMetricRule returned issues {issues}"
+    assert (
+        len(issues.errors) == 0
+    ), f"SemanticManifestValidator without DerivedMetricRule returned issues {issues.errors}"
 
 
 def test_cant_configure_model_validator_without_rules() -> None:  # noqa: D

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -588,7 +588,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=measure_name),
                         window=PydanticMetricTimeWindow(count=1, granularity=TimeGranularity.WEEK),
-                        cumulative_type_params=PydanticCumulativeTypeParams(period_agg=PeriodAggregation.END),
+                        cumulative_type_params=PydanticCumulativeTypeParams(period_agg=PeriodAggregation.LAST),
                     ),
                 ),
                 metric_with_guaranteed_meta(
@@ -628,7 +628,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                         grain_to_date=TimeGranularity.MONTH,
                         cumulative_type_params=PydanticCumulativeTypeParams(
                             window=PydanticMetricTimeWindow(count=1, granularity=TimeGranularity.WEEK),
-                            period_agg=PeriodAggregation.START,
+                            period_agg=PeriodAggregation.FIRST,
                         ),
                     ),
                 ),
@@ -661,7 +661,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                     type=MetricType.CUMULATIVE,
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=measure_name),
-                        cumulative_type_params=PydanticCumulativeTypeParams(period_agg=PeriodAggregation.START),
+                        cumulative_type_params=PydanticCumulativeTypeParams(period_agg=PeriodAggregation.FIRST),
                     ),
                 ),
             ],

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -674,8 +674,8 @@ def test_cumulative_metrics() -> None:  # noqa: D
         print(issue.message)
     assert len(build_issues) == 8
     expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
-    expected_substr2 = "`window` set twice in cumulative metric"
-    expected_substr3 = "`grain_to_date` set twice in cumulative metric"
+    expected_substr2 = "Got differing values for `window`"
+    expected_substr3 = "Got differing values for `grain_to_date`"
     expected_substr4 = "Cumulative `type_params.window` field has been moved and will soon be deprecated."
     expected_substr5 = "Cumulative `type_params.grain_to_date` field has been moved and will soon be deprecated."
     missing_error_strings = set()

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -15,6 +15,7 @@ from dbt_semantic_interfaces.implementations.filters.where_filter import (
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticConstantPropertyInput,
     PydanticConversionTypeParams,
+    PydanticCumulativeTypeParams,
     PydanticMetricInput,
     PydanticMetricInputMeasure,
     PydanticMetricTimeWindow,
@@ -38,10 +39,12 @@ from dbt_semantic_interfaces.type_enums import (
     DimensionType,
     EntityType,
     MetricType,
+    PeriodAggregation,
     TimeGranularity,
 )
 from dbt_semantic_interfaces.validations.metrics import (
     ConversionMetricRule,
+    CumulativeMetricRule,
     DerivedMetricRule,
     WhereFiltersAreParseable,
 )
@@ -548,4 +551,136 @@ def test_conversion_metrics() -> None:  # noqa: D
         if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
             missing_error_strings.add(expected_str)
     assert len(missing_error_strings) == 0, "Failed to match one or more expected errors: "
+    f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+
+
+def test_cumulative_metrics() -> None:  # noqa: D
+    measure_name = "foo"
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([CumulativeMetricRule()])
+    validation_results = model_validator.validate_semantic_manifest(
+        PydanticSemanticManifest(
+            semantic_models=[
+                semantic_model_with_guaranteed_meta(
+                    name="sum_measure",
+                    measures=[
+                        PydanticMeasure(
+                            name=measure_name,
+                            agg=AggregationType.SUM,
+                            agg_time_dimension="ds",
+                        )
+                    ],
+                    dimensions=[
+                        PydanticDimension(
+                            name="ds",
+                            type=DimensionType.TIME,
+                            type_params=PydanticDimensionTypeParams(
+                                time_granularity=TimeGranularity.DAY,
+                            ),
+                        ),
+                    ],
+                ),
+            ],
+            metrics=[
+                # Metrics with old type params structure - should 2 get warnings
+                metric_with_guaranteed_meta(
+                    name="metric1",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        window=PydanticMetricTimeWindow(count=1, granularity=TimeGranularity.WEEK),
+                        cumulative_type_params=PydanticCumulativeTypeParams(period_agg=PeriodAggregation.END),
+                    ),
+                ),
+                metric_with_guaranteed_meta(
+                    name="metric2",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        grain_to_date=TimeGranularity.MONTH,
+                    ),
+                ),
+                # Metrics with new type params structure - should have no issues
+                metric_with_guaranteed_meta(
+                    name="big_mama",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        cumulative_type_params=PydanticCumulativeTypeParams(
+                            window=PydanticMetricTimeWindow(count=1, granularity=TimeGranularity.WEEK),
+                            period_agg=PeriodAggregation.AVERAGE,
+                        ),
+                    ),
+                ),
+                metric_with_guaranteed_meta(
+                    name="lil_baby",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        cumulative_type_params=PydanticCumulativeTypeParams(grain_to_date=TimeGranularity.MONTH),
+                    ),
+                ),
+                # Metric with both window & grain across both type_params - should get 2 warnings
+                metric_with_guaranteed_meta(
+                    name="woooooo",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        grain_to_date=TimeGranularity.MONTH,
+                        cumulative_type_params=PydanticCumulativeTypeParams(
+                            window=PydanticMetricTimeWindow(count=1, granularity=TimeGranularity.WEEK),
+                            period_agg=PeriodAggregation.START,
+                        ),
+                    ),
+                ),
+                # Metrics with duplicated window or grain_to_date - should 4 get warnings
+                metric_with_guaranteed_meta(
+                    name="what_a_metric",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        grain_to_date=TimeGranularity.YEAR,
+                        cumulative_type_params=PydanticCumulativeTypeParams(
+                            grain_to_date=TimeGranularity.HOUR,
+                        ),
+                    ),
+                ),
+                metric_with_guaranteed_meta(
+                    name="dis_bad",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        window=PydanticMetricTimeWindow(count=2, granularity=TimeGranularity.QUARTER),
+                        cumulative_type_params=PydanticCumulativeTypeParams(
+                            window=PydanticMetricTimeWindow(count=1, granularity=TimeGranularity.QUARTER),
+                        ),
+                    ),
+                ),
+                # Metric without window or grain_to_date - should have no issues
+                metric_with_guaranteed_meta(
+                    name="dis_good",
+                    type=MetricType.CUMULATIVE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=measure_name),
+                        cumulative_type_params=PydanticCumulativeTypeParams(period_agg=PeriodAggregation.START),
+                    ),
+                ),
+            ],
+            project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
+        )
+    )
+
+    build_issues = validation_results.all_issues
+    for issue in build_issues:
+        print(issue.message)
+    assert len(build_issues) == 8
+    expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
+    expected_substr2 = "`window` set twice in cumulative metric"
+    expected_substr3 = "`grain_to_date` set twice in cumulative metric"
+    expected_substr4 = "Cumulative `type_params.window` field has been moved and will soon be deprecated."
+    expected_substr5 = "Cumulative `type_params.grain_to_date` field has been moved and will soon be deprecated."
+    missing_error_strings = set()
+    for expected_str in [expected_substr1, expected_substr2, expected_substr3, expected_substr4, expected_substr5]:
+        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
+            missing_error_strings.add(expected_str)
+    assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
     f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"


### PR DESCRIPTION
Resolves #289
Completes SL-2363
Completes SL-2364

### Description
Move cumulative metric type params to a nested key within `type_params` called `cumulative_type_params`.
Add new `period_agg` field with options `FIRST`, `LAST`, and `AVERAGE`. (Note we chose `FIRST` and `LAST` because that language aligns with the window function syntax we'll use for those - `FIRST_VALUE` and `LAST_VALUE`.) This will be used when aggregating cumulative metrics to non-default time granularities.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
