### PR TITLE
Add `default_granularity` to metric spec

### DIFF
--- a/.changes/unreleased/Features-20240614-140515.yaml
+++ b/.changes/unreleased/Features-20240614-140515.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add default_grain to metric spec.
+time: 2024-06-14T14:05:15.355931-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "290"

--- a/.changes/unreleased/Features-20240614-140515.yaml
+++ b/.changes/unreleased/Features-20240614-140515.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add default_grain to metric spec.
+body: Add default_granularity to metric spec.
 time: 2024-06-14T14:05:15.355931-07:00
 custom:
   Author: courtneyholcomb

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test:
 	export FORMAT_JSON_LOGS="1" && hatch -v run dev-env:pytest -n auto tests
 
 lint:
-	hatch run dev-env:pre-commit run --show-diff-on-failure --color=always --all-files
+	hatch run dev-env:pre-commit run --color=always --all-files
 
 json_schema:
 	hatch run dev-env:python dbt_semantic_interfaces/parsing/generate_json_schema_file.py

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -211,7 +211,7 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
     metadata: Optional[PydanticMetadata]
     label: Optional[str] = None
     config: Optional[PydanticMetricConfig]
-    default_grain: Optional[TimeGranularity] = None
+    default_granularity: Optional[TimeGranularity] = None
 
     @property
     def input_measures(self) -> Sequence[PydanticMetricInputMeasure]:

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Set
 
 from typing_extensions import override
 
@@ -16,7 +16,12 @@ from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilterIntersection,
 )
 from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
-from dbt_semantic_interfaces.protocols import MetricConfig, ProtocolHint
+from dbt_semantic_interfaces.protocols import (
+    Metric,
+    MetricConfig,
+    MetricInputMeasure,
+    ProtocolHint,
+)
 from dbt_semantic_interfaces.references import MeasureReference, MetricReference
 from dbt_semantic_interfaces.type_enums import (
     ConversionCalculationType,
@@ -191,8 +196,12 @@ class PydanticMetricConfig(HashableBaseModel, ProtocolHint[MetricConfig]):  # no
     meta: Dict[str, Any] = Field(default_factory=dict)
 
 
-class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing):
+class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[Metric]):
     """Describes a metric."""
+
+    @override
+    def _implements_protocol(self) -> Metric:  # noqa: D
+        return self
 
     name: str
     description: Optional[str]
@@ -229,3 +238,31 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing):
             return (self.type_params.numerator, self.type_params.denominator)
         else:
             assert_values_exhausted(self.type)
+
+    @staticmethod
+    def all_input_measures_for_metric(
+        metric: Metric, metric_index: Dict[MetricReference, Metric]
+    ) -> Set[MetricInputMeasure]:
+        """Gets all input measures for the metric, including those defined on input metrics (recursively)."""
+        measures = set()
+        if metric.type is MetricType.SIMPLE or metric.type is MetricType.CUMULATIVE:
+            assert (
+                metric.type_params.measure is not None
+            ), f"Metric {metric.name} should have a measure defined, but it does not."
+            measures.add(metric.type_params.measure)
+        elif metric.type is MetricType.DERIVED or metric.type is MetricType.RATIO:
+            for input_metric in metric.input_metrics:
+                nested_metric = metric_index.get(MetricReference(input_metric.name))
+                assert nested_metric, f"Could not find metric {input_metric.name} in semantic manifest."
+                measures.update(
+                    PydanticMetric.all_input_measures_for_metric(metric=nested_metric, metric_index=metric_index)
+                )
+        elif metric.type is MetricType.CONVERSION:
+            conversion_type_params = metric.type_params.conversion_type_params
+            assert conversion_type_params, "Conversion metric should have conversion_type_params."
+            measures.add(conversion_type_params.base_measure)
+            measures.add(conversion_type_params.conversion_measure)
+        else:
+            assert_values_exhausted(metric.type)
+
+        return measures

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -202,6 +202,7 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing):
     metadata: Optional[PydanticMetadata]
     label: Optional[str] = None
     config: Optional[PydanticMetricConfig]
+    default_grain: Optional[TimeGranularity] = None
 
     @property
     def input_measures(self) -> Sequence[PydanticMetricInputMeasure]:

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -19,6 +19,7 @@ from dbt_semantic_interfaces.protocols import (
     SemanticModelDefaults,
 )
 from dbt_semantic_interfaces.references import (
+    DimensionReference,
     EntityReference,
     LinkableElementReference,
     MeasureReference,
@@ -168,7 +169,7 @@ class PydanticSemanticModel(HashableBaseModel, ModelWithMetadataParsing, Protoco
             f"No dimension with name ({measure_reference.element_name}) in semantic_model with name ({self.name})"
         )
 
-    def get_dimension(self, dimension_reference: LinkableElementReference) -> PydanticDimension:  # noqa: D
+    def get_dimension(self, dimension_reference: DimensionReference) -> PydanticDimension:  # noqa: D
         for dim in self.dimensions:
             if dim.reference == dimension_reference:
                 return dim

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -458,6 +458,32 @@
                 "config": {
                     "$ref": "#/definitions/metric_config_schema"
                 },
+                "default_granularity": {
+                    "enum": [
+                        "NANOSECOND",
+                        "MICROSECOND",
+                        "MILLISECOND",
+                        "SECOND",
+                        "MINUTE",
+                        "HOUR",
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                        "nanosecond",
+                        "microsecond",
+                        "millisecond",
+                        "second",
+                        "minute",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                        "quarter",
+                        "year"
+                    ]
+                },
                 "description": {
                     "type": "string"
                 },

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -304,6 +304,7 @@ metric_schema = {
         "description": {"type": "string"},
         "label": {"type": "string"},
         "config": {"$ref": "metric_config_schema"},
+        "default_granularity": {"enum": time_granularity_values},
     },
     "additionalProperties": False,
     "required": ["name", "type", "type_params"],

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -325,3 +325,14 @@ class Metric(Protocol):
     def label(self) -> Optional[str]:
         """Returns a string representing a human readable label for the metric."""
         pass
+
+    @property
+    @abstractmethod
+    def default_grain(self) -> Optional[TimeGranularity]:
+        """Default grain used for the metric.
+
+        This will be used in a couple of circumstances:
+        - as the default grain for metric_time if no grain is specified
+        - as the window function order by when reaggregating cumulative metrics for non-default grains
+        """
+        pass

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -328,7 +328,7 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def default_grain(self) -> Optional[TimeGranularity]:
+    def default_granularity(self) -> Optional[TimeGranularity]:
         """Default grain used for the metric.
 
         This will be used in a couple of circumstances:

--- a/dbt_semantic_interfaces/references.py
+++ b/dbt_semantic_interfaces/references.py
@@ -47,6 +47,7 @@ class EntityReference(LinkableElementReference):  # noqa: D
 class TimeDimensionReference(DimensionReference):  # noqa: D
     pass
 
+    @property
     def dimension_reference(self) -> DimensionReference:  # noqa: D
         return DimensionReference(element_name=self.element_name)
 

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -123,7 +123,7 @@ def metric_with_guaranteed_meta(
     type_params: PydanticMetricTypeParams,
     metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
-    default_grain: Optional[TimeGranularity] = None,
+    default_granularity: Optional[TimeGranularity] = None,
 ) -> PydanticMetric:
     """Creates a metric with the given input.
 
@@ -136,7 +136,7 @@ def metric_with_guaranteed_meta(
         type_params=type_params,
         filter=None,
         metadata=metadata,
-        default_grain=default_grain,
+        default_granularity=default_granularity,
     )
 
 

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -24,7 +24,7 @@ from dbt_semantic_interfaces.implementations.semantic_model import (
     PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
-from dbt_semantic_interfaces.type_enums import MetricType
+from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +123,7 @@ def metric_with_guaranteed_meta(
     type_params: PydanticMetricTypeParams,
     metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
+    default_grain: Optional[TimeGranularity] = None,
 ) -> PydanticMetric:
     """Creates a metric with the given input.
 
@@ -135,6 +136,7 @@ def metric_with_guaranteed_meta(
         type_params=type_params,
         filter=None,
         metadata=metadata,
+        default_grain=default_grain,
     )
 
 

--- a/dbt_semantic_interfaces/transformations/default_grain.py
+++ b/dbt_semantic_interfaces/transformations/default_grain.py
@@ -1,0 +1,48 @@
+from typing import Set
+
+from typing_extensions import override
+
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.protocols import ProtocolHint
+from dbt_semantic_interfaces.references import (
+    DimensionReference,
+    TimeDimensionReference,
+)
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
+from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
+
+
+class SetDefaultGrainRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+    """If default_grain is not set for a metric, set it to DAY if available, else the smallest available grain."""
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
+
+    @staticmethod
+    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:
+        """For each metric, set default_grain to DAY or the smallest granularity supported by all agg_time_dims."""
+        for metric in semantic_manifest.metrics:
+            if metric.default_grain:
+                continue
+
+            default_grain = TimeGranularity.DAY
+            seen_agg_time_dimensions: Set[TimeDimensionReference] = set()
+            for semantic_model in semantic_manifest.semantic_models:
+                for measure_ref in set(metric.measure_references).intersection(semantic_model.measure_references):
+                    agg_time_dimension_ref = semantic_model.checked_agg_time_dimension_for_measure(measure_ref)
+                    if agg_time_dimension_ref in seen_agg_time_dimensions:
+                        continue
+                    seen_agg_time_dimensions.add(agg_time_dimension_ref)
+                    dimension = semantic_model.get_dimension(DimensionReference(agg_time_dimension_ref.element_name))
+                    if (
+                        dimension.type_params
+                        and dimension.type_params.time_granularity.to_int() > default_grain.to_int()
+                    ):
+                        default_grain = dimension.type_params.time_granularity
+
+        return semantic_manifest

--- a/dbt_semantic_interfaces/transformations/default_grain.py
+++ b/dbt_semantic_interfaces/transformations/default_grain.py
@@ -17,7 +17,7 @@ from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 
 class SetDefaultGrainRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
-    """If default_grain is not set for a metric, set it to DAY if available, else the smallest available grain."""
+    """If default_granularity is not set for a metric, set it to DAY if available, else the smallest available grain."""
 
     @override
     def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
@@ -25,12 +25,12 @@ class SetDefaultGrainRule(ProtocolHint[SemanticManifestTransformRule[PydanticSem
 
     @staticmethod
     def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:
-        """For each metric, set default_grain to DAY or the smallest granularity supported by all agg_time_dims."""
+        """For each metric, set default_granularity to DAY or smallest granularity supported by all agg_time_dims."""
         for metric in semantic_manifest.metrics:
-            if metric.default_grain:
+            if metric.default_granularity:
                 continue
 
-            default_grain = TimeGranularity.DAY
+            default_granularity = TimeGranularity.DAY
             seen_agg_time_dimensions: Set[TimeDimensionReference] = set()
             for semantic_model in semantic_manifest.semantic_models:
                 for measure_ref in set(metric.measure_references).intersection(semantic_model.measure_references):
@@ -41,8 +41,8 @@ class SetDefaultGrainRule(ProtocolHint[SemanticManifestTransformRule[PydanticSem
                     dimension = semantic_model.get_dimension(DimensionReference(agg_time_dimension_ref.element_name))
                     if (
                         dimension.type_params
-                        and dimension.type_params.time_granularity.to_int() > default_grain.to_int()
+                        and dimension.type_params.time_granularity.to_int() > default_granularity.to_int()
                     ):
-                        default_grain = dimension.type_params.time_granularity
+                        default_granularity = dimension.type_params.time_granularity
 
         return semantic_manifest

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -592,9 +592,9 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
         Defaults to DAY in the
         """
         min_queryable_granularity: Optional[TimeGranularity] = None
-        for input_measure in PydanticMetric.all_input_measures_for_metric(metric=metric, metric_index=metric_index):
-            agg_time_dimension = measure_to_agg_time_dimension.get(input_measure.measure_reference)
-            assert agg_time_dimension, f"Measure '{input_measure.name}' not found in semantic manifest."
+        for measure_reference in PydanticMetric.all_input_measures_for_metric(metric=metric, metric_index=metric_index):
+            agg_time_dimension = measure_to_agg_time_dimension.get(measure_reference)
+            assert agg_time_dimension, f"Measure '{measure_reference.element_name}' not found in semantic manifest."
             if not agg_time_dimension.type_params:
                 continue
             defined_time_granularity = agg_time_dimension.type_params.time_granularity

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -578,7 +578,7 @@ class ConversionMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
 
 
 class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
-    """Checks that default_grain set for metric is queryable for that metric."""
+    """Checks that default_granularity set for metric is queryable for that metric."""
 
     @staticmethod
     def _min_queryable_granularity_for_metric(
@@ -605,7 +605,7 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
 
     @staticmethod
     @validate_safely(
-        whats_being_done="running model validation ensuring a metric's default_grain is valid for the metric"
+        whats_being_done="running model validation ensuring a metric's default_granularity is valid for the metric"
     )
     def _validate_metric(
         metric: Metric,
@@ -618,7 +618,7 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
             metric=MetricModelReference(metric_name=metric.name),
         )
 
-        if metric.default_grain:
+        if metric.default_granularity:
             min_queryable_granularity = DefaultGrainRule._min_queryable_granularity_for_metric(
                 metric=metric, metric_index=metric_index, measure_to_agg_time_dimension=measure_to_agg_time_dimension
             )
@@ -627,15 +627,15 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
                 for granularity in TimeGranularity
                 if granularity.to_int() >= min_queryable_granularity.to_int()
             ]
-            if metric.default_grain.name not in valid_granularities:
+            if metric.default_granularity.name not in valid_granularities:
                 issues.append(
                     ValidationError(
                         context=context,
                         message=(
-                            f"`default_grain` for metric '{metric.name}' must be >= {min_queryable_granularity.name}. "
-                            "Valid options are those that are >= the largest granularity defined for the metric's "
-                            f"measures' agg_time_dimensions. Got: {metric.default_grain.name}. "
-                            f"Valid options: {valid_granularities}"
+                            f"`default_granularity` for metric '{metric.name}' must be >= "
+                            f"{min_queryable_granularity.name}. Valid options are those that are >= the largest "
+                            f"granularity defined for the metric's measures' agg_time_dimensions. Got: "
+                            f"{metric.default_granularity.name}. Valid options: {valid_granularities}"
                         ),
                     )
                 )
@@ -643,9 +643,9 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
         return issues
 
     @staticmethod
-    @validate_safely(whats_being_done="running manifest validation ensuring metric default_grains are valid")
+    @validate_safely(whats_being_done="running manifest validation ensuring metric default_granularitys are valid")
     def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
-        """Validate that the default_grain for each metric is queryable for that metric.
+        """Validate that the default_granularity for each metric is queryable for that metric.
 
         TODO: figure out a more efficient way to reference other aspects of the model. This validation essentially
         requires parsing the entire model, which could be slow and likely is repeated work. The blocker is that the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.1"
+version = "0.6.2.dev0"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -154,6 +154,7 @@ metric:
   name: "trailing_2_months_revenue"
   description: "trailing_2_months_revenue"
   type: cumulative
+  default_granularity: month
   type_params:
     measure:
       name: txn_revenue

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -46,6 +46,7 @@ from dbt_semantic_interfaces.validations.metrics import (
     CUMULATIVE_TYPE_PARAMS_SUPPORTED,
     ConversionMetricRule,
     CumulativeMetricRule,
+    DefaultGrainRule,
     DerivedMetricRule,
     WhereFiltersAreParseable,
 )
@@ -713,3 +714,114 @@ def test_cumulative_metrics() -> None:  # noqa: D
                 missing_error_strings.add(expected_str)
         assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
         f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+
+
+def test_default_grain() -> None:
+    """Test that default grain is validated appropriately."""
+    week_measure_name = "foo"
+    month_measure_name = "boo"
+    week_time_dim_name = "ds__week"
+    month_time_dim_name = "ds__month"
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DefaultGrainRule()])
+    validation_results = model_validator.validate_semantic_manifest(
+        PydanticSemanticManifest(
+            semantic_models=[
+                semantic_model_with_guaranteed_meta(
+                    name="semantic_model",
+                    measures=[
+                        PydanticMeasure(
+                            name=month_measure_name, agg=AggregationType.SUM, agg_time_dimension=month_time_dim_name
+                        ),
+                        PydanticMeasure(
+                            name=week_measure_name, agg=AggregationType.SUM, agg_time_dimension=week_time_dim_name
+                        ),
+                    ],
+                    dimensions=[
+                        PydanticDimension(
+                            name=month_time_dim_name,
+                            type=DimensionType.TIME,
+                            type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.MONTH),
+                        ),
+                        PydanticDimension(
+                            name=week_time_dim_name,
+                            type=DimensionType.TIME,
+                            type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.WEEK),
+                        ),
+                    ],
+                ),
+            ],
+            metrics=[
+                # Simple metrics
+                metric_with_guaranteed_meta(
+                    name="month_metric_with_no_default_grain_set",
+                    type=MetricType.SIMPLE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=month_measure_name),
+                    ),
+                ),
+                metric_with_guaranteed_meta(
+                    name="week_metric_with_valid_default_grain",
+                    type=MetricType.SIMPLE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=week_measure_name),
+                    ),
+                    default_grain=TimeGranularity.MONTH,
+                ),
+                metric_with_guaranteed_meta(
+                    name="month_metric_with_invalid_default_grain",
+                    type=MetricType.SIMPLE,
+                    type_params=PydanticMetricTypeParams(
+                        measure=PydanticMetricInputMeasure(name=month_measure_name),
+                    ),
+                    default_grain=TimeGranularity.WEEK,
+                ),
+                # Derived metrics
+                metric_with_guaranteed_meta(
+                    name="derived_metric_with_no_default_grain_set",
+                    type=MetricType.DERIVED,
+                    type_params=PydanticMetricTypeParams(
+                        metrics=[
+                            PydanticMetricInput(name="week_metric_with_valid_default_grain"),
+                        ],
+                        expr="week_metric_with_valid_default_grain + 1",
+                    ),
+                ),
+                metric_with_guaranteed_meta(
+                    name="derived_metric_with_valid_default_grain",
+                    type=MetricType.DERIVED,
+                    type_params=PydanticMetricTypeParams(
+                        metrics=[
+                            PydanticMetricInput(name="week_metric_with_valid_default_grain"),
+                            PydanticMetricInput(name="month_metric_with_no_default_grain_set"),
+                        ],
+                        expr="week_metric_with_valid_default_grain + month_metric_with_no_default_grain_set",
+                    ),
+                    default_grain=TimeGranularity.YEAR,
+                ),
+                metric_with_guaranteed_meta(
+                    name="derived_metric_with_invalid_default_grain",
+                    type=MetricType.DERIVED,
+                    type_params=PydanticMetricTypeParams(
+                        metrics=[
+                            PydanticMetricInput(name="week_metric_with_valid_default_grain"),
+                            PydanticMetricInput(name="month_metric_with_no_default_grain_set"),
+                        ],
+                        expr="week_metric_with_valid_default_grain + month_metric_with_no_default_grain_set",
+                    ),
+                    default_grain=TimeGranularity.DAY,
+                ),
+            ],
+            project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
+        )
+    )
+
+    build_issues = validation_results.all_issues
+    assert len(build_issues) == 2
+    expected_substr1 = "`default_grain` for metric 'month_metric_with_invalid_default_grain' must be >= MONTH."
+    expected_substr2 = "`default_grain` for metric 'derived_metric_with_invalid_default_grain' must be >= MONTH."
+    missing_error_strings = set()
+    for expected_str in [expected_substr1, expected_substr2]:
+        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
+            missing_error_strings.add(expected_str)
+    assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
+    f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -716,7 +716,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
         f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
 
 
-def test_default_grain() -> None:
+def test_default_granularity() -> None:
     """Test that default grain is validated appropriately."""
     week_measure_name = "foo"
     month_measure_name = "boo"
@@ -753,62 +753,66 @@ def test_default_grain() -> None:
             metrics=[
                 # Simple metrics
                 metric_with_guaranteed_meta(
-                    name="month_metric_with_no_default_grain_set",
+                    name="month_metric_with_no_default_granularity_set",
                     type=MetricType.SIMPLE,
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=month_measure_name),
                     ),
                 ),
                 metric_with_guaranteed_meta(
-                    name="week_metric_with_valid_default_grain",
+                    name="week_metric_with_valid_default_granularity",
                     type=MetricType.SIMPLE,
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=week_measure_name),
                     ),
-                    default_grain=TimeGranularity.MONTH,
+                    default_granularity=TimeGranularity.MONTH,
                 ),
                 metric_with_guaranteed_meta(
-                    name="month_metric_with_invalid_default_grain",
+                    name="month_metric_with_invalid_default_granularity",
                     type=MetricType.SIMPLE,
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=month_measure_name),
                     ),
-                    default_grain=TimeGranularity.WEEK,
+                    default_granularity=TimeGranularity.WEEK,
                 ),
                 # Derived metrics
                 metric_with_guaranteed_meta(
-                    name="derived_metric_with_no_default_grain_set",
+                    name="derived_metric_with_no_default_granularity_set",
                     type=MetricType.DERIVED,
                     type_params=PydanticMetricTypeParams(
                         metrics=[
-                            PydanticMetricInput(name="week_metric_with_valid_default_grain"),
+                            PydanticMetricInput(name="week_metric_with_valid_default_granularity"),
                         ],
-                        expr="week_metric_with_valid_default_grain + 1",
+                        expr="week_metric_with_valid_default_granularity + 1",
                     ),
                 ),
                 metric_with_guaranteed_meta(
-                    name="derived_metric_with_valid_default_grain",
+                    name="derived_metric_with_valid_default_granularity",
                     type=MetricType.DERIVED,
                     type_params=PydanticMetricTypeParams(
                         metrics=[
-                            PydanticMetricInput(name="week_metric_with_valid_default_grain"),
-                            PydanticMetricInput(name="month_metric_with_no_default_grain_set"),
+                            PydanticMetricInput(name="week_metric_with_valid_default_granularity"),
+                            PydanticMetricInput(name="month_metric_with_no_default_granularity_set"),
                         ],
-                        expr="week_metric_with_valid_default_grain + month_metric_with_no_default_grain_set",
+                        expr=(
+                            "week_metric_with_valid_default_granularity + month_metric_with_no_default_granularity_set"
+                        ),
                     ),
-                    default_grain=TimeGranularity.YEAR,
+                    default_granularity=TimeGranularity.YEAR,
                 ),
                 metric_with_guaranteed_meta(
-                    name="derived_metric_with_invalid_default_grain",
+                    name="derived_metric_with_invalid_default_granularity",
                     type=MetricType.DERIVED,
                     type_params=PydanticMetricTypeParams(
                         metrics=[
-                            PydanticMetricInput(name="week_metric_with_valid_default_grain"),
-                            PydanticMetricInput(name="month_metric_with_no_default_grain_set"),
+                            PydanticMetricInput(name="week_metric_with_valid_default_granularity"),
+                            PydanticMetricInput(name="month_metric_with_no_default_granularity_set"),
                         ],
-                        expr="week_metric_with_valid_default_grain + month_metric_with_no_default_grain_set",
+                        expr=(
+                            "week_metric_with_valid_default_granularity + month_metric_with_no_default_granularity_set"
+                        ),
                     ),
-                    default_grain=TimeGranularity.DAY,
+                    default_granularity=TimeGranularity.DAY,
                 ),
             ],
             project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
@@ -817,8 +821,12 @@ def test_default_grain() -> None:
 
     build_issues = validation_results.all_issues
     assert len(build_issues) == 2
-    expected_substr1 = "`default_grain` for metric 'month_metric_with_invalid_default_grain' must be >= MONTH."
-    expected_substr2 = "`default_grain` for metric 'derived_metric_with_invalid_default_grain' must be >= MONTH."
+    expected_substr1 = (
+        "`default_granularity` for metric 'month_metric_with_invalid_default_granularity' must be >= MONTH."
+    )
+    expected_substr2 = (
+        "`default_granularity` for metric 'derived_metric_with_invalid_default_granularity' must be >= MONTH."
+    )
     missing_error_strings = set()
     for expected_str in [expected_substr1, expected_substr2]:
         if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):


### PR DESCRIPTION
Resolves #290

### Description
Now that we are enabling sub-daily granularities, the current behavior of `metric_time` will likely be unexpected to users. If they change any of their time dimensions to use a grain smaller than DAY, `metric_time` will default to that grain. To avoid this confusion, add a parameter that allows users to choose which grain they want their metric to default to. This will default to DAY if not set to avoid the unexpected behavior change. (If DAY is smaller than the defined granularity, will default to the smallest available granularity.)


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
