### PR TITLE
Make all `*Reference` classes orderable

### DIFF
--- a/dbt_semantic_interfaces/references.py
+++ b/dbt_semantic_interfaces/references.py
@@ -12,14 +12,14 @@ class ElementReference(SerializableDataclass):
     element_name: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class LinkableElementReference(ElementReference):
     """Used when we need to refer to a dimension or entity, but other attributes are unknown."""
 
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class MeasureReference(ElementReference):
     """Used when we need to refer to a measure.
 
@@ -29,7 +29,7 @@ class MeasureReference(ElementReference):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class DimensionReference(LinkableElementReference):  # noqa: D
     pass
 
@@ -38,12 +38,12 @@ class DimensionReference(LinkableElementReference):  # noqa: D
         return TimeDimensionReference(element_name=self.element_name)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class EntityReference(LinkableElementReference):  # noqa: D
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class TimeDimensionReference(DimensionReference):  # noqa: D
     pass
 
@@ -51,7 +51,7 @@ class TimeDimensionReference(DimensionReference):  # noqa: D
         return DimensionReference(element_name=self.element_name)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class MetricReference(ElementReference):  # noqa: D
     pass
 
@@ -66,14 +66,14 @@ class ModelReference(SerializableDataclass):
     pass
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class SemanticModelReference(ModelReference):
     """A reference to a semantic model definition in the model."""
 
     semantic_model_name: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class SemanticModelElementReference(ModelReference):
     """A reference to an element definition in a semantic model definition in the model.
 
@@ -101,7 +101,7 @@ class SemanticModelElementReference(ModelReference):
         return self.semantic_model_name == ref.semantic_model_name
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, order=True)
 class MetricModelReference(ModelReference):
     """A reference to a metric definition in the model."""
 


### PR DESCRIPTION
### Description

This PR makes all `*Reference` classes order-able to make it easier to provide a consistent order for test / logging purposes.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
