### PR TITLE
Adjust application of `cumulative_type_params` to smooth out release process

### DIFF
--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -17,6 +17,9 @@ from dbt_semantic_interfaces.transformations.convert_count import ConvertCountTo
 from dbt_semantic_interfaces.transformations.convert_median import (
     ConvertMedianToPercentileRule,
 )
+from dbt_semantic_interfaces.transformations.cumulative_type_params import (
+    SetCumulativeTypeParamsRule,
+)
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.rule_set import (
@@ -50,6 +53,7 @@ class PydanticSemanticManifestTransformRuleSet(
             ConvertCountToSumRule(),
             ConvertMedianToPercentileRule(),
             AddInputMetricMeasuresRule(),
+            SetCumulativeTypeParamsRule(),
         )
 
     @property

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -24,6 +24,9 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
     validate_safely,
 )
 
+# Temp: undo once cumulative_type_params are supported in MF
+CUMULATIVE_TYPE_PARAMS_SUPPORTED = False
+
 
 class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that cumulative sum metrics are configured properly."""
@@ -42,7 +45,7 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
             for field in ("window", "grain_to_date"):
                 type_params_field_value = getattr(metric.type_params, field)
                 # Warn that the old type_params structure has been deprecated.
-                if type_params_field_value:
+                if type_params_field_value and CUMULATIVE_TYPE_PARAMS_SUPPORTED:
                     issues.append(
                         ValidationWarning(
                             context=metric_context,
@@ -62,7 +65,7 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
                     type_params_field_value
                     and cumulative_type_params_field_value
                     and cumulative_type_params_field_value != type_params_field_value
-                ):
+                ) and CUMULATIVE_TYPE_PARAMS_SUPPORTED:
                     issues.append(
                         ValidationError(
                             context=metric_context,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.1.dev0"
+version = "0.6.1"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -43,6 +43,7 @@ from dbt_semantic_interfaces.type_enums import (
     TimeGranularity,
 )
 from dbt_semantic_interfaces.validations.metrics import (
+    CUMULATIVE_TYPE_PARAMS_SUPPORTED,
     ConversionMetricRule,
     CumulativeMetricRule,
     DerivedMetricRule,
@@ -690,17 +691,25 @@ def test_cumulative_metrics() -> None:  # noqa: D
     )
 
     build_issues = validation_results.all_issues
-    for issue in build_issues:
-        print(issue.message)
-    assert len(build_issues) == 8
-    expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
-    expected_substr2 = "Got differing values for `window`"
-    expected_substr3 = "Got differing values for `grain_to_date`"
-    expected_substr4 = "Cumulative `type_params.window` field has been moved and will soon be deprecated."
-    expected_substr5 = "Cumulative `type_params.grain_to_date` field has been moved and will soon be deprecated."
-    missing_error_strings = set()
-    for expected_str in [expected_substr1, expected_substr2, expected_substr3, expected_substr4, expected_substr5]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
-            missing_error_strings.add(expected_str)
-    assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
-    f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+    if CUMULATIVE_TYPE_PARAMS_SUPPORTED:
+        assert len(build_issues) == 8
+        expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
+        expected_substr2 = "Got differing values for `window`"
+        expected_substr3 = "Got differing values for `grain_to_date`"
+        expected_substr4 = "Cumulative `type_params.window` field has been moved and will soon be deprecated."
+        expected_substr5 = "Cumulative `type_params.grain_to_date` field has been moved and will soon be deprecated."
+        missing_error_strings = set()
+        for expected_str in [expected_substr1, expected_substr2, expected_substr3, expected_substr4, expected_substr5]:
+            if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
+                missing_error_strings.add(expected_str)
+        assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
+        f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+    else:
+        assert len(build_issues) == 1
+        expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
+        missing_error_strings = set()
+        for expected_str in [expected_substr1]:
+            if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
+                missing_error_strings.add(expected_str)
+        assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
+        f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"


### PR DESCRIPTION
### Description
2 adjustments related to `cumulative_type_params`:
- Add `SetCumulativeTypeParamsRule` to the set of transformations that actually get applied in prod & test.
- Disable related validations temporarily. This will allow us to add support for cumulative_type_params in MetricFlow before these validations roll out to customers.

Also upgrades to a new production patch version so that we these changes can be used in `metricflow-semantics` appropriately.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
