### PR TITLE
Cleanup: Rename `DefaultGrain` to `DefaultGranularity` where missed

### DIFF
--- a/dbt_semantic_interfaces/transformations/default_granularity.py
+++ b/dbt_semantic_interfaces/transformations/default_granularity.py
@@ -16,7 +16,7 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
 from dbt_semantic_interfaces.type_enums.time_granularity import TimeGranularity
 
 
-class SetDefaultGrainRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+class SetDefaultGranularityRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
     """If default_granularity is not set for a metric, set it to DAY if available, else the smallest available grain."""
 
     @override

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -577,7 +577,7 @@ class ConversionMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
         return issues
 
 
-class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
+class DefaultGranularityRule(SemanticManifestValidationRule[SemanticManifestT], Generic[SemanticManifestT]):
     """Checks that default_granularity set for metric is queryable for that metric."""
 
     @staticmethod
@@ -619,7 +619,7 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
         )
 
         if metric.default_granularity:
-            min_queryable_granularity = DefaultGrainRule._min_queryable_granularity_for_metric(
+            min_queryable_granularity = DefaultGranularityRule._min_queryable_granularity_for_metric(
                 metric=metric, metric_index=metric_index, measure_to_agg_time_dimension=measure_to_agg_time_dimension
             )
             valid_granularities = [
@@ -666,7 +666,7 @@ class DefaultGrainRule(SemanticManifestValidationRule[SemanticManifestT], Generi
 
         metric_index = {MetricReference(metric.name): metric for metric in semantic_manifest.metrics}
         for metric in semantic_manifest.metrics or []:
-            issues += DefaultGrainRule._validate_metric(
+            issues += DefaultGranularityRule._validate_metric(
                 metric=metric,
                 metric_index=metric_index,
                 measure_to_agg_time_dimension=measure_to_agg_time_dimension,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.2.dev0"
+version = "0.6.2.dev1"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -46,7 +46,7 @@ from dbt_semantic_interfaces.validations.metrics import (
     CUMULATIVE_TYPE_PARAMS_SUPPORTED,
     ConversionMetricRule,
     CumulativeMetricRule,
-    DefaultGrainRule,
+    DefaultGranularityRule,
     DerivedMetricRule,
     WhereFiltersAreParseable,
 )
@@ -722,7 +722,7 @@ def test_default_granularity() -> None:
     month_measure_name = "boo"
     week_time_dim_name = "ds__week"
     month_time_dim_name = "ds__month"
-    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DefaultGrainRule()])
+    model_validator = SemanticManifestValidator[PydanticSemanticManifest]([DefaultGranularityRule()])
     validation_results = model_validator.validate_semantic_manifest(
         PydanticSemanticManifest(
             semantic_models=[


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Missed the classes & file names when renaming this field. Not very important since users won't see this, but thought it would be helpful to have consistency for development.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
