### PR TITLE
Set `default_granularity` in `SetDefaultGranularityRule`

### DIFF
--- a/dbt_semantic_interfaces/transformations/default_granularity.py
+++ b/dbt_semantic_interfaces/transformations/default_granularity.py
@@ -45,4 +45,6 @@ class SetDefaultGranularityRule(ProtocolHint[SemanticManifestTransformRule[Pydan
                     ):
                         default_granularity = dimension.type_params.time_granularity
 
+            metric.default_granularity = default_granularity
+
         return semantic_manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.2.dev1"
+version = "0.6.2.dev2"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/transformations/test_configurable_transform_rules.py
+++ b/tests/transformations/test_configurable_transform_rules.py
@@ -1,5 +1,10 @@
+from typing import Dict
+
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.transformations.default_granularity import (
+    SetDefaultGranularityRule,
 )
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
     PydanticSemanticManifestTransformer,
@@ -7,6 +12,7 @@ from dbt_semantic_interfaces.transformations.semantic_manifest_transformer impor
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
+from dbt_semantic_interfaces.type_enums import TimeGranularity
 
 
 class SliceNamesRule(SemanticManifestTransformRule):
@@ -32,3 +38,30 @@ def test_can_configure_model_transform_rules(  # noqa: D
     rules = [SliceNamesRule()]
     transformed_model = PydanticSemanticManifestTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
     assert all(len(x.name) == 3 for x in transformed_model.semantic_models)
+
+
+def test_set_default_granularity_rule(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
+    pre_model = simple_semantic_manifest__with_primary_transforms
+
+    metric_exists_without_default_granularity = False
+    configured_default_granularities: Dict[str, TimeGranularity] = {}
+    for metric in pre_model.metrics:
+        if metric.default_granularity:
+            configured_default_granularities[metric.name] = metric.default_granularity
+            metric_exists_without_default_granularity = True
+
+    assert (
+        pre_model.metrics and metric_exists_without_default_granularity
+    ), "If there are no metrics without a configured default_granularity, this tests nothing."
+
+    rules = [SetDefaultGranularityRule()]
+    transformed_model = PydanticSemanticManifestTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
+
+    for metric in transformed_model.metrics:
+        assert metric.default_granularity, f"No default_granularity set in transformation for metric '{metric.name}'"
+        if metric.name in configured_default_granularities:
+            assert (
+                metric.default_granularity == configured_default_granularities[metric.name]
+            ), f"Default granularity was unexpected changed during transformation for metric '{metric.name}"


### PR DESCRIPTION
### Description
Actually set the `default_granularity` during transformation using `SetDefaultGranularityRule`. This was an oversight from a previous PR. I added a test this time to ensure it works.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
