### PR TITLE
Include `SetDefaultGranularityRule` in `all_rules`

### DIFF
--- a/dbt_semantic_interfaces/transformations/default_granularity.py
+++ b/dbt_semantic_interfaces/transformations/default_granularity.py
@@ -34,7 +34,12 @@ class SetDefaultGranularityRule(ProtocolHint[SemanticManifestTransformRule[Pydan
             seen_agg_time_dimensions: Set[TimeDimensionReference] = set()
             for semantic_model in semantic_manifest.semantic_models:
                 for measure_ref in set(metric.measure_references).intersection(semantic_model.measure_references):
-                    agg_time_dimension_ref = semantic_model.checked_agg_time_dimension_for_measure(measure_ref)
+                    try:
+                        agg_time_dimension_ref = semantic_model.checked_agg_time_dimension_for_measure(measure_ref)
+                    except AssertionError:
+                        # This indicates the agg_time_dimension is misconfigured, which will fail elsewhere.
+                        # Do nothing here to avoid disrupting the validation process.
+                        continue
                     if agg_time_dimension_ref in seen_agg_time_dimensions:
                         continue
                     seen_agg_time_dimensions.add(agg_time_dimension_ref)

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -20,6 +20,7 @@ from dbt_semantic_interfaces.transformations.convert_median import (
 from dbt_semantic_interfaces.transformations.cumulative_type_params import (
     SetCumulativeTypeParamsRule,
 )
+from dbt_semantic_interfaces.transformations.default_granularity import SetDefaultGranularityRule
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.rule_set import (
@@ -54,6 +55,7 @@ class PydanticSemanticManifestTransformRuleSet(
             ConvertMedianToPercentileRule(),
             AddInputMetricMeasuresRule(),
             SetCumulativeTypeParamsRule(),
+            SetDefaultGranularityRule(),
         )
 
     @property

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -20,7 +20,9 @@ from dbt_semantic_interfaces.transformations.convert_median import (
 from dbt_semantic_interfaces.transformations.cumulative_type_params import (
     SetCumulativeTypeParamsRule,
 )
-from dbt_semantic_interfaces.transformations.default_granularity import SetDefaultGranularityRule
+from dbt_semantic_interfaces.transformations.default_granularity import (
+    SetDefaultGranularityRule,
+)
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
 from dbt_semantic_interfaces.transformations.rule_set import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.2.dev2"
+version = "0.6.2.dev3"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/validations/test_measures.py
+++ b/tests/validations/test_measures.py
@@ -72,6 +72,8 @@ def test_measures_only_exist_in_one_semantic_model() -> None:  # noqa: D
           node_relation:
             schema_name: some_schema
             alias: source_table
+          defaults:
+            agg_time_dimension: ds
           entities:
             - name: example_entity
               type: primary


### PR DESCRIPTION
### Description
Missed this - needs to be manually added to `all_rules` in order to get applied in MF.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
