### PR TITLE
Set `default_granularity` properly for nested metrics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.2"
+version = "0.6.3"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -559,3 +559,32 @@ metric:
     measure:
       name: listings
   filter: "{{ Metric('bookings', group_by=['listing', 'metric_time']) }} > 2"
+---
+metric:
+  name: monthly_bookings
+  description: bookings by month
+  label: bookings by month
+  type: simple
+  type_params:
+    measure:
+      name: monthly_bookings
+---
+metric:
+  name: yearly_bookings
+  description: bookings by year
+  label: bookings by year
+  type: simple
+  type_params:
+    measure:
+      name: yearly_bookings
+---
+metric:
+  name: monthly_times_yearly_bookings
+  description: monthly times yearly bookings
+  label: monthly times yearly bookings
+  type: derived
+  type_params:
+    expr: monthly_bookings * yearly_bookings
+    metrics:
+      - name: monthly_bookings
+      - name: yearly_bookings

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_source.yaml
@@ -65,7 +65,14 @@ semantic_model:
         percentile: 0.99
         use_discrete_percentile: true
         use_approximate_percentile: true
-
+    - name: monthly_bookings
+      expr: "1"
+      agg: sum
+      agg_time_dimension: ds_monthly
+    - name: yearly_bookings
+      expr: "1"
+      agg: sum
+      agg_time_dimension: ds_yearly
 
   dimensions:
     - name: is_instant
@@ -83,6 +90,16 @@ semantic_model:
       type: time
       type_params:
         time_granularity: day
+    - name: ds_monthly
+      type: time
+      expr: ds
+      type_params:
+        time_granularity: month
+    - name: ds_yearly
+      type: time
+      expr: ds
+      type_params:
+        time_granularity: year
 
   primary_entity: booking
 

--- a/tests/transformations/test_configurable_transform_rules.py
+++ b/tests/transformations/test_configurable_transform_rules.py
@@ -65,3 +65,5 @@ def test_set_default_granularity_rule(  # noqa: D
             assert (
                 metric.default_granularity == configured_default_granularities[metric.name]
             ), f"Default granularity was unexpected changed during transformation for metric '{metric.name}"
+        if metric.name == "monthly_times_yearly_bookings":
+            assert metric.default_granularity == TimeGranularity.YEAR


### PR DESCRIPTION
### Description
Previously, this transformation was not setting default granularity properly for metrics with input metrics (i.e., derived & ratio metrics). This is because `Metric.measure_references` only gets the top-level measures, not nested measures from input metrics. This PR fixes that bug by utilizing `PydanticMetric.all_input_measures_for_metric()` instead.
Note that this feature (`default_granularity`) has not been released yet so no customers should be impacted by this bug.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
