### PR TITLE
Default granularity bug fix: handle time dimensions with the same name

### DIFF
--- a/dbt_semantic_interfaces/transformations/default_granularity.py
+++ b/dbt_semantic_interfaces/transformations/default_granularity.py
@@ -9,10 +9,10 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
 )
 from dbt_semantic_interfaces.protocols import ProtocolHint
 from dbt_semantic_interfaces.protocols.metric import Metric
-from dbt_semantic_interfaces.protocols.semantic_model import SemanticModel
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     MetricReference,
+    SemanticModelReference,
     TimeDimensionReference,
 )
 from dbt_semantic_interfaces.transformations.transform_rule import (
@@ -38,7 +38,7 @@ class SetDefaultGranularityRule(ProtocolHint[SemanticManifestTransformRule[Pydan
                 continue
 
             default_granularity = TimeGranularity.DAY
-            seen_agg_time_dimensions: Set[Tuple[SemanticModel, TimeDimensionReference]] = set()
+            seen_agg_time_dimensions: Set[Tuple[SemanticModelReference, TimeDimensionReference]] = set()
 
             metric_index: Dict[MetricReference, Metric] = {
                 MetricReference(metric.name): metric for metric in semantic_manifest.metrics
@@ -59,7 +59,7 @@ class SetDefaultGranularityRule(ProtocolHint[SemanticManifestTransformRule[Pydan
                         )
                         continue
                     # Time dims might have the same names across semantic models, so check model/name combo.
-                    semantic_model_with_agg_time_dimension = (semantic_model, agg_time_dimension_ref)
+                    semantic_model_with_agg_time_dimension = (semantic_model.reference, agg_time_dimension_ref)
                     if semantic_model_with_agg_time_dimension in seen_agg_time_dimensions:
                         continue
                     seen_agg_time_dimensions.add(semantic_model_with_agg_time_dimension)

--- a/dbt_semantic_interfaces/transformations/default_granularity.py
+++ b/dbt_semantic_interfaces/transformations/default_granularity.py
@@ -50,6 +50,7 @@ class SetDefaultGranularityRule(ProtocolHint[SemanticManifestTransformRule[Pydan
                         # This indicates the agg_time_dimension is misconfigured, which will fail elsewhere.
                         # Do nothing here to avoid disrupting the validation process.
                         continue
+                    # This will skip some!!
                     if agg_time_dimension_ref in seen_agg_time_dimensions:
                         continue
                     seen_agg_time_dimensions.add(agg_time_dimension_ref)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.3"
+version = "0.6.4"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_monthly.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_monthly.yaml
@@ -14,7 +14,7 @@ semantic_model:
     - name: monthly_bookings
       expr: "1"
       agg: sum
-      
+
   dimensions:
     - name: ds
       type: time

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_monthly.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_monthly.yaml
@@ -1,0 +1,35 @@
+---
+semantic_model:
+  name: bookings_monthly
+  description: bookings_monthly
+
+  node_relation:
+    schema_name: $source_schema
+    alias: fct_bookings
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: monthly_bookings
+      expr: "1"
+      agg: sum
+      
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        time_granularity: month
+
+  primary_entity: monthly_booking
+
+  entities:
+    - name: listing
+      type: foreign
+      expr: listing_id
+    - name: guest
+      type: foreign
+      expr: guest_id
+    - name: host
+      type: foreign
+      expr: host_id

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_source.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_source.yaml
@@ -65,14 +65,6 @@ semantic_model:
         percentile: 0.99
         use_discrete_percentile: true
         use_approximate_percentile: true
-    - name: monthly_bookings
-      expr: "1"
-      agg: sum
-      agg_time_dimension: ds_monthly
-    - name: yearly_bookings
-      expr: "1"
-      agg: sum
-      agg_time_dimension: ds_yearly
 
   dimensions:
     - name: is_instant
@@ -90,16 +82,6 @@ semantic_model:
       type: time
       type_params:
         time_granularity: day
-    - name: ds_monthly
-      type: time
-      expr: ds
-      type_params:
-        time_granularity: month
-    - name: ds_yearly
-      type: time
-      expr: ds
-      type_params:
-        time_granularity: year
 
   primary_entity: booking
 

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_yearly.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_yearly.yaml
@@ -1,0 +1,35 @@
+---
+semantic_model:
+  name: bookings_yearly
+  description: bookings_yearly
+
+  node_relation:
+    schema_name: $source_schema
+    alias: fct_bookings
+
+  defaults:
+    agg_time_dimension: ds
+
+  measures:
+    - name: yearly_bookings
+      expr: "1"
+      agg: sum
+      
+  dimensions:
+    - name: ds
+      type: time
+      type_params:
+        time_granularity: year
+
+  primary_entity: yearly_booking
+
+  entities:
+    - name: listing
+      type: foreign
+      expr: listing_id
+    - name: guest
+      type: foreign
+      expr: guest_id
+    - name: host
+      type: foreign
+      expr: host_id

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_yearly.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/semantic_models/bookings_yearly.yaml
@@ -14,7 +14,7 @@ semantic_model:
     - name: yearly_bookings
       expr: "1"
       agg: sum
-      
+
   dimensions:
     - name: ds
       type: time


### PR DESCRIPTION
### Description
Found another bug in SetDefaultGranularityRule. If there are multiple `agg_time_dimensions` with the same name across semantic models, and they have different granularities, we'll only check one. Fixed here!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
