### PR TITLE
Don't require `time_granularity_name` in `QueryInterfaceTimeDimensionFactory`

### DIFF
--- a/.changes/unreleased/Fixes-20240703-131327.yaml
+++ b/.changes/unreleased/Fixes-20240703-131327.yaml
@@ -1,0 +1,7 @@
+kind: Fixes
+body: Don't require time_granularity_name in QueryInterfaceTimeDimensionFactory. This
+  creates consistency with other interfaces.
+time: 2024-07-03T13:13:27.671224-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "306"

--- a/dbt_semantic_interfaces/protocols/query_interface.py
+++ b/dbt_semantic_interfaces/protocols/query_interface.py
@@ -60,7 +60,7 @@ class QueryInterfaceTimeDimensionFactory(Protocol):
     def create(
         self,
         time_dimension_name: str,
-        time_granularity_name: str,
+        time_granularity_name: Optional[str] = None,
         entity_path: Sequence[str] = (),
         descending: Optional[bool] = None,
         date_part_name: Optional[str] = None,


### PR DESCRIPTION
Resolves #306

### Description
Currently, the protocol for `QueryInterfaceTimeDimensionFactory` requires `time_granularity_name` to be set. This is inconsistent with other interfaces, where granularity is not required and can be resolved at query time. For example, the DSI _implementation_ of this protocol (`WhereFilterTimeDimensionFactory`) does not require the parameter, but the implementation in MFS does.
I did not include tests since this is a change to the protocol only. The corresponding change in MFS will have tests.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
