### PR TITLE
Add full SL team to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,4 +13,4 @@
 
 
 # Parsing, validations, and protocols
-/dbt_semantic_interfaces/**  @dbt-labs/metricflow-admins @QMalcolm @graciegoheen
+/dbt_semantic_interfaces/**  @dbt-labs/semantic-layer @QMalcolm @graciegoheen


### PR DESCRIPTION

### Description
This will enable all SL engineers to give approval for DSI PRs, instead of just MetricFlow admins.