### PR TITLE
Remove inconsistent Jinja param errors

### DIFF
--- a/dbt_semantic_interfaces/call_parameter_sets.py
+++ b/dbt_semantic_interfaces/call_parameter_sets.py
@@ -16,15 +16,16 @@ from dbt_semantic_interfaces.type_enums.date_part import DatePart
 
 @dataclass(frozen=True)
 class DimensionCallParameterSet:
-    """When 'Dimension(...)' is used in the Jinja template of the where filter, the parameters to that call."""
+    """When 'Dimension(...)' is used in a Jinja template, the parameters to that call."""
 
     entity_path: Tuple[EntityReference, ...]
     dimension_reference: DimensionReference
+    # TODO: MFS Jinja allows grain and date part in Dimension(...). Should we allow them here, too, for consistency?
 
 
 @dataclass(frozen=True)
 class TimeDimensionCallParameterSet:
-    """When 'TimeDimension(...)' is used in the Jinja template of the where filter, the parameters to that call."""
+    """When 'TimeDimension(...)' is used in the Jinja template, the parameters to that call."""
 
     entity_path: Tuple[EntityReference, ...]
     time_dimension_reference: TimeDimensionReference
@@ -34,7 +35,7 @@ class TimeDimensionCallParameterSet:
 
 @dataclass(frozen=True)
 class EntityCallParameterSet:
-    """When 'Entity(...)' is used in the Jinja template of the where filter, the parameters to that call."""
+    """When 'Entity(...)' is used in the Jinja template, the parameters to that call."""
 
     entity_path: Tuple[EntityReference, ...]
     entity_reference: EntityReference

--- a/dbt_semantic_interfaces/type_enums/__init__.py
+++ b/dbt_semantic_interfaces/type_enums/__init__.py
@@ -4,6 +4,7 @@ from dbt_semantic_interfaces.type_enums.aggregation_type import (  # noqa:F401
 from dbt_semantic_interfaces.type_enums.conversion_calculation_type import (  # noqa:F401
     ConversionCalculationType,
 )
+from dbt_semantic_interfaces.type_enums.date_part import DatePart  # noqa:F401
 from dbt_semantic_interfaces.type_enums.dimension_type import DimensionType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.entity_type import EntityType  # noqa:F401
 from dbt_semantic_interfaces.type_enums.metric_type import MetricType  # noqa:F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.4"
+version = "0.6.5"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
### Description
Remove some errors related to Jinja objects. This will allow more flexible syntax. The main problem driving this change is that we have multiple places that parse the same Jinja syntax, but each has different behavior. This means that if you pass a certain syntax into a where filter, that same syntax won't work in a group by. In order to align the two, we must use the more permissive option, since adding new restrictions would be a breaking change. Changes here:
- Allow passing the grain in the name of a time dimension using dunder syntax. This means it can be passed in the name or via a separate parameter, and we will only error if both are passed and they don't match.
- Don't error if `metric_time` is passed into a `Dimension(...)` object. This error creates inconsistent restrictions, not only between where & group by params, but within this where param. Before this change, it would only error if you passed `metric_time` into `Dimension(...)` _without_ a grain. If you include a grain, no error. Instead of raising this error, just allow it and MF will sort it out.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
