### PR TITLE
Rename `Metric.default_granularity` field to `Metric.time_granularity`

### DIFF
--- a/.changes/unreleased/Features-20240614-140515.yaml
+++ b/.changes/unreleased/Features-20240614-140515.yaml
@@ -1,5 +1,5 @@
 kind: Features
-body: Add default_granularity to metric spec.
+body: Add time_granularity to metric spec.
 time: 2024-06-14T14:05:15.355931-07:00
 custom:
   Author: courtneyholcomb

--- a/.changes/unreleased/Under the Hood-20240711-105519.yaml
+++ b/.changes/unreleased/Under the Hood-20240711-105519.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Rename Metric.default_granularity field to Metric.time_granularity.
+time: 2024-07-11T10:55:19.887705-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "290"

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -206,7 +206,7 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
     metadata: Optional[PydanticMetadata]
     label: Optional[str] = None
     config: Optional[PydanticMetricConfig]
-    default_granularity: Optional[TimeGranularity] = None
+    time_granularity: Optional[TimeGranularity] = None
 
     @property
     def input_measures(self) -> Sequence[PydanticMetricInputMeasure]:

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -458,7 +458,7 @@
                 "config": {
                     "$ref": "#/definitions/metric_config_schema"
                 },
-                "default_granularity": {
+                "time_granularity": {
                     "enum": [
                         "NANOSECOND",
                         "MICROSECOND",

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -304,7 +304,7 @@ metric_schema = {
         "description": {"type": "string"},
         "label": {"type": "string"},
         "config": {"$ref": "metric_config_schema"},
-        "default_granularity": {"enum": time_granularity_values},
+        "time_granularity": {"enum": time_granularity_values},
     },
     "additionalProperties": False,
     "required": ["name", "type", "type_params"],

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -328,7 +328,7 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def default_granularity(self) -> Optional[TimeGranularity]:
+    def time_granularity(self) -> Optional[TimeGranularity]:
         """Default grain used for the metric.
 
         This will be used in a couple of circumstances:

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -123,7 +123,7 @@ def metric_with_guaranteed_meta(
     type_params: PydanticMetricTypeParams,
     metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
-    default_granularity: Optional[TimeGranularity] = None,
+    time_granularity: Optional[TimeGranularity] = None,
 ) -> PydanticMetric:
     """Creates a metric with the given input.
 
@@ -136,7 +136,7 @@ def metric_with_guaranteed_meta(
         type_params=type_params,
         filter=None,
         metadata=metadata,
-        default_granularity=default_granularity,
+        time_granularity=time_granularity,
     )
 
 

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -20,8 +20,8 @@ from dbt_semantic_interfaces.transformations.convert_median import (
 from dbt_semantic_interfaces.transformations.cumulative_type_params import (
     SetCumulativeTypeParamsRule,
 )
-from dbt_semantic_interfaces.transformations.default_granularity import (
-    SetDefaultGranularityRule,
+from dbt_semantic_interfaces.transformations.metric_time_granularity import (
+    SetMetricTimeGranularityRule,
 )
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
@@ -57,7 +57,7 @@ class PydanticSemanticManifestTransformRuleSet(
             ConvertMedianToPercentileRule(),
             AddInputMetricMeasuresRule(),
             SetCumulativeTypeParamsRule(),
-            SetDefaultGranularityRule(),
+            SetMetricTimeGranularityRule(),
         )
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.5"
+version = "0.6.6"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/metrics.yaml
@@ -154,7 +154,7 @@ metric:
   name: "trailing_2_months_revenue"
   description: "trailing_2_months_revenue"
   type: cumulative
-  default_granularity: month
+  time_granularity: month
   type_params:
     measure:
       name: txn_revenue

--- a/tests/transformations/test_configurable_transform_rules.py
+++ b/tests/transformations/test_configurable_transform_rules.py
@@ -3,8 +3,8 @@ from typing import Dict
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.transformations.default_granularity import (
-    SetDefaultGranularityRule,
+from dbt_semantic_interfaces.transformations.metric_time_granularity import (
+    SetMetricTimeGranularityRule,
 )
 from dbt_semantic_interfaces.transformations.semantic_manifest_transformer import (
     PydanticSemanticManifestTransformer,
@@ -40,30 +40,30 @@ def test_can_configure_model_transform_rules(  # noqa: D
     assert all(len(x.name) == 3 for x in transformed_model.semantic_models)
 
 
-def test_set_default_granularity_rule(  # noqa: D
+def test_set_time_granularity_rule(  # noqa: D
     simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
 ) -> None:
     pre_model = simple_semantic_manifest__with_primary_transforms
 
-    metric_exists_without_default_granularity = False
+    metric_exists_without_time_granularity = False
     configured_default_granularities: Dict[str, TimeGranularity] = {}
     for metric in pre_model.metrics:
-        if metric.default_granularity:
-            configured_default_granularities[metric.name] = metric.default_granularity
-            metric_exists_without_default_granularity = True
+        if metric.time_granularity:
+            configured_default_granularities[metric.name] = metric.time_granularity
+            metric_exists_without_time_granularity = True
 
     assert (
-        pre_model.metrics and metric_exists_without_default_granularity
-    ), "If there are no metrics without a configured default_granularity, this tests nothing."
+        pre_model.metrics and metric_exists_without_time_granularity
+    ), "If there are no metrics without a configured time_granularity, this tests nothing."
 
-    rules = [SetDefaultGranularityRule()]
+    rules = [SetMetricTimeGranularityRule()]
     transformed_model = PydanticSemanticManifestTransformer.transform(pre_model, ordered_rule_sequences=(rules,))
 
     for metric in transformed_model.metrics:
-        assert metric.default_granularity, f"No default_granularity set in transformation for metric '{metric.name}'"
+        assert metric.time_granularity, f"No time_granularity set in transformation for metric '{metric.name}'"
         if metric.name in configured_default_granularities:
             assert (
-                metric.default_granularity == configured_default_granularities[metric.name]
-            ), f"Default granularity was unexpected changed during transformation for metric '{metric.name}"
+                metric.time_granularity == configured_default_granularities[metric.name]
+            ), f"Time granularity was unexpected changed during transformation for metric '{metric.name}"
         if metric.name == "monthly_times_yearly_bookings":
-            assert metric.default_granularity == TimeGranularity.YEAR
+            assert metric.time_granularity == TimeGranularity.YEAR


### PR DESCRIPTION
### Description
After some discussion with product and dev experience, we've decided to change the name of this field. It hasn't shipped to core yet so is not a breaking change. The name change is intended to remove the word "default", which should be implied for a YAML field. This is more consistent with other dbt YAML objects, which have a default in YAML that can be overridden at query time. The name `time_granularity` is also more consistent with the field we have on time dimensions.
Everything in this PR is just a find & replace operation.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
