### PR TITLE
Only give one validation warning for deprecated cumulative fields

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.6.7"
+version = "0.6.8"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -602,7 +602,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                 ),
             ],
             metrics=[
-                # Metrics with old type params structure - should 2 get warnings
+                # Metrics with old type params structure - should get warning
                 metric_with_guaranteed_meta(
                     name="metric1",
                     type=MetricType.CUMULATIVE,
@@ -640,7 +640,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                         cumulative_type_params=PydanticCumulativeTypeParams(grain_to_date=TimeGranularity.MONTH),
                     ),
                 ),
-                # Metric with both window & grain across both type_params - should get 2 warnings
+                # Metric with both window & grain across both type_params - should get warning
                 metric_with_guaranteed_meta(
                     name="woooooo",
                     type=MetricType.CUMULATIVE,
@@ -653,7 +653,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                         ),
                     ),
                 ),
-                # Metrics with duplicated window or grain_to_date - should 4 get warnings
+                # Metrics with duplicated window or grain_to_date - should get warning
                 metric_with_guaranteed_meta(
                     name="what_a_metric",
                     type=MetricType.CUMULATIVE,
@@ -691,12 +691,12 @@ def test_cumulative_metrics() -> None:  # noqa: D
     )
 
     build_issues = validation_results.all_issues
-    assert len(build_issues) == 8
+    assert len(build_issues) == 4
     expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
     expected_substr2 = "Got differing values for `window`"
     expected_substr3 = "Got differing values for `grain_to_date`"
-    expected_substr4 = "Cumulative `type_params.window` field has been moved and will soon be deprecated."
-    expected_substr5 = "Cumulative `type_params.grain_to_date` field has been moved and will soon be deprecated."
+    expected_substr4 = "Cumulative fields `type_params.window` and `type_params.grain_to_date` have been moved"
+    expected_substr5 = str(sorted({"what_a_metric", "dis_bad", "woooooo", "metric1", "metric2"}))
     missing_error_strings = set()
     for expected_str in [expected_substr1, expected_substr2, expected_substr3, expected_substr4, expected_substr5]:
         if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):


### PR DESCRIPTION
### Description
These `cumulative_type_params` validations turned out more annoying than helpful, so we've decided to only give one warning for the entire manifest instead of one per metric. This required a little bit of restructuring.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
