### PR TITLE
Add new time spine configuration

### DIFF
--- a/.changes/unreleased/Features-20240716-104215.yaml
+++ b/.changes/unreleased/Features-20240716-104215.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support for configuring multiple time spines at different granularities.
+time: 2024-07-16T10:42:15.662883-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "280"

--- a/dbt_semantic_interfaces/implementations/node_relation.py
+++ b/dbt_semantic_interfaces/implementations/node_relation.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from typing_extensions import override
+
+from dbt_semantic_interfaces.implementations.base import HashableBaseModel
+from dbt_semantic_interfaces.protocols import ProtocolHint
+from dbt_semantic_interfaces.protocols.node_relation import NodeRelation
+from dsi_pydantic_shim import validator
+
+
+class PydanticNodeRelation(HashableBaseModel, ProtocolHint[NodeRelation]):
+    """Path object to where the data should be."""
+
+    alias: str
+    schema_name: str
+    database: Optional[str] = None
+    relation_name: str = ""
+
+    @override
+    def _implements_protocol(self) -> NodeRelation:  # noqa: D
+        return self
+
+    @validator("relation_name", always=True)
+    @classmethod
+    def __create_default_relation_name(cls, value: Any, values: Any) -> str:  # type: ignore[misc]
+        """Dynamically build the dot path for `relation_name`, if not specified."""
+        if value:
+            # Only build the relation_name if it was not present in config.
+            return value
+
+        alias, schema, database = values.get("alias"), values.get("schema_name"), values.get("database")
+        if alias is None or schema is None:
+            raise ValueError(
+                f"Failed to build relation_name because alias and/or schema was None. schema: {schema}, alias: {alias}"
+            )
+
+        if database is not None:
+            value = f"{database}.{schema}.{alias}"
+        else:
+            value = f"{schema}.{alias}"
+        return value
+
+    @staticmethod
+    def from_string(sql_str: str) -> PydanticNodeRelation:  # noqa: D
+        sql_str_split = sql_str.split(".")
+        if len(sql_str_split) == 2:
+            return PydanticNodeRelation(schema_name=sql_str_split[0], alias=sql_str_split[1])
+        elif len(sql_str_split) == 3:
+            return PydanticNodeRelation(database=sql_str_split[0], schema_name=sql_str_split[1], alias=sql_str_split[2])
+        raise RuntimeError(
+            f"Invalid input for a SQL table, expected form '<schema>.<table>' or '<db>.<schema>.<table>' "
+            f"but got: {sql_str}"
+        )

--- a/dbt_semantic_interfaces/implementations/project_configuration.py
+++ b/dbt_semantic_interfaces/implementations/project_configuration.py
@@ -14,6 +14,7 @@ from dbt_semantic_interfaces.implementations.semantic_version import (
     UNKNOWN_VERSION_SENTINEL,
     PydanticSemanticVersion,
 )
+from dbt_semantic_interfaces.implementations.time_spine import PydanticTimeSpine
 from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
     PydanticTimeSpineTableConfiguration,
 )
@@ -32,6 +33,7 @@ class PydanticProjectConfiguration(HashableBaseModel, ModelWithMetadataParsing, 
     time_spine_table_configurations: List[PydanticTimeSpineTableConfiguration]
     metadata: Optional[PydanticMetadata] = None
     dsi_package_version: PydanticSemanticVersion = UNKNOWN_VERSION_SENTINEL
+    time_spines: List[PydanticTimeSpine] = []
 
     @validator("dsi_package_version", always=True)
     @classmethod

--- a/dbt_semantic_interfaces/implementations/semantic_model.py
+++ b/dbt_semantic_interfaces/implementations/semantic_model.py
@@ -12,13 +12,13 @@ from dbt_semantic_interfaces.implementations.elements.dimension import PydanticD
 from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
 from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
 from dbt_semantic_interfaces.implementations.metadata import PydanticMetadata
+from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
 from dbt_semantic_interfaces.protocols import (
     ProtocolHint,
     SemanticModel,
     SemanticModelConfig,
     SemanticModelDefaults,
 )
-from dbt_semantic_interfaces.protocols.semantic_model import NodeRelation
 from dbt_semantic_interfaces.references import (
     DimensionReference,
     EntityReference,
@@ -27,52 +27,7 @@ from dbt_semantic_interfaces.references import (
     SemanticModelReference,
     TimeDimensionReference,
 )
-from dsi_pydantic_shim import Field, validator
-
-
-class PydanticNodeRelation(HashableBaseModel, ProtocolHint[NodeRelation]):
-    """Path object to where the data should be."""
-
-    alias: str
-    schema_name: str
-    database: Optional[str] = None
-    relation_name: str = ""
-
-    @override
-    def _implements_protocol(self) -> NodeRelation:  # noqa: D
-        return self
-
-    @validator("relation_name", always=True)
-    @classmethod
-    def __create_default_relation_name(cls, value: Any, values: Any) -> str:  # type: ignore[misc]
-        """Dynamically build the dot path for `relation_name`, if not specified."""
-        if value:
-            # Only build the relation_name if it was not present in config.
-            return value
-
-        alias, schema, database = values.get("alias"), values.get("schema_name"), values.get("database")
-        if alias is None or schema is None:
-            raise ValueError(
-                f"Failed to build relation_name because alias and/or schema was None. schema: {schema}, alias: {alias}"
-            )
-
-        if database is not None:
-            value = f"{database}.{schema}.{alias}"
-        else:
-            value = f"{schema}.{alias}"
-        return value
-
-    @staticmethod
-    def from_string(sql_str: str) -> PydanticNodeRelation:  # noqa: D
-        sql_str_split = sql_str.split(".")
-        if len(sql_str_split) == 2:
-            return PydanticNodeRelation(schema_name=sql_str_split[0], alias=sql_str_split[1])
-        elif len(sql_str_split) == 3:
-            return PydanticNodeRelation(database=sql_str_split[0], schema_name=sql_str_split[1], alias=sql_str_split[2])
-        raise RuntimeError(
-            f"Invalid input for a SQL table, expected form '<schema>.<table>' or '<db>.<schema>.<table>' "
-            f"but got: {sql_str}"
-        )
+from dsi_pydantic_shim import Field
 
 
 class PydanticSemanticModelDefaults(HashableBaseModel, ProtocolHint[SemanticModelDefaults]):  # noqa: D

--- a/dbt_semantic_interfaces/implementations/time_spine.py
+++ b/dbt_semantic_interfaces/implementations/time_spine.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing_extensions import override
+
+from dbt_semantic_interfaces.implementations.base import HashableBaseModel
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticNodeRelation
+from dbt_semantic_interfaces.protocols import ProtocolHint
+from dbt_semantic_interfaces.protocols.time_spine import (
+    TimeSpine,
+    TimeSpinePrimaryColumn,
+)
+from dbt_semantic_interfaces.type_enums import TimeGranularity
+
+
+class PydanticTimeSpinePrimaryColumn(HashableBaseModel, ProtocolHint[TimeSpinePrimaryColumn]):
+    """Legacy Pydantic implementation of SemanticVersion. In the process of deprecation."""
+
+    @override
+    def _implements_protocol(self) -> TimeSpinePrimaryColumn:
+        return self
+
+    name: str
+    time_granularity: TimeGranularity
+
+
+class PydanticTimeSpine(HashableBaseModel, ProtocolHint[TimeSpine]):
+    """Legacy Pydantic implementation of SemanticVersion. In the process of deprecation."""
+
+    @override
+    def _implements_protocol(self) -> TimeSpine:
+        return self
+
+    name: str
+    node_relation: PydanticNodeRelation
+    primary_column: PydanticTimeSpinePrimaryColumn

--- a/dbt_semantic_interfaces/implementations/time_spine_table_configuration.py
+++ b/dbt_semantic_interfaces/implementations/time_spine_table_configuration.py
@@ -16,7 +16,7 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 class PydanticTimeSpineTableConfiguration(
     HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[TimeSpineTableConfiguration]
 ):
-    """Pydantic implementation of SemanticVersion."""
+    """Legacy Pydantic implementation of SemanticVersion. In the process of deprecation."""
 
     @override
     def _implements_protocol(self) -> TimeSpineTableConfiguration:

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -621,11 +621,15 @@
                         "$ref": "#/definitions/time_spine_table_configuration_schema"
                     },
                     "type": "array"
+                },
+                "time_spines": {
+                    "items": {
+                        "$ref": "#/definitions/time_spine_schema"
+                    },
+                    "type": "array"
                 }
             },
-            "required": [
-                "time_spine_table_configurations"
-            ],
+            "required": [],
             "type": "object"
         },
         "saved_query_query_params_schema": {
@@ -753,6 +757,67 @@
             },
             "required": [
                 "name"
+            ],
+            "type": "object"
+        },
+        "time_spine_primary_column_schema": {
+            "$id": "time_spine_primary_column_schema",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "time_granularity": {
+                    "enum": [
+                        "NANOSECOND",
+                        "MICROSECOND",
+                        "MILLISECOND",
+                        "SECOND",
+                        "MINUTE",
+                        "HOUR",
+                        "DAY",
+                        "WEEK",
+                        "MONTH",
+                        "QUARTER",
+                        "YEAR",
+                        "nanosecond",
+                        "microsecond",
+                        "millisecond",
+                        "second",
+                        "minute",
+                        "hour",
+                        "day",
+                        "week",
+                        "month",
+                        "quarter",
+                        "year"
+                    ]
+                }
+            },
+            "required": [
+                "name",
+                "time_granularity"
+            ],
+            "type": "object"
+        },
+        "time_spine_schema": {
+            "$id": "time_spine_schema",
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "node_relation": {
+                    "$ref": "#/definitions/node_relation_schema"
+                },
+                "primary_column": {
+                    "$ref": "#/definitions/time_spine_primary_column_schema"
+                }
+            },
+            "required": [
+                "name",
+                "node_relation",
+                "primary_column"
             ],
             "type": "object"
         },

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -347,6 +347,29 @@ time_spine_table_configuration_schema = {
     "required": ["location", "column_name", "grain"],
 }
 
+time_spine_primary_column_schema = {
+    "$id": "time_spine_primary_column_schema",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "time_granularity": {"enum": time_granularity_values},
+    },
+    "additionalProperties": False,
+    "required": ["name", "time_granularity"],
+}
+
+time_spine_schema = {
+    "$id": "time_spine_schema",
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "node_relation": {"$ref": "node_relation_schema"},
+        "primary_column": {"$ref": "time_spine_primary_column_schema"},
+    },
+    "additionalProperties": False,
+    "required": ["name", "node_relation", "primary_column"],
+}
+
 
 project_configuration_schema = {
     "$id": "project_configuration_schema",
@@ -356,9 +379,13 @@ project_configuration_schema = {
             "type": "array",
             "items": {"$ref": "time_spine_table_configuration_schema"},
         },
+        "time_spines": {
+            "type": "array",
+            "items": {"$ref": "time_spine_schema"},
+        },
     },
     "additionalProperties": False,
-    "required": ["time_spine_table_configurations"],
+    "required": [],
 }
 
 export_config_schema = {
@@ -475,6 +502,8 @@ schema_store = {
     node_relation_schema["$id"]: node_relation_schema,
     semantic_model_defaults_schema["$id"]: semantic_model_defaults_schema,
     time_spine_table_configuration_schema["$id"]: time_spine_table_configuration_schema,
+    time_spine_schema["$id"]: time_spine_schema,
+    time_spine_primary_column_schema["$id"]: time_spine_primary_column_schema,
     export_schema["$id"]: export_schema,
     export_config_schema["$id"]: export_config_schema,
     saved_query_query_params_schema["$id"]: saved_query_query_params_schema,

--- a/dbt_semantic_interfaces/protocols/node_relation.py
+++ b/dbt_semantic_interfaces/protocols/node_relation.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Optional, Protocol
+
+
+class NodeRelation(Protocol):
+    """Path object to where the data should be."""
+
+    @property
+    @abstractmethod
+    def alias(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def schema_name(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def database(self) -> Optional[str]:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def relation_name(self) -> str:  # noqa: D
+        pass

--- a/dbt_semantic_interfaces/protocols/project_configuration.py
+++ b/dbt_semantic_interfaces/protocols/project_configuration.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 from typing import Protocol, Sequence
 
 from dbt_semantic_interfaces.protocols.semantic_version import SemanticVersion
+from dbt_semantic_interfaces.protocols.time_spine import TimeSpine
 from dbt_semantic_interfaces.protocols.time_spine_configuration import (
     TimeSpineTableConfiguration,
 )
@@ -18,6 +19,12 @@ class ProjectConfiguration(Protocol):
 
     @property
     @abstractmethod
-    def time_spine_table_configurations(self) -> Sequence[TimeSpineTableConfiguration]:
+    def time_spines(self) -> Sequence[TimeSpine]:
         """The time spine table configurations. Multiple allowed for different time grains."""
+        pass
+
+    @property
+    @abstractmethod
+    def time_spine_table_configurations(self) -> Sequence[TimeSpineTableConfiguration]:
+        """Legacy time spine table configurations. In the process of deprecation."""
         pass

--- a/dbt_semantic_interfaces/protocols/semantic_model.py
+++ b/dbt_semantic_interfaces/protocols/semantic_model.py
@@ -7,6 +7,7 @@ from dbt_semantic_interfaces.protocols.dimension import Dimension
 from dbt_semantic_interfaces.protocols.entity import Entity
 from dbt_semantic_interfaces.protocols.measure import Measure
 from dbt_semantic_interfaces.protocols.metadata import Metadata
+from dbt_semantic_interfaces.protocols.node_relation import NodeRelation
 from dbt_semantic_interfaces.references import (
     EntityReference,
     LinkableElementReference,
@@ -14,30 +15,6 @@ from dbt_semantic_interfaces.references import (
     SemanticModelReference,
     TimeDimensionReference,
 )
-
-
-class NodeRelation(Protocol):
-    """Path object to where the data should be."""
-
-    @property
-    @abstractmethod
-    def alias(self) -> str:  # noqa: D
-        pass
-
-    @property
-    @abstractmethod
-    def schema_name(self) -> str:  # noqa: D
-        pass
-
-    @property
-    @abstractmethod
-    def database(self) -> Optional[str]:  # noqa: D
-        pass
-
-    @property
-    @abstractmethod
-    def relation_name(self) -> str:  # noqa: D
-        pass
 
 
 class SemanticModelDefaults(Protocol):

--- a/dbt_semantic_interfaces/protocols/time_spine.py
+++ b/dbt_semantic_interfaces/protocols/time_spine.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Protocol
+
+from dbt_semantic_interfaces.implementations.node_relation import NodeRelation
+from dbt_semantic_interfaces.type_enums import TimeGranularity
+
+
+class TimeSpine(Protocol):
+    """Describes a table that contains dates at a specific time grain.
+
+    One column must map to a standard granularity (one of the TimeGranularity enum members). Others might represent
+    custom granularity columns. Custom granularity columns are not yet implemented.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """A name the user assigns to this time spine."""
+        pass
+
+    @property
+    @abstractmethod
+    def node_relation(self) -> NodeRelation:
+        """dbt model where this time spine lives."""  # noqa: D403
+        pass
+
+    @property
+    @abstractmethod
+    def primary_column(self) -> TimeSpinePrimaryColumn:
+        """The column in the time spine that maps to one of our standard granularities."""
+        pass
+
+
+class TimeSpinePrimaryColumn(Protocol):
+    """The column in the time spine that maps to one of our standard granularities."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """The column name."""
+        pass
+
+    @property
+    @abstractmethod
+    def time_granularity(self) -> TimeGranularity:
+        """The column name."""
+        pass

--- a/dbt_semantic_interfaces/protocols/time_spine_configuration.py
+++ b/dbt_semantic_interfaces/protocols/time_spine_configuration.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 from typing import Protocol
 
@@ -5,10 +7,10 @@ from dbt_semantic_interfaces.type_enums import TimeGranularity
 
 
 class TimeSpineTableConfiguration(Protocol):
-    """Describes the configuration for a time spine table.
+    """Legacy time spine class that will eventually be deprecated in favor of TimeSpine.
 
+    Describes the configuration for a time spine table.
     A time spine table is a table with a single column containing dates at a specific grain.
-
     e.g. with day granularity:
     ...
     2020-01-01

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -20,7 +20,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import (
-    NodeRelation,
+    PydanticNodeRelation,
     PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
@@ -143,7 +143,7 @@ def metric_with_guaranteed_meta(
 def semantic_model_with_guaranteed_meta(
     name: str,
     description: Optional[str] = None,
-    node_relation: Optional[NodeRelation] = None,
+    node_relation: Optional[PydanticNodeRelation] = None,
     metadata: PydanticMetadata = default_meta(),
     entities: Sequence[PydanticEntity] = (),
     measures: Sequence[PydanticMeasure] = (),
@@ -155,7 +155,7 @@ def semantic_model_with_guaranteed_meta(
     """
     created_node_relation = node_relation
     if created_node_relation is None:
-        created_node_relation = NodeRelation(
+        created_node_relation = PydanticNodeRelation(
             schema_name="schema",
             alias="table",
         )

--- a/tests/example_project_configuration.py
+++ b/tests/example_project_configuration.py
@@ -1,7 +1,12 @@
 import textwrap
 
+from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
 from dbt_semantic_interfaces.implementations.project_configuration import (
     PydanticProjectConfiguration,
+)
+from dbt_semantic_interfaces.implementations.time_spine import (
+    PydanticTimeSpine,
+    PydanticTimeSpinePrimaryColumn,
 )
 from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
     PydanticTimeSpineTableConfiguration,
@@ -17,6 +22,13 @@ EXAMPLE_PROJECT_CONFIGURATION = PydanticProjectConfiguration(
             grain=TimeGranularity.DAY,
         )
     ],
+    time_spines=[
+        PydanticTimeSpine(
+            name="day_time_spine",
+            node_relation=PydanticNodeRelation(alias="day_time_spine", schema_name="stuff"),
+            primary_column=PydanticTimeSpinePrimaryColumn(name="ds_day", time_granularity=TimeGranularity.DAY),
+        )
+    ],
 )
 
 EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE = YamlConfigFile(
@@ -28,6 +40,14 @@ EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE = YamlConfigFile(
             - location: example_schema.example_table
               column_name: ds
               grain: day
+          time_spines:
+            - name: day_time_spine
+              node_relation:
+                schema_name: stuff
+                alias: day_time_spine
+              primary_column:
+                name: ds_day
+                time_granularity: day
         """
     ),
 )

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/project_configuration.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/project_configuration.yaml
@@ -4,3 +4,11 @@ project_configuration:
     - location: example_schema.example_table
       column_name: ds
       grain: day
+  time_spines:
+    - name: day_time_spine
+      node_relation:
+        schema_name: stuff
+        alias: day_time_spine
+      primary_column:
+        name: ds_day
+        time_granularity: day

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -35,7 +35,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
+from dbt_semantic_interfaces.implementations.time_spine_table_deprecated import (
     PydanticTimeSpineTableConfiguration,
 )
 from dbt_semantic_interfaces.protocols import Dimension as DimensionProtocol
@@ -48,7 +48,7 @@ from dbt_semantic_interfaces.protocols import (
     SemanticManifest as SemanticManifestProtocol,
 )
 from dbt_semantic_interfaces.protocols import SemanticModel as SemanticModelProtocol
-from dbt_semantic_interfaces.protocols.time_spine_configuration import (
+from dbt_semantic_interfaces.protocols.time_spine_deprecated import (
     TimeSpineTableConfiguration as TimeSpineTableConfigurationProtocol,
 )
 from dbt_semantic_interfaces.type_enums import DimensionType, MetricType

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -35,7 +35,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.implementations.time_spine_deprecated import (
+from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
     PydanticTimeSpineTableConfiguration,
 )
 from dbt_semantic_interfaces.protocols import Dimension as DimensionProtocol
@@ -48,7 +48,7 @@ from dbt_semantic_interfaces.protocols import (
     SemanticManifest as SemanticManifestProtocol,
 )
 from dbt_semantic_interfaces.protocols import SemanticModel as SemanticModelProtocol
-from dbt_semantic_interfaces.protocols.time_spine_deprecated import (
+from dbt_semantic_interfaces.protocols.time_spine_configuration import (
     TimeSpineTableConfiguration as TimeSpineTableConfigurationProtocol,
 )
 from dbt_semantic_interfaces.type_enums import DimensionType, MetricType

--- a/tests/test_implements_satisfy_protocols.py
+++ b/tests/test_implements_satisfy_protocols.py
@@ -35,7 +35,7 @@ from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
-from dbt_semantic_interfaces.implementations.time_spine_table_deprecated import (
+from dbt_semantic_interfaces.implementations.time_spine_deprecated import (
     PydanticTimeSpineTableConfiguration,
 )
 from dbt_semantic_interfaces.protocols import Dimension as DimensionProtocol

--- a/tests/validations/test_reserved_keywords.py
+++ b/tests/validations/test_reserved_keywords.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
-from dbt_semantic_interfaces.implementations.semantic_model import NodeRelation
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticNodeRelation
 from dbt_semantic_interfaces.test_utils import find_semantic_model_with
 from dbt_semantic_interfaces.validations.reserved_keywords import (
     RESERVED_KEYWORDS,
@@ -76,7 +76,7 @@ def test_reserved_keywords_in_node_relation(  # noqa: D
     (semantic_model_with_node_relation, _index) = find_semantic_model_with(
         model=model, function=lambda semantic_model: semantic_model.node_relation is not None
     )
-    semantic_model_with_node_relation.node_relation = NodeRelation(
+    semantic_model_with_node_relation.node_relation = PydanticNodeRelation(
         alias=random_keyword(),
         schema_name="some_schema",
     )


### PR DESCRIPTION
Resolves #280 

### Description
The time spine configuration has been redesigned to support new features (sub-daily granularity and custom calendar - [designs here](https://www.notion.so/dbtlabs/Custom-Calendar-bb8e98131c1247b084dba242e05421db?pvs=4#9c5120839d68447680d3e1f09b500abe)). This PR adds the new configuration needed for sub-daily granularity and marks the old one as in the process of deprecation. Best reviewed by commit to isolate the `NodeRelation` changes.

- Deprecated config: Currently, the `TimeSpineTableConfiguration` is automatically set for all users in the core parser. This assumes the user has set up a model called `metricflow_time_spine` at `DAY` granularity, so that configuration is set automatically in the manifest. This config was never exposed to users in YAML. The only logic change made here for the legacy config is to make it no longer required in the JSON schema, which will help with eventual migration. The plan is to continue setting the old config automatically in the manifest until users have migrated over to the new one, using validation warnings to prompt them to migrate. MetricFlow will support both fields in the meantime.
- `NodeRelation` changes: I renamed the `NodeRelation` implementation class `PydanticNodeRelation` to match all other implementation classes - previously the protocol and implementation classes had the same name. This will not be a breaking change for core/mantle because this class is never imported directly there. I also needed to move those classes to their own files to avoid circular imports. Viewing that commit separately should be helpful for review - the commit is purely copy/paste, no logic changes.
- New config: I've included an example of what the YAML spec has been designed to look like below. Note that the top level key (`semantic-layer`) and the `model` key will be implemented in core instead of here.
```
semantic-layer:
  time_spines:
    - name: daily_time_spine
      model: ref('daily_time_spine')
      primary_column:
        name: created_at
        time_granularity: day
```


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
