### PR TITLE
Remove name from time spine config

### DIFF
--- a/dbt_semantic_interfaces/implementations/time_spine.py
+++ b/dbt_semantic_interfaces/implementations/time_spine.py
@@ -30,6 +30,5 @@ class PydanticTimeSpine(HashableBaseModel, ProtocolHint[TimeSpine]):
     def _implements_protocol(self) -> TimeSpine:
         return self
 
-    name: str
     node_relation: PydanticNodeRelation
     primary_column: PydanticTimeSpinePrimaryColumn

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -804,9 +804,6 @@
             "$id": "time_spine_schema",
             "additionalProperties": false,
             "properties": {
-                "name": {
-                    "type": "string"
-                },
                 "node_relation": {
                     "$ref": "#/definitions/node_relation_schema"
                 },
@@ -815,7 +812,6 @@
                 }
             },
             "required": [
-                "name",
                 "node_relation",
                 "primary_column"
             ],

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -362,12 +362,11 @@ time_spine_schema = {
     "$id": "time_spine_schema",
     "type": "object",
     "properties": {
-        "name": {"type": "string"},
         "node_relation": {"$ref": "node_relation_schema"},
         "primary_column": {"$ref": "time_spine_primary_column_schema"},
     },
     "additionalProperties": False,
-    "required": ["name", "node_relation", "primary_column"],
+    "required": ["node_relation", "primary_column"],
 }
 
 

--- a/dbt_semantic_interfaces/protocols/time_spine.py
+++ b/dbt_semantic_interfaces/protocols/time_spine.py
@@ -16,12 +16,6 @@ class TimeSpine(Protocol):
 
     @property
     @abstractmethod
-    def name(self) -> str:
-        """A name the user assigns to this time spine."""
-        pass
-
-    @property
-    @abstractmethod
     def node_relation(self) -> NodeRelation:
         """dbt model where this time spine lives."""  # noqa: D403
         pass

--- a/tests/example_project_configuration.py
+++ b/tests/example_project_configuration.py
@@ -24,7 +24,6 @@ EXAMPLE_PROJECT_CONFIGURATION = PydanticProjectConfiguration(
     ],
     time_spines=[
         PydanticTimeSpine(
-            name="day_time_spine",
             node_relation=PydanticNodeRelation(alias="day_time_spine", schema_name="stuff"),
             primary_column=PydanticTimeSpinePrimaryColumn(name="ds_day", time_granularity=TimeGranularity.DAY),
         )
@@ -41,8 +40,7 @@ EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE = YamlConfigFile(
               column_name: ds
               grain: day
           time_spines:
-            - name: day_time_spine
-              node_relation:
+            - node_relation:
                 schema_name: stuff
                 alias: day_time_spine
               primary_column:

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/project_configuration.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/project_configuration.yaml
@@ -5,8 +5,7 @@ project_configuration:
       column_name: ds
       grain: day
   time_spines:
-    - name: day_time_spine
-      node_relation:
+    - node_relation:
         schema_name: stuff
         alias: day_time_spine
       primary_column:


### PR DESCRIPTION
### Description
Remove `name` field from `TimeSpine` objects. The designs have changed so that there is no longer a name separate from the time spine's model. The model alias will be used instead, which makes this field redundant.
This won't be a breaking change for manifests because none of them have this object yet. (Only an empty list in the `time_spines` field.)

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
