### PR TITLE
Streamline object-builder text parsing

### DIFF
--- a/dbt_semantic_interfaces/parsing/text_input/description_renderer.py
+++ b/dbt_semantic_interfaces/parsing/text_input/description_renderer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from dbt_semantic_interfaces.parsing.text_input.ti_description import (
+    QueryItemDescription,
+)
+
+
+class QueryItemDescriptionRenderer(ABC):
+    """Defines how query items specified via object-builder syntax in a Jinja template should be rendered.
+
+    e.g. For a Jinja template in a where-filter:
+
+        {{ Dimension('listing__country') }} = 'US'
+        AND {{ TimeDimension('metric_time') }} > '2020-01-01'
+
+    a particular implementation might be used to render it to:
+
+        listing__count = 'US'
+        AND metric_time__day > '2020-01-01'
+    """
+
+    @abstractmethod
+    def render_description(self, item_description: QueryItemDescription) -> str:
+        """Return the string that will be substituted for the query item in the Jinja template."""
+        raise NotImplementedError

--- a/dbt_semantic_interfaces/parsing/text_input/rendering_helper.py
+++ b/dbt_semantic_interfaces/parsing/text_input/rendering_helper.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import typing
+from typing import Callable, FrozenSet, Optional, Sequence
+
+from typing_extensions import override
+
+from dbt_semantic_interfaces.parsing.text_input.ti_description import (
+    ObjectBuilderMethod,
+    QueryItemDescription,
+    QueryItemType,
+)
+from dbt_semantic_interfaces.parsing.text_input.ti_exceptions import (
+    InvalidBuilderMethodException,
+)
+
+if typing.TYPE_CHECKING:
+    from dbt_semantic_interfaces.parsing.text_input.ti_processor import (
+        QueryItemDescriptionProcessor,
+    )
+
+from dbt_semantic_interfaces.parsing.text_input.valid_method import ValidMethodMapping
+
+
+class ObjectBuilderJinjaRenderHelper:
+    """Helps to build the methods that go into the Jinja template `.render()` call.
+
+    e.g.
+
+        SandboxedEnvironment(undefined=StrictUndefined)
+            .from_string(jinja_template)
+            .render(
+                Dimension=render_helper.get_function_for_dimension(),
+                TimeDimension=render_helper.get_function_for_time_dimension(),
+                Entity=render_helper.get_function_for_entity(),
+                Metric=render_helper.get_function_for_metric(),
+            )
+        )
+    """
+
+    def __init__(  # noqa: D107
+        self,
+        description_processor: QueryItemDescriptionProcessor,
+        valid_method_mapping: ValidMethodMapping,
+    ) -> None:
+        self._description_processor = description_processor
+        self._valid_method_mapping = valid_method_mapping
+
+    def get_function_for_dimension(self) -> Callable:
+        """Returns the function that should be passed in to `.render(Dimension=...)`."""
+        description_processor = self._description_processor
+        item_type = QueryItemType.DIMENSION
+        allowed_methods = self._valid_method_mapping[item_type]
+
+        def _create(name: str, entity_path: Sequence[str] = ()) -> _RenderingClassForJinjaTemplate:
+            return _RenderingClassForJinjaTemplate(
+                description_processor=description_processor,
+                allowed_methods=allowed_methods,
+                initial_item_description=QueryItemDescription(
+                    item_type=item_type,
+                    item_name=name,
+                    entity_path=tuple(entity_path),
+                    time_granularity_name=None,
+                    date_part_name=None,
+                    group_by_for_metric_item=(),
+                    descending=None,
+                ),
+            )
+
+        return _create
+
+    def get_function_for_time_dimension(self) -> Callable:
+        """Returns the function that should be passed in to `.render(TimeDimension=...)`."""
+        description_processor = self._description_processor
+        item_type = QueryItemType.TIME_DIMENSION
+        allowed_methods = self._valid_method_mapping[item_type]
+
+        def _create(
+            time_dimension_name: str,
+            time_granularity_name: Optional[str] = None,
+            entity_path: Sequence[str] = (),
+            descending: Optional[bool] = None,
+            date_part_name: Optional[str] = None,
+        ) -> _RenderingClassForJinjaTemplate:
+            return _RenderingClassForJinjaTemplate(
+                description_processor=description_processor,
+                allowed_methods=allowed_methods,
+                initial_item_description=QueryItemDescription(
+                    item_type=item_type,
+                    item_name=time_dimension_name,
+                    entity_path=tuple(entity_path),
+                    time_granularity_name=time_granularity_name,
+                    date_part_name=date_part_name,
+                    group_by_for_metric_item=(),
+                    descending=descending,
+                ),
+            )
+
+        return _create
+
+    def get_function_for_entity(self) -> Callable:
+        """Returns the function that should be passed in to `.render(Entity=...)`."""
+        description_processor = self._description_processor
+        item_type = QueryItemType.ENTITY
+        allowed_methods = self._valid_method_mapping[item_type]
+
+        def _create(entity_name: str, entity_path: Sequence[str] = ()) -> _RenderingClassForJinjaTemplate:
+            return _RenderingClassForJinjaTemplate(
+                description_processor=description_processor,
+                allowed_methods=allowed_methods,
+                initial_item_description=QueryItemDescription(
+                    item_type=item_type,
+                    item_name=entity_name,
+                    entity_path=tuple(entity_path),
+                    time_granularity_name=None,
+                    date_part_name=None,
+                    group_by_for_metric_item=(),
+                    descending=None,
+                ),
+            )
+
+        return _create
+
+    def get_function_for_metric(self) -> Callable:
+        """Returns the function that should be passed in to `.render(Metric=...)`."""
+        description_processor = self._description_processor
+        item_type = QueryItemType.METRIC
+        allowed_methods = self._valid_method_mapping[item_type]
+
+        def _create(metric_name: str, group_by: Sequence[str] = ()) -> _RenderingClassForJinjaTemplate:
+            return _RenderingClassForJinjaTemplate(
+                description_processor=description_processor,
+                allowed_methods=allowed_methods,
+                initial_item_description=QueryItemDescription(
+                    item_type=item_type,
+                    item_name=metric_name,
+                    entity_path=(),
+                    time_granularity_name=None,
+                    date_part_name=None,
+                    group_by_for_metric_item=tuple(group_by),
+                    descending=None,
+                ),
+            )
+
+        return _create
+
+
+class _RenderingClassForJinjaTemplate:
+    """Helper class that behaves like a builder object as used in a Jinja template.
+
+    e.g. in the Jinja template:
+
+        {{ Dimension('listing__created_at').grain('day').date_part('month') }}
+
+    The `Dimension('listing__created_at')` is an instance of this class and when builder methods like `.grain()` are
+    called on it, the state of the instance is updated and returns itself so that additional builder methods can be
+    chained.
+    """
+
+    def __init__(
+        self,
+        description_processor: QueryItemDescriptionProcessor,
+        allowed_methods: FrozenSet[ObjectBuilderMethod],
+        initial_item_description: QueryItemDescription,
+    ) -> None:
+        """Initializer.
+
+        Args:
+            description_processor: The description processor that will run using the query-item description described
+            in the builder call. It will run after all builder methods are called.
+            allowed_methods: Builder methods that can be used. Otherwise, an `InvalidBuilderMethodException` is raised.
+            initial_item_description: The starting description. Usually it contains the element name and entity path.
+        """
+        self._description_processor = description_processor
+        self._allowed_builder_methods = allowed_methods
+        self._current_description = initial_item_description
+
+    def _update_current_description(
+        self,
+        time_granularity_name: Optional[str] = None,
+        date_part_name: Optional[str] = None,
+        descending: Optional[bool] = None,
+    ) -> None:
+        args = (time_granularity_name, date_part_name, descending)
+        assert sum(1 for arg in args if arg is not None) == 1, f"Expected exactly 1 argument set, but got {args}"
+
+        builder_method: Optional[ObjectBuilderMethod]
+        if time_granularity_name is not None:
+            builder_method = ObjectBuilderMethod.GRAIN
+        elif date_part_name is not None:
+            builder_method = ObjectBuilderMethod.DATE_PART
+        elif descending is not None:
+            builder_method = ObjectBuilderMethod.DESCENDING
+        else:
+            assert False, "Exactly 1 argument should have been set as previously checked."
+
+        if builder_method not in self._allowed_builder_methods:
+            raise InvalidBuilderMethodException(
+                f"`{builder_method.value}` can't be used with `{self._current_description.item_type.value}`"
+                f" in this context.",
+                item_type=self._current_description.item_type,
+                invalid_builder_method=builder_method,
+            )
+        self._current_description = self._current_description.create_modified(
+            time_granularity_name=time_granularity_name,
+            date_part_name=date_part_name,
+            descending=descending,
+        )
+
+    def grain(self, time_granularity: str) -> _RenderingClassForJinjaTemplate:
+        self._update_current_description(time_granularity_name=time_granularity)
+        return self
+
+    def descending(self, _is_descending: bool) -> _RenderingClassForJinjaTemplate:
+        self._update_current_description(descending=_is_descending)
+        return self
+
+    def date_part(self, date_part_name: str) -> _RenderingClassForJinjaTemplate:
+        self._update_current_description(date_part_name=date_part_name)
+        return self
+
+    @override
+    def __str__(self) -> str:
+        return self._description_processor.process_description(self._current_description)

--- a/dbt_semantic_interfaces/parsing/text_input/rendering_helper.py
+++ b/dbt_semantic_interfaces/parsing/text_input/rendering_helper.py
@@ -177,23 +177,9 @@ class _RenderingClassForJinjaTemplate:
 
     def _update_current_description(
         self,
-        time_granularity_name: Optional[str] = None,
-        date_part_name: Optional[str] = None,
-        descending: Optional[bool] = None,
+        builder_method: ObjectBuilderMethod,
+        new_description: QueryItemDescription,
     ) -> None:
-        args = (time_granularity_name, date_part_name, descending)
-        assert sum(1 for arg in args if arg is not None) == 1, f"Expected exactly 1 argument set, but got {args}"
-
-        builder_method: Optional[ObjectBuilderMethod]
-        if time_granularity_name is not None:
-            builder_method = ObjectBuilderMethod.GRAIN
-        elif date_part_name is not None:
-            builder_method = ObjectBuilderMethod.DATE_PART
-        elif descending is not None:
-            builder_method = ObjectBuilderMethod.DESCENDING
-        else:
-            assert False, "Exactly 1 argument should have been set as previously checked."
-
         if builder_method not in self._allowed_builder_methods:
             raise InvalidBuilderMethodException(
                 f"`{builder_method.value}` can't be used with `{self._current_description.item_type.value}`"
@@ -201,22 +187,27 @@ class _RenderingClassForJinjaTemplate:
                 item_type=self._current_description.item_type,
                 invalid_builder_method=builder_method,
             )
-        self._current_description = self._current_description.create_modified(
-            time_granularity_name=time_granularity_name,
-            date_part_name=date_part_name,
-            descending=descending,
-        )
+        self._current_description = new_description
 
     def grain(self, time_granularity: str) -> _RenderingClassForJinjaTemplate:
-        self._update_current_description(time_granularity_name=time_granularity)
+        self._update_current_description(
+            builder_method=ObjectBuilderMethod.GRAIN,
+            new_description=self._current_description.create_modified(time_granularity_name=time_granularity),
+        )
         return self
 
     def descending(self, _is_descending: bool) -> _RenderingClassForJinjaTemplate:
-        self._update_current_description(descending=_is_descending)
+        self._update_current_description(
+            builder_method=ObjectBuilderMethod.DESCENDING,
+            new_description=self._current_description.create_modified(descending=_is_descending),
+        )
         return self
 
     def date_part(self, date_part_name: str) -> _RenderingClassForJinjaTemplate:
-        self._update_current_description(date_part_name=date_part_name)
+        self._update_current_description(
+            builder_method=ObjectBuilderMethod.DATE_PART,
+            new_description=self._current_description.create_modified(date_part_name=date_part_name),
+        )
         return self
 
     @override

--- a/dbt_semantic_interfaces/parsing/text_input/ti_description.py
+++ b/dbt_semantic_interfaces/parsing/text_input/ti_description.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class QueryItemDescription:
+    """Describes a query item specified by the user.
+
+    For example, the following specified in an order-by of a saved query:
+
+        Dimension("user__created_at", entity_path=['listing']).grain('day').date_part('month').descending(True)
+
+        ->
+
+        QueryItemDescription(
+            item_type=GroupByItemType.DIMENSION,
+            item_name="user__created_at",
+            entity_path=['listing'],
+            time_granularity_name='day'
+            date_part_name='month'
+            descending=True
+        )
+
+    * This is named "...Description" to keep it general as the way users specify query items will change significantly
+      in the not-so-distant future.
+    * This can be later expanded to a set of classes for better typing.
+    """
+
+    item_type: QueryItemType
+    item_name: str
+    entity_path: Tuple[str, ...]
+    group_by_for_metric_item: Tuple[str, ...]
+    time_granularity_name: Optional[str]
+    date_part_name: Optional[str]
+    descending: Optional[bool]
+
+    def __post_init__(self) -> None:  # noqa: D105
+        if self.item_type is QueryItemType.ENTITY or self.item_type is QueryItemType.METRIC:
+            assert (
+                self.time_granularity_name is None
+            ), f"{self.time_granularity_name=} is not supported for {self.item_type=}"
+            assert self.date_part_name is None, f"{self.date_part_name=} is not supported for {self.item_type=}"
+
+        if self.item_type is not QueryItemType.METRIC:
+            assert (
+                not self.group_by_for_metric_item
+            ), f"{self.group_by_for_metric_item=} is not supported for {self.item_type=}"
+
+    def create_modified(
+        self,
+        time_granularity_name: Optional[str],
+        date_part_name: Optional[str],
+        descending: Optional[bool],
+    ) -> QueryItemDescription:
+        """Create one with the same fields as self except the ones provided."""
+        return QueryItemDescription(
+            item_type=self.item_type,
+            item_name=self.item_name,
+            entity_path=self.entity_path,
+            time_granularity_name=time_granularity_name or self.time_granularity_name,
+            date_part_name=date_part_name or self.date_part_name,
+            group_by_for_metric_item=self.group_by_for_metric_item,
+            descending=descending or self.descending,
+        )
+
+
+class QueryItemType(Enum):
+    """Enumerates the types of items that a used to group items in a filter or a query.
+
+    e.g. in the object-builder syntax: QueryItemType.DIMENSION refers to `Dimension(...)`.
+
+    The value of the enum is the name of the builder "object".
+    """
+
+    DIMENSION = "Dimension"
+    TIME_DIMENSION = "TimeDimension"
+    ENTITY = "Entity"
+    METRIC = "Metric"
+
+
+class ObjectBuilderMethod(Enum):
+    """In the object builder notation, the possible methods that can be called on the builder object.
+
+    e.g. ObjectBuilderMethod.GRAIN refers to `.grain` in `Dimension(...).grain('month')`
+
+    The value of the enum is the name of the method.
+    """
+
+    GRAIN = "grain"
+    DATE_PART = "date_part"
+    DESCENDING = "descending"

--- a/dbt_semantic_interfaces/parsing/text_input/ti_description.py
+++ b/dbt_semantic_interfaces/parsing/text_input/ti_description.py
@@ -51,9 +51,9 @@ class QueryItemDescription:
 
     def create_modified(
         self,
-        time_granularity_name: Optional[str],
-        date_part_name: Optional[str],
-        descending: Optional[bool],
+        time_granularity_name: Optional[str] = None,
+        date_part_name: Optional[str] = None,
+        descending: Optional[bool] = None,
     ) -> QueryItemDescription:
         """Create one with the same fields as self except the ones provided."""
         return QueryItemDescription(

--- a/dbt_semantic_interfaces/parsing/text_input/ti_exceptions.py
+++ b/dbt_semantic_interfaces/parsing/text_input/ti_exceptions.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dbt_semantic_interfaces.errors import InvalidQuerySyntax
+from dbt_semantic_interfaces.parsing.text_input.ti_description import (
+    ObjectBuilderMethod,
+    QueryItemType,
+)
+
+
+class QueryItemJinjaException(Exception):
+    """Raised when there is an exception when calling Jinja package methods on the query item input."""
+
+    pass
+
+
+class InvalidBuilderMethodException(InvalidQuerySyntax):
+    """Raised when a query item using the object-builder format uses a disallowed method.
+
+    For example, `Entity('listing').grain('day')` should raise this exception since `grain` is only applicable to
+    `Dimension()`.
+    """
+
+    def __init__(  # noqa: D107
+        self, message: str, item_type: QueryItemType, invalid_builder_method: ObjectBuilderMethod
+    ) -> None:
+        super().__init__(message)
+        self._item_type = item_type
+        self._invalid_builder_method = invalid_builder_method
+
+    @property
+    def item_type(self) -> QueryItemType:
+        """Return the item that was used with the invalid method."""
+        return self._item_type
+
+    @property
+    def invalid_builder_method(self) -> ObjectBuilderMethod:
+        """Return the invalid builder method that was used."""
+        return self._invalid_builder_method

--- a/dbt_semantic_interfaces/parsing/text_input/ti_processor.py
+++ b/dbt_semantic_interfaces/parsing/text_input/ti_processor.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from dbt_semantic_interfaces.parsing.text_input.description_renderer import (
+    QueryItemDescriptionRenderer,
+)
+from dbt_semantic_interfaces.parsing.text_input.ti_description import (
+    QueryItemDescription,
+)
+from dbt_semantic_interfaces.parsing.text_input.valid_method import ValidMethodMapping
+
+
+class QueryItemTextProcessor:
+    """Performs processing actions for text containing query items specified in the object-builder syntax.
+
+    This currently supports:
+    * Collecting `QueryItemDescription`s from a Jinja template.
+    * Rendering a Jinja template using a specified renderer.
+    """
+
+    def collect_descriptions_from_template(
+        self,
+        jinja_template: str,
+        valid_method_mapping: ValidMethodMapping,
+    ) -> Sequence[QueryItemDescription]:
+        """Returns the `QueryItemDescription`s that are found in a Jinja template.
+
+        Args:
+            jinja_template: A Jinja-template string like `{{ Dimension('listing__country') }} = 'US'`.
+            valid_method_mapping: Mapping from the builder object to the valid methods. See
+            `ConfiguredValidMethodMapping`.
+
+        Returns:
+            A sequence of the descriptions found in the template.
+
+        Raises:
+            QueryItemJinjaException: See definition.
+            InvalidBuilderMethodException: See definition.
+        """
+        raise NotImplementedError
+
+    def render_template(
+        self,
+        jinja_template: str,
+        renderer: QueryItemDescriptionRenderer,
+        valid_method_mapping: ValidMethodMapping,
+    ) -> str:
+        """Renders the Jinja template using the specified renderer.
+
+        Args:
+            jinja_template: A Jinja template string like `{{ Dimension('listing__country') }} = 'US'`.
+            renderer: The renderer to use for rendering each item.
+            valid_method_mapping: Mapping from the builder object to the valid methods. See
+            `ConfiguredValidMethodMapping`.
+
+        Returns:
+            The rendered Jinja template.
+
+        Raises:
+            QueryItemJinjaException: See definition.
+            InvalidBuilderMethodException: See definition.
+        """
+        raise NotImplementedError

--- a/dbt_semantic_interfaces/parsing/text_input/ti_processor.py
+++ b/dbt_semantic_interfaces/parsing/text_input/ti_processor.py
@@ -1,12 +1,25 @@
 from __future__ import annotations
 
-from typing import Sequence
+from abc import ABC, abstractmethod
+from textwrap import indent
+from typing import List, Sequence
+
+from jinja2 import StrictUndefined, TemplateSyntaxError, UndefinedError
+from jinja2.exceptions import SecurityError
+from jinja2.sandbox import SandboxedEnvironment
+from typing_extensions import override
 
 from dbt_semantic_interfaces.parsing.text_input.description_renderer import (
     QueryItemDescriptionRenderer,
 )
+from dbt_semantic_interfaces.parsing.text_input.rendering_helper import (
+    ObjectBuilderJinjaRenderHelper,
+)
 from dbt_semantic_interfaces.parsing.text_input.ti_description import (
     QueryItemDescription,
+)
+from dbt_semantic_interfaces.parsing.text_input.ti_exceptions import (
+    QueryItemJinjaException,
 )
 from dbt_semantic_interfaces.parsing.text_input.valid_method import ValidMethodMapping
 
@@ -38,7 +51,13 @@ class QueryItemTextProcessor:
             QueryItemJinjaException: See definition.
             InvalidBuilderMethodException: See definition.
         """
-        raise NotImplementedError
+        description_collector = _CollectDescriptionProcessor()
+        self._process_template(
+            jinja_template=jinja_template,
+            valid_method_mapping=valid_method_mapping,
+            description_processor=description_collector,
+        )
+        return description_collector.collected_descriptions()
 
     def render_template(
         self,
@@ -61,4 +80,81 @@ class QueryItemTextProcessor:
             QueryItemJinjaException: See definition.
             InvalidBuilderMethodException: See definition.
         """
+        render_processor = _RendererProcessor(renderer)
+        return self._process_template(
+            jinja_template=jinja_template,
+            valid_method_mapping=valid_method_mapping,
+            description_processor=render_processor,
+        )
+
+    def _process_template(
+        self,
+        jinja_template: str,
+        valid_method_mapping: ValidMethodMapping,
+        description_processor: QueryItemDescriptionProcessor,
+    ) -> str:
+        """Helper to run a `QueryItemDescriptionProcessor` on a Jinja template."""
+        render_helper = ObjectBuilderJinjaRenderHelper(
+            description_processor=description_processor,
+            valid_method_mapping=valid_method_mapping,
+        )
+        try:
+            # the string that the sandbox renders is unused
+            rendered = (
+                SandboxedEnvironment(undefined=StrictUndefined)
+                .from_string(jinja_template)
+                .render(
+                    Dimension=render_helper.get_function_for_dimension(),
+                    TimeDimension=render_helper.get_function_for_time_dimension(),
+                    Entity=render_helper.get_function_for_entity(),
+                    Metric=render_helper.get_function_for_metric(),
+                )
+            )
+        except (UndefinedError, TemplateSyntaxError, SecurityError) as e:
+            raise QueryItemJinjaException(
+                f"Error while processing Jinja template:" f"\n{indent(jinja_template, prefix='    ')}"
+            ) from e
+
+        return rendered
+
+
+class QueryItemDescriptionProcessor(ABC):
+    """General processor that does something to a query-item description seen in a Jinja template."""
+
+    @abstractmethod
+    def process_description(self, item_description: QueryItemDescription) -> str:
+        """Process the given description, and return a string that would be substituted into the Jinja template."""
         raise NotImplementedError
+
+
+class _CollectDescriptionProcessor(QueryItemDescriptionProcessor):
+    """Processor that collects all descriptions that were processed."""
+
+    def __init__(self) -> None:  # noqa: D107
+        self._items: List[QueryItemDescription] = []
+
+    def collected_descriptions(self) -> Sequence[QueryItemDescription]:
+        """Return all descriptions that were processed so far."""
+        return self._items
+
+    @override
+    def process_description(self, item_description: QueryItemDescription) -> str:
+        if item_description not in self._items:
+            self._items.append(item_description)
+
+        return ""
+
+
+class _RendererProcessor(QueryItemDescriptionProcessor):
+    """Processor that renders the descriptions in a Jinja template using the given renderer.
+
+    This is just a pass-through, but it allows `QueryItemDescriptionRenderer` to be a facade that has more appropriate
+    method names.
+    """
+
+    def __init__(self, renderer: QueryItemDescriptionRenderer) -> None:  # noqa: D107
+        self._renderer = renderer
+
+    @override
+    def process_description(self, item_description: QueryItemDescription) -> str:
+        return self._renderer.render_description(item_description)

--- a/dbt_semantic_interfaces/parsing/text_input/valid_method.py
+++ b/dbt_semantic_interfaces/parsing/text_input/valid_method.py
@@ -1,0 +1,31 @@
+from typing import FrozenSet, Mapping
+
+from dbt_semantic_interfaces.parsing.text_input.ti_description import (
+    ObjectBuilderMethod,
+    QueryItemType,
+)
+
+ValidMethodMapping = Mapping[QueryItemType, FrozenSet[ObjectBuilderMethod]]
+
+
+class ConfiguredValidMethodMapping:
+    """Default mappings for methods valid for the object-builder syntax."""
+
+    # In an order-by item, `.descending(...)` is allowed.
+    DEFAULT_MAPPING_FOR_ORDER_BY: ValidMethodMapping = {
+        QueryItemType.METRIC: frozenset({ObjectBuilderMethod.DESCENDING}),
+        QueryItemType.ENTITY: frozenset({ObjectBuilderMethod.DESCENDING}),
+        QueryItemType.DIMENSION: frozenset(
+            {ObjectBuilderMethod.DESCENDING, ObjectBuilderMethod.GRAIN, ObjectBuilderMethod.DATE_PART}
+        ),
+        QueryItemType.TIME_DIMENSION: frozenset({ObjectBuilderMethod.DESCENDING}),
+    }
+
+    DEFAULT_MAPPING: ValidMethodMapping = {
+        QueryItemType.METRIC: frozenset(),
+        QueryItemType.ENTITY: frozenset(),
+        QueryItemType.DIMENSION: frozenset(
+            {ObjectBuilderMethod.DESCENDING, ObjectBuilderMethod.GRAIN, ObjectBuilderMethod.DATE_PART}
+        ),
+        QueryItemType.TIME_DIMENSION: frozenset(),
+    }

--- a/dbt_semantic_interfaces/parsing/where_filter/where_filter_parser.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/where_filter_parser.py
@@ -1,25 +1,22 @@
 from __future__ import annotations
 
-from jinja2 import StrictUndefined
-from jinja2.exceptions import SecurityError, TemplateSyntaxError, UndefinedError
-from jinja2.sandbox import SandboxedEnvironment
-
 from dbt_semantic_interfaces.call_parameter_sets import (
     FilterCallParameterSets,
     ParseWhereFilterException,
 )
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from dbt_semantic_interfaces.parsing.text_input.ti_description import QueryItemType
+from dbt_semantic_interfaces.parsing.text_input.ti_exceptions import (
+    QueryItemJinjaException,
+)
+from dbt_semantic_interfaces.parsing.text_input.ti_processor import (
+    QueryItemTextProcessor,
+)
+from dbt_semantic_interfaces.parsing.text_input.valid_method import (
+    ConfiguredValidMethodMapping,
+)
 from dbt_semantic_interfaces.parsing.where_filter.parameter_set_factory import (
     ParameterSetFactory,
-)
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_dimension import (
-    WhereFilterDimensionFactory,
-)
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_entity import (
-    WhereFilterEntityFactory,
-    WhereFilterMetricFactory,
-)
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_time_dimension import (
-    WhereFilterTimeDimensionFactory,
 )
 
 
@@ -29,20 +26,14 @@ class WhereFilterParser:
     @staticmethod
     def parse_call_parameter_sets(where_sql_template: str) -> FilterCallParameterSets:
         """Return the result of extracting the semantic objects referenced in the where SQL template string."""
-        time_dimension_factory = WhereFilterTimeDimensionFactory()
-        dimension_factory = WhereFilterDimensionFactory()
-        entity_factory = WhereFilterEntityFactory()
-        metric_factory = WhereFilterMetricFactory()
+        text_processor = QueryItemTextProcessor()
 
         try:
-            # the string that the sandbox renders is unused
-            SandboxedEnvironment(undefined=StrictUndefined).from_string(where_sql_template).render(
-                Dimension=dimension_factory.create,
-                TimeDimension=time_dimension_factory.create,
-                Entity=entity_factory.create,
-                Metric=metric_factory.create,
+            descriptions = text_processor.collect_descriptions_from_template(
+                jinja_template=where_sql_template,
+                valid_method_mapping=ConfiguredValidMethodMapping.DEFAULT_MAPPING,
             )
-        except (UndefinedError, TemplateSyntaxError, SecurityError) as e:
+        except QueryItemJinjaException as e:
             raise ParseWhereFilterException(f"Error while parsing Jinja template:\n{where_sql_template}") from e
 
         """
@@ -50,21 +41,59 @@ class WhereFilterParser:
         added to time_dimension_call_parameter_sets otherwise they are add to dimension_call_parameter_sets
         """
         dimension_call_parameter_sets = []
-        for dimension in dimension_factory.created:
-            if dimension.time_granularity_name or dimension.date_part_name:
-                time_dimension_factory.time_dimension_call_parameter_sets.append(
+        time_dimension_call_parameter_sets = []
+        entity_call_parameter_sets = []
+        metric_call_parameter_sets = []
+
+        for description in descriptions:
+            item_type = description.item_type
+
+            if item_type is QueryItemType.DIMENSION:
+                if description.time_granularity_name or description.date_part_name:
+                    time_dimension_call_parameter_sets.append(
+                        ParameterSetFactory.create_time_dimension(
+                            time_dimension_name=description.item_name,
+                            time_granularity_name=description.time_granularity_name,
+                            entity_path=description.entity_path,
+                            date_part_name=description.date_part_name,
+                        )
+                    )
+                else:
+                    dimension_call_parameter_sets.append(
+                        ParameterSetFactory.create_dimension(
+                            dimension_name=description.item_name,
+                            entity_path=description.entity_path,
+                        )
+                    )
+            elif item_type is QueryItemType.TIME_DIMENSION:
+                time_dimension_call_parameter_sets.append(
                     ParameterSetFactory.create_time_dimension(
-                        dimension.name, dimension.time_granularity_name, dimension.entity_path, dimension.date_part_name
+                        time_dimension_name=description.item_name,
+                        time_granularity_name=description.time_granularity_name,
+                        entity_path=description.entity_path,
+                        date_part_name=description.date_part_name,
+                    )
+                )
+            elif item_type is QueryItemType.ENTITY:
+                entity_call_parameter_sets.append(
+                    ParameterSetFactory.create_entity(
+                        entity_name=description.item_name,
+                        entity_path=description.entity_path,
+                    )
+                )
+            elif item_type is QueryItemType.METRIC:
+                metric_call_parameter_sets.append(
+                    ParameterSetFactory.create_metric(
+                        metric_name=description.item_name,
+                        group_by=description.group_by_for_metric_item,
                     )
                 )
             else:
-                dimension_call_parameter_sets.append(
-                    ParameterSetFactory.create_dimension(dimension.name, dimension.entity_path)
-                )
+                assert_values_exhausted(item_type)
 
         return FilterCallParameterSets(
             dimension_call_parameter_sets=tuple(dimension_call_parameter_sets),
-            time_dimension_call_parameter_sets=tuple(time_dimension_factory.time_dimension_call_parameter_sets),
-            entity_call_parameter_sets=tuple(entity_factory.entity_call_parameter_sets),
-            metric_call_parameter_sets=tuple(metric_factory.metric_call_parameter_sets),
+            time_dimension_call_parameter_sets=tuple(time_dimension_call_parameter_sets),
+            entity_call_parameter_sets=tuple(entity_call_parameter_sets),
+            metric_call_parameter_sets=tuple(metric_call_parameter_sets),
         )


### PR DESCRIPTION
### Description

When parsing the Jinja template in where-filters, there is currently a set of factory and factory-specific classes to implement a specific behavior. I've noticed that there are multiple implementations of those classes (if you add the ones in this repo and dependent repos), and it seemed like there was an opportunity to streamline the structure to handle the update for saved-queries and other changes down the road.

This PR adds a `QueryItemDescription` that encapsulates what the user has specified in the text input, and also adds a `QueryItemTextProcessor` that allows you to:

* Find all the `QueryItemDescription`s in a template.
* Render a template for a given `QueryItemDescription` using a configurable format.
* Configure what builder methods (e.g. `.descending()`) are allowed in which cases.

These features seem like it would support existing use cases, but tagging @DevonFulcher to confirm. 

Also, please view by commit. The first commit includes the interface, so if there are issues there, it would be better to get those resolved before updating the later commits.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
