### PR TITLE
Add validation for limit in a saved query

### DIFF
--- a/.changes/unreleased/Features-20240805-102141.yaml
+++ b/.changes/unreleased/Features-20240805-102141.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Add support for order-by and limit in a saved query.
+time: 2024-08-05T10:21:41.445782-07:00
+custom:
+  Author: plypaul
+  Issue: "325"

--- a/tests/validations/test_saved_query_limit.py
+++ b/tests/validations/test_saved_query_limit.py
@@ -1,0 +1,76 @@
+import copy
+
+from dbt_semantic_interfaces.implementations.saved_query import (
+    PydanticSavedQuery,
+    PydanticSavedQueryQueryParams,
+)
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.validations.saved_query import SavedQueryRule
+from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
+    SemanticManifestValidator,
+)
+from tests.validations.test_saved_query import check_only_one_error_with_message
+
+
+def test_invalid_limit(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
+    manifest = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
+    manifest.saved_queries = [
+        PydanticSavedQuery(
+            name="Example Saved Query",
+            description="Example description.",
+            query_params=PydanticSavedQueryQueryParams(
+                metrics=["listings"],
+                limit=-1,
+            ),
+        ),
+    ]
+
+    manifest_validator = SemanticManifestValidator[PydanticSemanticManifest]([SavedQueryRule()])
+    check_only_one_error_with_message(
+        manifest_validator.validate_semantic_manifest(manifest),
+        "Invalid limit value",
+    )
+
+
+def test_valid_limit(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
+    manifest = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
+    manifest.saved_queries = [
+        PydanticSavedQuery(
+            name="Example Saved Query",
+            description="Example description.",
+            query_params=PydanticSavedQueryQueryParams(
+                metrics=["listings"],
+                limit=1,
+            ),
+        ),
+    ]
+
+    manifest_validator = SemanticManifestValidator[PydanticSemanticManifest]([SavedQueryRule()])
+    results = manifest_validator.validate_semantic_manifest(manifest)
+    assert results.all_issues == ()
+
+
+def test_zero_limit(  # noqa: D
+    simple_semantic_manifest__with_primary_transforms: PydanticSemanticManifest,
+) -> None:
+    manifest = copy.deepcopy(simple_semantic_manifest__with_primary_transforms)
+    manifest.saved_queries = [
+        PydanticSavedQuery(
+            name="Example Saved Query",
+            description="Example description.",
+            query_params=PydanticSavedQueryQueryParams(
+                metrics=["listings"],
+                limit=0,
+            ),
+        ),
+    ]
+
+    manifest_validator = SemanticManifestValidator[PydanticSemanticManifest]([SavedQueryRule()])
+    results = manifest_validator.validate_semantic_manifest(manifest)
+    assert results.all_issues == ()


### PR DESCRIPTION
Resolves #325 

### Description

This PR adds a validation for the limit field in a saved query.
### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
