### PR TITLE
Add default for `time_spine_table_configurations`

### DIFF
--- a/dbt_semantic_interfaces/implementations/project_configuration.py
+++ b/dbt_semantic_interfaces/implementations/project_configuration.py
@@ -30,7 +30,7 @@ class PydanticProjectConfiguration(HashableBaseModel, ModelWithMetadataParsing, 
     def _implements_protocol(self) -> ProjectConfiguration:
         return self
 
-    time_spine_table_configurations: List[PydanticTimeSpineTableConfiguration]
+    time_spine_table_configurations: List[PydanticTimeSpineTableConfiguration] = []
     metadata: Optional[PydanticMetadata] = None
     dsi_package_version: PydanticSemanticVersion = UNKNOWN_VERSION_SENTINEL
     time_spines: List[PydanticTimeSpine] = []


### PR DESCRIPTION
### Description
Adds an empty default for the legacy time spine table configurations so that they will not be required anymore. This will mainly just simplify tests in MetricFlow for now, but will help us deprecate the old time spines in the long run.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
