### PR TITLE
Support `time_granularity` and `date_part` parameters in Jinja `Dimension` object

### DIFF
--- a/dbt_semantic_interfaces/call_parameter_sets.py
+++ b/dbt_semantic_interfaces/call_parameter_sets.py
@@ -20,7 +20,8 @@ class DimensionCallParameterSet:
 
     entity_path: Tuple[EntityReference, ...]
     dimension_reference: DimensionReference
-    # TODO: MFS Jinja allows grain and date part in Dimension(...). Should we allow them here, too, for consistency?
+    time_granularity: Optional[TimeGranularity] = None
+    date_part: Optional[DatePart] = None
 
 
 @dataclass(frozen=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.7.1"
+version = "0.7.2"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This is supported in JDBC already, so this will create a more consistent experience for customers.

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
