### PR TITLE
Add parsed_column_name property to `PydanticTimeSpineCustomGranularityColumn`

### DIFF
--- a/dbt_semantic_interfaces/implementations/time_spine.py
+++ b/dbt_semantic_interfaces/implementations/time_spine.py
@@ -37,6 +37,11 @@ class PydanticTimeSpineCustomGranularityColumn(  # noqa: D101
 
     @property
     def parsed_column_name(self) -> str:
+        """The name of the column in the time spine table that contains this custom granularity.
+
+        For convenience in writing configs, if there is no `column_name` set, we assume the `name`
+        is also the column name.
+        """
         return self.column_name or self.name
 
 

--- a/dbt_semantic_interfaces/implementations/time_spine.py
+++ b/dbt_semantic_interfaces/implementations/time_spine.py
@@ -35,6 +35,10 @@ class PydanticTimeSpineCustomGranularityColumn(  # noqa: D101
     name: str
     column_name: Optional[str] = None
 
+    @property
+    def parsed_column_name(self) -> str:
+        return self.column_name or self.name
+
 
 class PydanticTimeSpine(HashableBaseModel, ProtocolHint[TimeSpine]):  # noqa: D101
     @override

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.7.1"
+version = "0.7.2.dev0"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
This allows us to centralize this logic in one place to use everywhere instead of rewriting it in different places.


### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
