### PR TITLE
Add validation warning when filter is applied to conversion input measure

### DIFF
--- a/.changes/unreleased/Features-20240927-154038.yaml
+++ b/.changes/unreleased/Features-20240927-154038.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Added validation warning when using filter on conversion input measure
+time: 2024-09-27T15:40:38.968626-04:00
+custom:
+    Author: WilliamDee
+    Issue: None

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -617,7 +617,7 @@ def test_conversion_metrics() -> None:  # noqa: D
         "the measure must be COUNT/SUM(1)/COUNT_DISTINCT",
         "The provided constant property: bad_dim, cannot be found",
         "The provided constant property: bad_dim2, cannot be found",
-        "filter on a conversion input measure is not fully supported",
+        "filtering on a conversion input measure is not fully supported yet",
     ]
     check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import List, Tuple
 
 import pytest
 
@@ -54,8 +55,19 @@ from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
 )
 from dbt_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationException,
+    ValidationIssue,
 )
 from tests.example_project_configuration import EXAMPLE_PROJECT_CONFIGURATION
+
+
+def check_error_in_issues(error_substrings: List[str], issues: Tuple[ValidationIssue, ...]) -> None:
+    """Check error substrings in build issues."""
+    missing_error_strings = set()
+    for expected_str in error_substrings:
+        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in issues):
+            missing_error_strings.add(expected_str)
+    assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
+    f"{missing_error_strings} in {set([x.as_readable_str() for x in issues])}"
 
 
 def test_metric_no_time_dim_dim_only_source() -> None:  # noqa:D
@@ -328,14 +340,7 @@ def test_derived_metric() -> None:  # noqa: D
         "No input metrics found for derived metric",
         "No `expr` set for derived metric",
     ]
-    missing_error_strings = set()
-    for expected_str in expected_substrings:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
-            missing_error_strings.add(expected_str)
-    assert len(missing_error_strings) == 0, (
-        f"Failed to match one or more expected errors: {missing_error_strings} in "
-        f"{set([x.as_readable_str() for x in build_issues])}"
-    )
+    check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 
 
 def test_where_filter_validations_happy(  # noqa: D
@@ -606,25 +611,15 @@ def test_conversion_metrics() -> None:  # noqa: D
     assert len(result.errors) == 5
     assert len(result.warnings) == 1
 
-    expected_substr1 = f"{invalid_entity} not found in base semantic model"
-    expected_substr2 = f"{invalid_entity} not found in conversion semantic model"
-    expected_substr3 = "the measure must be COUNT/SUM(1)/COUNT_DISTINCT"
-    expected_substr4 = "The provided constant property: bad_dim, cannot be found"
-    expected_substr5 = "The provided constant property: bad_dim2, cannot be found"
-    expected_substr6 = "filter on a conversion input measure is not fully supported"
-    missing_error_strings = set()
-    for expected_str in [
-        expected_substr1,
-        expected_substr2,
-        expected_substr3,
-        expected_substr4,
-        expected_substr5,
-        expected_substr6,
-    ]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
-            missing_error_strings.add(expected_str)
-    assert len(missing_error_strings) == 0, "Failed to match one or more expected errors: "
-    f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+    expected_substrings = [
+        f"{invalid_entity} not found in base semantic model",
+        f"{invalid_entity} not found in conversion semantic model",
+        "the measure must be COUNT/SUM(1)/COUNT_DISTINCT",
+        "The provided constant property: bad_dim, cannot be found",
+        "The provided constant property: bad_dim2, cannot be found",
+        "filter on a conversion input measure is not fully supported",
+    ]
+    check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 
 
 def test_cumulative_metrics() -> None:  # noqa: D
@@ -744,17 +739,14 @@ def test_cumulative_metrics() -> None:  # noqa: D
 
     build_issues = validation_results.all_issues
     assert len(build_issues) == 4
-    expected_substr1 = "Both window and grain_to_date set for cumulative metric. Please set one or the other."
-    expected_substr2 = "Got differing values for `window`"
-    expected_substr3 = "Got differing values for `grain_to_date`"
-    expected_substr4 = "Cumulative fields `type_params.window` and `type_params.grain_to_date` have been moved"
-    expected_substr5 = str(sorted({"what_a_metric", "dis_bad", "woooooo", "metric1", "metric2"}))
-    missing_error_strings = set()
-    for expected_str in [expected_substr1, expected_substr2, expected_substr3, expected_substr4, expected_substr5]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
-            missing_error_strings.add(expected_str)
-    assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
-    f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+    expected_substrings = [
+        "Both window and grain_to_date set for cumulative metric. Please set one or the other.",
+        "Got differing values for `window`",
+        "Got differing values for `grain_to_date`",
+        "Cumulative fields `type_params.window` and `type_params.grain_to_date` have been moved",
+        str(sorted({"what_a_metric", "dis_bad", "woooooo", "metric1", "metric2"})),
+    ]
+    check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 
 
 def test_time_granularity() -> None:
@@ -858,11 +850,8 @@ def test_time_granularity() -> None:
 
     build_issues = validation_results.all_issues
     assert len(build_issues) == 2
-    expected_substr1 = "`time_granularity` for metric 'month_metric_with_invalid_time_granularity' must be >= MONTH."
-    expected_substr2 = "`time_granularity` for metric 'derived_metric_with_invalid_time_granularity' must be >= MONTH."
-    missing_error_strings = set()
-    for expected_str in [expected_substr1, expected_substr2]:
-        if not any(actual_str.as_readable_str().find(expected_str) != -1 for actual_str in build_issues):
-            missing_error_strings.add(expected_str)
-    assert len(missing_error_strings) == 0, "Failed to match one or more expected issues: "
-    f"{missing_error_strings} in {set([x.as_readable_str() for x in build_issues])}"
+    expected_substrings = [
+        "`time_granularity` for metric 'month_metric_with_invalid_time_granularity' must be >= MONTH.",
+        "`time_granularity` for metric 'derived_metric_with_invalid_time_granularity' must be >= MONTH.",
+    ]
+    check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)


### PR DESCRIPTION
Resolves SL-2862

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Since filtering on a conversion input measure is not fully supported, we will add a warning when this is added to let the user know.
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
