### PR TITLE
Bug fix: case-sensitive validation warning for filter granularity

### DIFF
--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -273,13 +273,13 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
         issues: List[ValidationIssue] = []
 
         valid_granularity_names = [
-            standard_granularity.name for standard_granularity in TimeGranularity
+            standard_granularity.value for standard_granularity in TimeGranularity
         ] + custom_granularity_names
         for _, parameter_set in filter_expression_parameter_sets:
             for time_dim_call_parameter_set in parameter_set.time_dimension_call_parameter_sets:
                 if not time_dim_call_parameter_set.time_granularity_name:
                     continue
-                if time_dim_call_parameter_set.time_granularity_name not in valid_granularity_names:
+                if time_dim_call_parameter_set.time_granularity_name.lower() not in valid_granularity_names:
                     issues.append(
                         ValidationWarning(
                             context=context,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.7.2"
+version = "0.7.3"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/saved_queries.yaml
+++ b/tests/fixtures/semantic_manifest_yamls/simple_semantic_manifest/saved_queries.yaml
@@ -25,12 +25,12 @@ saved_query:
     metrics:
       - listings
     group_by:
-      - TimeDimension('metric_time', 'DAY')
+      - TimeDimension('metric_time', 'day')
     where:
       - "{{ Metric('bookings', group_by=['listing', 'metric_time']) }} > 5"
     order_by:
       - Metric('listings').descending(True)
-      - TimeDimension('metric_time', 'DAY')
+      - TimeDimension('metric_time', 'day')
     limit: 10
 
   exports:

--- a/tests/parsing/test_object_builder_item_description.py
+++ b/tests/parsing/test_object_builder_item_description.py
@@ -24,6 +24,8 @@ def test_valid_object_builder_items() -> None:  # noqa: D
         "Entity('listing__created_at', entity_path=['host'])",
         "Metric('bookings', group_by=['listing__created_at'])",
         "TimeDimension('metric_time', time_granularity_name='martian_year')",
+        "TimeDimension('metric_time', time_granularity_name='month')",
+        "TimeDimension('metric_time', time_granularity_name='MONTH')",
     )
     for valid_item in valid_items:
         logger.info(f"Checking {valid_item=}")

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -469,7 +469,11 @@ def test_where_filter_validations_invalid_granularity(  # noqa: D
     assert metric.type_params.metrics is not None
     input_metric = metric.type_params.metrics[0]
     input_metric.filter = PydanticWhereFilterIntersection(
-        where_filters=[PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time', 'cool') }}")]
+        where_filters=[
+            PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time', 'cool') }}"),
+            PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time', 'month') }}"),
+            PydanticWhereFilter(where_sql_template="{{ TimeDimension('metric_time', 'MONTH') }}"),
+        ]
     )
     validator = SemanticManifestValidator[PydanticSemanticManifest]([WhereFiltersAreParseable()])
     issues = validator.validate_semantic_manifest(manifest)


### PR DESCRIPTION
### Description
Fixes a bad `ValidationWarning`. This warning was being triggered if you used lowercase granularity in a where filter, which should not be the case. This change makes it case insensitive.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
