### PR TITLE
Remove legacy time spine warning message

### DIFF
--- a/.changes/unreleased/Under the Hood-20241007-160153.yaml
+++ b/.changes/unreleased/Under the Hood-20241007-160153.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove legacy time spine warning message
+time: 2024-10-07T16:01:53.142516-05:00
+custom:
+    Author: DevonFulcher
+    Issue: None

--- a/dbt_semantic_interfaces/validations/time_spines.py
+++ b/dbt_semantic_interfaces/validations/time_spines.py
@@ -28,23 +28,10 @@ class TimeSpineRule(SemanticManifestValidationRule[SemanticManifestT], Generic[S
         if not semantic_manifest.semantic_models:
             return issues
 
-        time_spines = semantic_manifest.project_configuration.time_spines
-        if not time_spines:
-            docs_message = "See documentation to configure: https://docs.getdbt.com/docs/build/metricflow-time-spine"
-            # If they have the old time spine configured and need to migrate
-            if semantic_manifest.project_configuration.time_spine_table_configurations:
-                issues.append(
-                    ValidationWarning(
-                        message="Time spines without YAML configuration are in the process of deprecation. Please add "
-                        "YAML configuration for your 'metricflow_time_spine' model. " + docs_message
-                    )
-                )
-            return issues
-
         # Verify that there is only one time spine per granularity
         time_spines_by_granularity: Dict[TimeGranularity, List[TimeSpine]] = {}
         granularities_with_multiple_time_spines: Set[TimeGranularity] = set()
-        for time_spine in time_spines:
+        for time_spine in semantic_manifest.project_configuration.time_spines:
             granularity = time_spine.primary_column.time_granularity
             if granularity in time_spines_by_granularity:
                 time_spines_by_granularity[granularity].append(time_spine)

--- a/tests/validations/test_time_spines.py
+++ b/tests/validations/test_time_spines.py
@@ -21,6 +21,9 @@ from dbt_semantic_interfaces.implementations.time_spine import (
     PydanticTimeSpineCustomGranularityColumn,
     PydanticTimeSpinePrimaryColumn,
 )
+from dbt_semantic_interfaces.implementations.time_spine_table_configuration import (
+    PydanticTimeSpineTableConfiguration,
+)
 from dbt_semantic_interfaces.test_utils import semantic_model_with_guaranteed_meta
 from dbt_semantic_interfaces.type_enums import (
     AggregationType,
@@ -72,6 +75,56 @@ def test_valid_time_spines() -> None:  # noqa: D
         ),
     )
     SemanticManifestValidator[PydanticSemanticManifest]().checked_validations(semantic_manifest)
+
+
+def test_no_warning_for_legacy_time_spine() -> None:  # noqa: D
+    validator = SemanticManifestValidator[PydanticSemanticManifest]()
+    semantic_manifest = PydanticSemanticManifest(
+        semantic_models=[
+            semantic_model_with_guaranteed_meta(
+                name="sum_measure",
+                measures=[
+                    PydanticMeasure(
+                        name="foo",
+                        agg=AggregationType.SUM,
+                        agg_time_dimension="dim",
+                        create_metric=True,
+                        description="",
+                        agg_params=None,
+                        metadata=None,
+                    )
+                ],
+                dimensions=[
+                    PydanticDimension(
+                        name="dim",
+                        type=DimensionType.TIME,
+                        type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.SECOND),
+                        description="",
+                        metadata=None,
+                    )
+                ],
+                entities=[
+                    PydanticEntity(name="entity", type=EntityType.PRIMARY, description="", role=None, metadata=None)
+                ],
+            ),
+        ],
+        metrics=[],
+        project_configuration=PydanticProjectConfiguration(
+            time_spine_table_configurations=[
+                PydanticTimeSpineTableConfiguration(location="baz", column_name="fun_col", grain=TimeGranularity.DAY)
+            ],
+            time_spines=[
+                PydanticTimeSpine(
+                    node_relation=PydanticNodeRelation(alias="time_spine", schema_name="schema"),
+                    primary_column=PydanticTimeSpinePrimaryColumn(name="ds", time_granularity=TimeGranularity.SECOND),
+                    custom_granularities=[],
+                )
+            ],
+        ),
+    )
+    issues = validator.validate_semantic_manifest(semantic_manifest)
+    assert not issues.has_blocking_issues
+    assert len(issues.warnings) == 0
 
 
 def test_duplicate_time_spine_granularity() -> None:  # noqa: D

--- a/tests/validations/test_time_spines.py
+++ b/tests/validations/test_time_spines.py
@@ -12,7 +12,6 @@ from dbt_semantic_interfaces.implementations.metric import (
 from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
 from dbt_semantic_interfaces.implementations.project_configuration import (
     PydanticProjectConfiguration,
-    PydanticTimeSpineTableConfiguration,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -73,38 +72,6 @@ def test_valid_time_spines() -> None:  # noqa: D
         ),
     )
     SemanticManifestValidator[PydanticSemanticManifest]().checked_validations(semantic_manifest)
-
-
-def test_only_legacy_time_spine() -> None:  # noqa: D
-    validator = SemanticManifestValidator[PydanticSemanticManifest]()
-    semantic_manifest = PydanticSemanticManifest(
-        semantic_models=[
-            semantic_model_with_guaranteed_meta(
-                name="sum_measure",
-                measures=[
-                    PydanticMeasure(name="foo", agg=AggregationType.SUM, agg_time_dimension="dim", create_metric=True)
-                ],
-                dimensions=[
-                    PydanticDimension(
-                        name="dim",
-                        type=DimensionType.TIME,
-                        type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.SECOND),
-                    )
-                ],
-                entities=[PydanticEntity(name="entity", type=EntityType.PRIMARY)],
-            ),
-        ],
-        metrics=[],
-        project_configuration=PydanticProjectConfiguration(
-            time_spine_table_configurations=[
-                PydanticTimeSpineTableConfiguration(location="hurrr", column_name="fun_col", grain=TimeGranularity.DAY)
-            ]
-        ),
-    )
-    issues = validator.validate_semantic_manifest(semantic_manifest)
-    assert not issues.has_blocking_issues
-    assert len(issues.warnings) == 1
-    assert "Time spines without YAML configuration are in the process of deprecation." in issues.warnings[0].message
 
 
 def test_duplicate_time_spine_granularity() -> None:  # noqa: D


### PR DESCRIPTION
Resolves # SL-2934

### Description

This PR removes the legacy time spine configuration warning in order to make the warning appear in dbt-core as a [behavior change](https://docs.getdbt.com/reference/global-configs/behavior-changes) instead.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
