### PR TITLE
Update support for custom granularity in other types

### DIFF
--- a/.changes/unreleased/Breaking Changes-20241108-215906.yaml
+++ b/.changes/unreleased/Breaking Changes-20241108-215906.yaml
@@ -1,0 +1,6 @@
+kind: Breaking Changes
+body: Adding support for custom grain in windows/grain_to_dates
+time: 2024-11-08T21:59:06.162076-05:00
+custom:
+    Author: WilliamDee
+    Issue: None

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -135,7 +135,7 @@ class PydanticMetricInput(HashableBaseModel):
     filter: Optional[PydanticWhereFilterIntersection]
     alias: Optional[str]
     offset_window: Optional[PydanticMetricTimeWindow]
-    offset_to_grain: Optional[TimeGranularity]
+    offset_to_grain: Optional[str]
 
     @property
     def as_reference(self) -> MetricReference:
@@ -163,7 +163,7 @@ class PydanticCumulativeTypeParams(HashableBaseModel):
     """Type params to provide context for cumulative metrics properties."""
 
     window: Optional[PydanticMetricTimeWindow]
-    grain_to_date: Optional[TimeGranularity]
+    grain_to_date: Optional[str]
     period_agg: PeriodAggregation = PeriodAggregation.FIRST
 
 
@@ -174,7 +174,9 @@ class PydanticMetricTypeParams(HashableBaseModel):
     numerator: Optional[PydanticMetricInput]
     denominator: Optional[PydanticMetricInput]
     expr: Optional[str]
+    # Legacy, supports custom grain through PydanticMetricTimeWindow changes (should deprecate though)
     window: Optional[PydanticMetricTimeWindow]
+    # Legacy, will not support custom granularity
     grain_to_date: Optional[TimeGranularity]
     metrics: Optional[List[PydanticMetricInput]]
     conversion_type_params: Optional[PydanticConversionTypeParams]
@@ -206,7 +208,7 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
     metadata: Optional[PydanticMetadata]
     label: Optional[str] = None
     config: Optional[PydanticMetricConfig]
-    time_granularity: Optional[TimeGranularity] = None
+    time_granularity: Optional[str] = None
 
     @property
     def input_measures(self) -> Sequence[PydanticMetricInputMeasure]:

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -80,7 +80,7 @@ class PydanticMetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
         The MetricTimeWindow is always expected to be provided as a string in user-defined YAML configs.
         """
         if isinstance(input, str):
-            return PydanticMetricTimeWindow.parse(window=input, custom_granularity_names=(), strict=False)
+            return PydanticMetricTimeWindow.parse(window=input.lower(), custom_granularity_names=(), strict=False)
         else:
             raise ValueError(
                 f"MetricTimeWindow inputs from model configs are expected to always be of type string, but got "
@@ -90,7 +90,7 @@ class PydanticMetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
     @property
     def is_standard_granularity(self) -> bool:
         """Returns whether the window uses standard TimeGranularity."""
-        return self.granularity in {item.value for item in TimeGranularity}
+        return self.granularity.casefold() in {item.value.casefold() for item in TimeGranularity}
 
     @property
     def window_string(self) -> str:
@@ -113,7 +113,9 @@ class PydanticMetricTimeWindow(PydanticCustomInputParser, HashableBaseModel):
 
         granularity = parts[1]
 
-        valid_time_granularities = {item.value for item in TimeGranularity} | set(custom_granularity_names)
+        valid_time_granularities = {item.value.lower() for item in TimeGranularity} | set(
+            c.lower() for c in custom_granularity_names
+        )
 
         # if we switched to python 3.9 this could just be `granularity = parts[0].removesuffix('s')
         if granularity.endswith("s") and granularity[:-1] in valid_time_granularities:

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -77,30 +77,7 @@
             "additionalProperties": false,
             "properties": {
                 "grain_to_date": {
-                    "enum": [
-                        "NANOSECOND",
-                        "MICROSECOND",
-                        "MILLISECOND",
-                        "SECOND",
-                        "MINUTE",
-                        "HOUR",
-                        "DAY",
-                        "WEEK",
-                        "MONTH",
-                        "QUARTER",
-                        "YEAR",
-                        "nanosecond",
-                        "microsecond",
-                        "millisecond",
-                        "second",
-                        "minute",
-                        "hour",
-                        "day",
-                        "week",
-                        "month",
-                        "quarter",
-                        "year"
-                    ]
+                    "type": "string"
                 },
                 "period_agg": {
                     "enum": [
@@ -488,30 +465,7 @@
                     "type": "string"
                 },
                 "time_granularity": {
-                    "enum": [
-                        "NANOSECOND",
-                        "MICROSECOND",
-                        "MILLISECOND",
-                        "SECOND",
-                        "MINUTE",
-                        "HOUR",
-                        "DAY",
-                        "WEEK",
-                        "MONTH",
-                        "QUARTER",
-                        "YEAR",
-                        "nanosecond",
-                        "microsecond",
-                        "millisecond",
-                        "second",
-                        "minute",
-                        "hour",
-                        "day",
-                        "week",
-                        "month",
-                        "quarter",
-                        "year"
-                    ]
+                    "type": "string"
                 },
                 "type": {
                     "enum": [

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -123,7 +123,7 @@ cumulative_type_params_schema = {
     "type": "object",
     "properties": {
         "window": {"type": "string"},
-        "grain_to_date": {"enum": time_granularity_values},
+        "grain_to_date": {"type": "string"},
         "period_agg": {"enum": period_agg_values},
     },
     "additionalProperties": False,
@@ -304,7 +304,7 @@ metric_schema = {
         "description": {"type": "string"},
         "label": {"type": "string"},
         "config": {"$ref": "metric_config_schema"},
-        "time_granularity": {"enum": time_granularity_values},
+        "time_granularity": {"type": "string"},
     },
     "additionalProperties": False,
     "required": ["name", "type", "type_params"],

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -50,6 +50,7 @@ class ParameterSetFactory:
         time_granularity_name: Optional[str] = None,
         entity_path: Sequence[str] = (),
         date_part_name: Optional[str] = None,
+        custom_granularity_names: Sequence[str] = (),
     ) -> TimeDimensionCallParameterSet:
         """Gets called by Jinja when rendering {{ TimeDimension(...) }}.
 

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -50,7 +50,6 @@ class ParameterSetFactory:
         time_granularity_name: Optional[str] = None,
         entity_path: Sequence[str] = (),
         date_part_name: Optional[str] = None,
-        custom_granularity_names: Sequence[str] = (),
     ) -> TimeDimensionCallParameterSet:
         """Gets called by Jinja when rendering {{ TimeDimension(...) }}.
 

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -107,7 +107,7 @@ class MetricInput(Protocol):
 
     @property
     @abstractmethod
-    def offset_to_grain(self) -> Optional[TimeGranularity]:  # noqa: D
+    def offset_to_grain(self) -> Optional[str]:  # noqa: D
         pass
 
     @property
@@ -194,7 +194,7 @@ class CumulativeTypeParams(Protocol):
 
     @property
     @abstractmethod
-    def grain_to_date(self) -> Optional[TimeGranularity]:  # noqa: D
+    def grain_to_date(self) -> Optional[str]:  # noqa: D
         pass
 
     @property
@@ -333,7 +333,7 @@ class Metric(Protocol):
 
     @property
     @abstractmethod
-    def time_granularity(self) -> Optional[TimeGranularity]:
+    def time_granularity(self) -> Optional[str]:
         """Default grain used for the metric.
 
         This will be used in a couple of circumstances:

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -72,7 +72,12 @@ class MetricTimeWindow(Protocol):
 
     @property
     @abstractmethod
-    def granularity(self) -> TimeGranularity:  # noqa: D
+    def granularity(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
+    def is_standard_granularity(self) -> bool:  # noqa: D
         pass
 
 

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -77,6 +77,11 @@ class MetricTimeWindow(Protocol):
 
     @property
     @abstractmethod
+    def window_string(self) -> str:  # noqa: D
+        pass
+
+    @property
+    @abstractmethod
     def is_standard_granularity(self) -> bool:  # noqa: D
         pass
 

--- a/dbt_semantic_interfaces/test_utils.py
+++ b/dbt_semantic_interfaces/test_utils.py
@@ -24,7 +24,7 @@ from dbt_semantic_interfaces.implementations.semantic_model import (
     PydanticSemanticModel,
 )
 from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
-from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
+from dbt_semantic_interfaces.type_enums import MetricType
 from dbt_semantic_interfaces.validations.validator_helpers import (
     SemanticManifestValidationResults,
     ValidationIssue,
@@ -127,7 +127,7 @@ def metric_with_guaranteed_meta(
     type_params: PydanticMetricTypeParams,
     metadata: PydanticMetadata = default_meta(),
     description: str = "adhoc metric",
-    time_granularity: Optional[TimeGranularity] = None,
+    time_granularity: Optional[str] = None,
 ) -> PydanticMetric:
     """Creates a metric with the given input.
 

--- a/dbt_semantic_interfaces/transformations/cumulative_type_params.py
+++ b/dbt_semantic_interfaces/transformations/cumulative_type_params.py
@@ -36,6 +36,6 @@ class SetCumulativeTypeParamsRule(ProtocolHint[SemanticManifestTransformRule[Pyd
                 if metric.type_params.window and not metric.type_params.cumulative_type_params.window:
                     metric.type_params.cumulative_type_params.window = metric.type_params.window
                 if metric.type_params.grain_to_date and not metric.type_params.cumulative_type_params.grain_to_date:
-                    metric.type_params.cumulative_type_params.grain_to_date = metric.type_params.grain_to_date
+                    metric.type_params.cumulative_type_params.grain_to_date = metric.type_params.grain_to_date.value
 
         return semantic_manifest

--- a/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
+++ b/dbt_semantic_interfaces/transformations/pydantic_rule_set.py
@@ -22,6 +22,9 @@ from dbt_semantic_interfaces.transformations.cumulative_type_params import (
 )
 from dbt_semantic_interfaces.transformations.names import LowerCaseNamesRule
 from dbt_semantic_interfaces.transformations.proxy_measure import CreateProxyMeasureRule
+from dbt_semantic_interfaces.transformations.remove_plural_from_window_granularity import (
+    RemovePluralFromWindowGranularityRule,
+)
 from dbt_semantic_interfaces.transformations.rule_set import (
     SemanticManifestTransformRuleSet,
 )
@@ -54,6 +57,7 @@ class PydanticSemanticManifestTransformRuleSet(
             ConvertMedianToPercentileRule(),
             AddInputMetricMeasuresRule(),
             SetCumulativeTypeParamsRule(),
+            RemovePluralFromWindowGranularityRule(),
         )
 
     @property

--- a/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
+++ b/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
@@ -1,0 +1,94 @@
+from typing import Sequence
+
+from typing_extensions import override
+
+from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
+from dbt_semantic_interfaces.errors import ModelTransformError
+from dbt_semantic_interfaces.implementations.metric import PydanticMetricTimeWindow
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.protocols import ProtocolHint
+from dbt_semantic_interfaces.transformations.transform_rule import (
+    SemanticManifestTransformRule,
+)
+from dbt_semantic_interfaces.type_enums import MetricType
+
+
+class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+    """Remove trailing s from granularity in MetricTimeWindow.
+
+    During parsing, MetricTimeWindow.granularity can still contain he trailing 's' (ie., 3 days).
+    This is because with the introduction of custom granularities, we don't have access to the valid
+    custom grains during parsing. This transformation rule is introduced to remove the trailing 's'
+    from `MetricTimeWindow.granularity` if necessary.
+    """
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
+
+    @staticmethod
+    def _update_metric(
+        semantic_manifest: PydanticSemanticManifest, metric_name: str, custom_granularity_names: Sequence[str]
+    ) -> None:
+        """Mutates all the MetricTimeWindow by reparsing to remove the trailing 's'."""
+
+        def reparse_window(window: PydanticMetricTimeWindow) -> PydanticMetricTimeWindow:
+            """Reparse the window to remove the trailing 's'."""
+            return PydanticMetricTimeWindow.parse(
+                window=window.window_string, custom_granularity_names=custom_granularity_names
+            )
+
+        matched_metric = next(
+            iter((metric for metric in semantic_manifest.metrics if metric.name == metric_name)), None
+        )
+        if matched_metric:
+            if matched_metric.type is MetricType.CUMULATIVE:
+                if (
+                    matched_metric.type_params.cumulative_type_params
+                    and matched_metric.type_params.cumulative_type_params.window
+                ):
+                    matched_metric.type_params.cumulative_type_params.window = reparse_window(
+                        matched_metric.type_params.cumulative_type_params.window
+                    )
+            elif matched_metric.type is MetricType.CONVERSION:
+                if (
+                    matched_metric.type_params.conversion_type_params
+                    and matched_metric.type_params.conversion_type_params.window
+                ):
+                    matched_metric.type_params.conversion_type_params.window = reparse_window(
+                        matched_metric.type_params.conversion_type_params.window
+                    )
+
+            elif matched_metric.type is MetricType.DERIVED or matched_metric.type is MetricType.RATIO:
+                for input_metric in matched_metric.input_metrics:
+                    if input_metric.offset_window:
+                        input_metric.offset_window = reparse_window(input_metric.offset_window)
+                    RemovePluralFromWindowGranularityRule._update_metric(
+                        semantic_manifest=semantic_manifest,
+                        metric_name=input_metric.name,
+                        custom_granularity_names=custom_granularity_names,
+                    )
+            elif matched_metric.type is MetricType.SIMPLE:
+                pass
+            else:
+                assert_values_exhausted(matched_metric.type)
+        else:
+            raise ModelTransformError(f"Metric '{metric_name}' is not configured as a metric in the model.")
+
+    @staticmethod
+    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
+        custom_granularity_names = [
+            granularity.name
+            for time_spine in semantic_manifest.project_configuration.time_spines
+            for granularity in time_spine.custom_granularities
+        ]
+
+        for metric in semantic_manifest.metrics:
+            RemovePluralFromWindowGranularityRule._update_metric(
+                semantic_manifest=semantic_manifest,
+                metric_name=metric.name,
+                custom_granularity_names=custom_granularity_names,
+            )
+        return semantic_manifest

--- a/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
+++ b/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
@@ -65,11 +65,6 @@ class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransfo
                 for input_metric in matched_metric.input_metrics:
                     if input_metric.offset_window:
                         input_metric.offset_window = reparse_window(input_metric.offset_window)
-                    RemovePluralFromWindowGranularityRule._update_metric(
-                        semantic_manifest=semantic_manifest,
-                        metric_name=input_metric.name,
-                        custom_granularity_names=custom_granularity_names,
-                    )
             elif matched_metric.type is MetricType.SIMPLE:
                 pass
             else:

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -109,9 +109,10 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
 
             if window:
                 try:
-                    window_str = f"{window.count} {window.granularity}"
                     # TODO: Should not call an implementation class.
-                    PydanticMetricTimeWindow.parse(window=window_str, custom_granularity_names=custom_granularity_names)
+                    PydanticMetricTimeWindow.parse(
+                        window=window.window_string, custom_granularity_names=custom_granularity_names
+                    )
                 except ParsingException as e:
                     issues.append(
                         ValidationError(

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -224,7 +224,7 @@ def test_cumulative_window_metric_parsing() -> None:
     assert metric.name == "cumulative_test"
     assert metric.type is MetricType.CUMULATIVE
     assert metric.type_params.measure == PydanticMetricInputMeasure(name="cumulative_measure")
-    assert metric.type_params.window == PydanticMetricTimeWindow(count=7, granularity=TimeGranularity.DAY)
+    assert metric.type_params.window == PydanticMetricTimeWindow(count=7, granularity=TimeGranularity.DAY.value)
 
 
 def test_grain_to_date_metric_parsing() -> None:
@@ -281,7 +281,7 @@ def test_derived_metric_offset_window_parsing() -> None:
     assert metric.type_params.metrics and len(metric.type_params.metrics) == 2
     metric1, metric2 = metric.type_params.metrics
     assert metric1.offset_window is None
-    assert metric2.offset_window == PydanticMetricTimeWindow(count=14, granularity=TimeGranularity.DAY)
+    assert metric2.offset_window == PydanticMetricTimeWindow(count=14, granularity=TimeGranularity.DAY.value)
     assert metric1.alias is None
     assert metric2.alias == "bookings_2_weeks_ago"
     assert metric.type_params.expr == "bookings / bookings_2_weeks_ago"
@@ -315,7 +315,7 @@ def test_derive_metric_offset_to_grain_parsing() -> None:
     assert metric.type_params.metrics and len(metric.type_params.metrics) == 2
     metric1, metric2 = metric.type_params.metrics
     assert metric1.offset_to_grain is None
-    assert metric2.offset_to_grain == TimeGranularity.MONTH
+    assert metric2.offset_to_grain == TimeGranularity.MONTH.value
     assert metric1.alias is None
     assert metric2.alias == "bookings_at_start_of_month"
     assert metric.type_params.expr == "bookings / bookings_at_start_of_month"
@@ -449,7 +449,7 @@ def test_conversion_metric_parsing() -> None:
         name="conversions"
     )
     assert metric.type_params.conversion_type_params.window == PydanticMetricTimeWindow(
-        count=7, granularity=TimeGranularity.DAY
+        count=7, granularity=TimeGranularity.DAY.value
     )
     assert metric.type_params.conversion_type_params.entity == "user"
     assert metric.type_params.conversion_type_params.calculation == ConversionCalculationType.CONVERSION_RATE
@@ -536,26 +536,6 @@ def test_invalid_cumulative_metric_window_format_parsing_error() -> None:
     build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
     assert build_result.issues.has_blocking_issues
     assert "Invalid window" in str(SemanticManifestValidationException(build_result.issues.all_issues))
-
-
-def test_invalid_cumulative_metric_window_granularity_parsing_error() -> None:
-    """Test for errror detection when parsing malformed cumulative metric window entries."""
-    yaml_contents = textwrap.dedent(
-        """\
-        metric:
-          name: invalid_cumulative_granularity_test
-          type: cumulative
-          type_params:
-            measure:
-              name: cumulative_measure
-            window: "7 moons"
-        """
-    )
-    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
-
-    build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
-    assert build_result.issues.has_blocking_issues
-    assert "Invalid time granularity" in str(SemanticManifestValidationException(build_result.issues.all_issues))
 
 
 def test_invalid_cumulative_metric_window_count_parsing_error() -> None:

--- a/tests/parsing/test_metric_parsing.py
+++ b/tests/parsing/test_metric_parsing.py
@@ -212,7 +212,7 @@ def test_cumulative_window_metric_parsing() -> None:
           type_params:
             measure:
               name: cumulative_measure
-            window: "7 days"
+            window: "7 Days"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
@@ -237,7 +237,7 @@ def test_grain_to_date_metric_parsing() -> None:
           type_params:
             measure:
               name: cumulative_measure
-            grain_to_date: "week"
+            grain_to_date: "weEk"
         """
     )
     file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)

--- a/tests/parsing/test_metric_parsing_with_custom_grain.py
+++ b/tests/parsing/test_metric_parsing_with_custom_grain.py
@@ -1,0 +1,262 @@
+import textwrap
+
+from dbt_semantic_interfaces.parsing.dir_to_model import (
+    parse_yaml_files_to_validation_ready_semantic_manifest,
+)
+from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
+from dbt_semantic_interfaces.test_utils import base_semantic_manifest_file
+from tests.example_project_configuration import (
+    EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE,
+)
+
+
+def test_cumulative_metric_with_custom_grain_to_date() -> None:  # noqa: D
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: booking_source
+          node_relation:
+            schema_name: some_schema
+            alias: some_alias
+          primary_entity: booking
+
+          entities:
+            - name: user
+              type: foreign
+              expr: user_id
+          dimensions:
+            - name: is_instant
+              type: categorical
+          measures:
+            - name: bookings
+              expr: "1"
+              agg: sum
+        ---
+        metric:
+          name: "bookings"
+          description: "bookings metric"
+          label: "Bookings"
+          type: simple
+          type_params:
+            measure:
+              name: bookings
+        ---
+        metric:
+          name: "test_cumulative_metric_with_custom_grain_to_date"
+          description: "Test cumulative grain to date with custom granularity"
+          type: cumulative
+          type_params:
+            measure:
+              name: bookings
+            cumulative_type_params:
+              grain_to_date: martian_week
+        """
+    )
+    metric_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_semantic_manifest(
+        [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, base_semantic_manifest_file(), metric_file]
+    )
+    assert not model.issues.has_blocking_issues
+    semantic_manifest = model.semantic_manifest
+    assert len(semantic_manifest.metrics) == 3
+
+    metric = next(
+        (m for m in semantic_manifest.metrics if m.name == "test_cumulative_metric_with_custom_grain_to_date"), None
+    )
+    assert metric is not None, "Can't find metric"
+    assert (
+        metric.type_params.cumulative_type_params
+        and metric.type_params.cumulative_type_params.grain_to_date == "martian_week"
+    )
+
+
+def test_cumulative_metric_with_custom_window() -> None:  # noqa: D
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: booking_source
+          node_relation:
+            schema_name: some_schema
+            alias: some_alias
+          primary_entity: booking
+
+          entities:
+            - name: user
+              type: foreign
+              expr: user_id
+          dimensions:
+            - name: is_instant
+              type: categorical
+          measures:
+            - name: bookings
+              expr: "1"
+              agg: sum
+        ---
+        metric:
+          name: "bookings"
+          description: "bookings metric"
+          label: "Bookings"
+          type: simple
+          type_params:
+            measure:
+              name: bookings
+        ---
+        metric:
+          name: "test_cumulative_metric_with_custom_window"
+          description: "Test cumulative window with custom granularity"
+          type: cumulative
+          time_granularity: martian_week
+          type_params:
+            measure:
+              name: bookings
+            cumulative_type_params:
+              window: 5 martian_weeks
+        """
+    )
+    metric_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_semantic_manifest(
+        [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, base_semantic_manifest_file(), metric_file]
+    )
+    assert not model.issues.has_blocking_issues
+    semantic_manifest = model.semantic_manifest
+    assert len(semantic_manifest.metrics) == 3
+
+    metric = next((m for m in semantic_manifest.metrics if m.name == "test_cumulative_metric_with_custom_window"), None)
+    assert metric is not None, "Can't find metric"
+    # Should have gotten rid of the trailing 's' from the transformations
+    assert (
+        metric.type_params.cumulative_type_params
+        and metric.type_params.cumulative_type_params.window
+        and metric.type_params.cumulative_type_params.window.window_string == "5 martian_week"
+    )
+
+
+def test_conversion_metric_with_custom_grain_window() -> None:  # noqa: D
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: booking_source
+          node_relation:
+            schema_name: some_schema
+            alias: some_alias
+          primary_entity: booking
+
+          entities:
+            - name: user
+              type: foreign
+              expr: user_id
+          dimensions:
+            - name: is_instant
+              type: categorical
+          measures:
+            - name: bookings
+              expr: "1"
+              agg: sum
+        ---
+        metric:
+          name: "bookings"
+          description: "bookings metric"
+          label: "Bookings"
+          type: simple
+          type_params:
+            measure:
+              name: bookings
+        ---
+        metric:
+          name: "test_conversion_metric_with_custom_grain_window"
+          description: "Test conversion metric window with custom granularity"
+          type: conversion
+          type_params:
+            conversion_type_params:
+              base_measure: bookings
+              conversion_measure: bookings
+              window: 7 martian_weeks
+              entity: user
+              calculation: conversion_rate
+        """
+    )
+    metric_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_semantic_manifest(
+        [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, base_semantic_manifest_file(), metric_file]
+    )
+    assert not model.issues.has_blocking_issues
+    semantic_manifest = model.semantic_manifest
+    assert len(semantic_manifest.metrics) == 3
+
+    metric = next(
+        (m for m in semantic_manifest.metrics if m.name == "test_conversion_metric_with_custom_grain_window"), None
+    )
+    assert metric is not None, "Can't find metric"
+    # Should have gotten rid of the trailing 's' from the transformations
+    assert (
+        metric.type_params.conversion_type_params
+        and metric.type_params.conversion_type_params.window
+        and metric.type_params.conversion_type_params.window.window_string == "7 martian_week"
+    )
+
+
+def test_input_metric_custom_grains() -> None:  # noqa: D
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: booking_source
+          node_relation:
+            schema_name: some_schema
+            alias: some_alias
+          primary_entity: booking
+
+          entities:
+            - name: user
+              type: foreign
+              expr: user_id
+          dimensions:
+            - name: is_instant
+              type: categorical
+          measures:
+            - name: bookings
+              expr: "1"
+              agg: sum
+        ---
+        metric:
+          name: "bookings"
+          description: "bookings metric"
+          label: "Bookings"
+          type: simple
+          type_params:
+            measure:
+              name: bookings
+        ---
+        metric:
+          name: "test_input_metric_custom_grains"
+          description: "Test custom granularity support in input metrics"
+          type: derived
+          type_params:
+            expr: bookings_offset_to_grain - bookings_offset_window
+            metrics:
+              - name: bookings
+                offset_to_grain: martian_week
+                alias: bookings_offset_to_grain
+              - name: bookings
+                offset_window: 14 martian_weeks
+                alias: bookings_offset_window
+        """
+    )
+
+    metric_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model = parse_yaml_files_to_validation_ready_semantic_manifest(
+        [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, base_semantic_manifest_file(), metric_file]
+    )
+    assert not model.issues.has_blocking_issues
+    semantic_manifest = model.semantic_manifest
+    assert len(semantic_manifest.metrics) == 3
+
+    metric = next((m for m in semantic_manifest.metrics if m.name == "test_input_metric_custom_grains"), None)
+    assert metric is not None, "Can't find metric"
+    # Should have gotten rid of the trailing 's' from the transformations
+    assert metric.type_params.metrics and {
+        m.offset_to_grain or (m.offset_window.window_string if m.offset_window else None)
+        for m in metric.type_params.metrics
+    } == {
+        "martian_week",
+        "14 martian_week",
+    }


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Support custom grain by switching the typing to be not on `TimeGranularity`
- `Metric.time_granularity` - `TimeGranularity -> str`
- `Metric.type_params.cumulative_type_params.grain_to_date` - `TimeGranularity -> str`
- `MetricInput.offset_to_grain` - `TimeGranularity -> str`
- `MetricTimeWindow.granularity` - `TimeGranularity -> str` affects the following
  - `Metric.type_params.conversion_type_params.window`
  - `Metric.type_params.cumulative_type_params.window`
  - `MetricInput.offset_window`

#### Changes to `MetricTimeWindow`
Because `MetricTimeWindow.granularity` is now a string, we allow it to be not as strict when ensuring it's a valid granularity during initial yaml parsing (since we don't have access to the custom granularities). Then during validations, we will properly validate that it's a valid grain, and during the transformation step we will remove trailing 's'.


<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)

Resolves SL-2826