### PR TITLE
Remove unnecessary check against legacy field

### DIFF
--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -76,7 +76,8 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
                     else None
                 )
                 if (
-                    type_params_field_value
+                    field == "window"
+                    and type_params_field_value
                     and cumulative_type_params_field_value
                     and cumulative_type_params_field_value != type_params_field_value
                 ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.8.0"
+version = "0.8.1"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -614,18 +614,6 @@ def test_cumulative_metrics() -> None:  # noqa: D
                         ),
                     ),
                 ),
-                # Metrics with duplicated window or grain_to_date - should get warning
-                metric_with_guaranteed_meta(
-                    name="what_a_metric",
-                    type=MetricType.CUMULATIVE,
-                    type_params=PydanticMetricTypeParams(
-                        measure=PydanticMetricInputMeasure(name=measure_name),
-                        grain_to_date=TimeGranularity.YEAR,
-                        cumulative_type_params=PydanticCumulativeTypeParams(
-                            grain_to_date=TimeGranularity.HOUR.value,
-                        ),
-                    ),
-                ),
                 metric_with_guaranteed_meta(
                     name="dis_bad",
                     type=MetricType.CUMULATIVE,
@@ -688,12 +676,11 @@ def test_cumulative_metrics() -> None:  # noqa: D
     )
 
     build_issues = validation_results.all_issues
-    assert len(build_issues) == 4
+    assert len(build_issues) == 3
     expected_substrings = [
         "Invalid time granularity",
         "Both window and grain_to_date set for cumulative metric. Please set one or the other.",
         "Got differing values for `window`",
-        "Got differing values for `grain_to_date`",
     ]
     check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
We decided that `Metric.type_params.grain_to_date` will not be changed to support custom grain, but this validation makes it break since it expects it to be the same typing.

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
