### PR TITLE
Finalize validations for custom granularities

### DIFF
--- a/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
+++ b/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
@@ -1,4 +1,4 @@
-from typing import Sequence
+from typing import Set
 
 from typing_extensions import override
 
@@ -30,7 +30,7 @@ class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransfo
 
     @staticmethod
     def _update_metric(
-        semantic_manifest: PydanticSemanticManifest, metric_name: str, custom_granularity_names: Sequence[str]
+        semantic_manifest: PydanticSemanticManifest, metric_name: str, custom_granularity_names: Set[str]
     ) -> None:
         """Mutates all the MetricTimeWindow by reparsing to remove the trailing 's'."""
         valid_time_granularities = {item.value.lower() for item in TimeGranularity} | set(
@@ -81,11 +81,11 @@ class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransfo
 
     @staticmethod
     def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
-        custom_granularity_names = [
+        custom_granularity_names = {
             granularity.name
             for time_spine in semantic_manifest.project_configuration.time_spines
             for granularity in time_spine.custom_granularities
-        ]
+        }
 
         for metric in semantic_manifest.metrics:
             RemovePluralFromWindowGranularityRule._update_metric(

--- a/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
+++ b/dbt_semantic_interfaces/transformations/remove_plural_from_window_granularity.py
@@ -12,7 +12,7 @@ from dbt_semantic_interfaces.protocols import ProtocolHint
 from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
-from dbt_semantic_interfaces.type_enums import MetricType
+from dbt_semantic_interfaces.type_enums import MetricType, TimeGranularity
 
 
 class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
@@ -33,12 +33,18 @@ class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransfo
         semantic_manifest: PydanticSemanticManifest, metric_name: str, custom_granularity_names: Sequence[str]
     ) -> None:
         """Mutates all the MetricTimeWindow by reparsing to remove the trailing 's'."""
+        valid_time_granularities = {item.value.lower() for item in TimeGranularity} | set(
+            c.lower() for c in custom_granularity_names
+        )
 
-        def reparse_window(window: PydanticMetricTimeWindow) -> PydanticMetricTimeWindow:
+        def trim_trailing_s(window: PydanticMetricTimeWindow) -> PydanticMetricTimeWindow:
             """Reparse the window to remove the trailing 's'."""
-            return PydanticMetricTimeWindow.parse(
-                window=window.window_string, custom_granularity_names=custom_granularity_names
-            )
+            granularity = window.granularity
+            if granularity.endswith("s") and granularity[:-1] in valid_time_granularities:
+                # months -> month
+                granularity = granularity[:-1]
+            window.granularity = granularity
+            return window
 
         matched_metric = next(
             iter((metric for metric in semantic_manifest.metrics if metric.name == metric_name)), None
@@ -49,22 +55,23 @@ class RemovePluralFromWindowGranularityRule(ProtocolHint[SemanticManifestTransfo
                     matched_metric.type_params.cumulative_type_params
                     and matched_metric.type_params.cumulative_type_params.window
                 ):
-                    matched_metric.type_params.cumulative_type_params.window = reparse_window(
+                    matched_metric.type_params.cumulative_type_params.window = trim_trailing_s(
                         matched_metric.type_params.cumulative_type_params.window
                     )
+
             elif matched_metric.type is MetricType.CONVERSION:
                 if (
                     matched_metric.type_params.conversion_type_params
                     and matched_metric.type_params.conversion_type_params.window
                 ):
-                    matched_metric.type_params.conversion_type_params.window = reparse_window(
+                    matched_metric.type_params.conversion_type_params.window = trim_trailing_s(
                         matched_metric.type_params.conversion_type_params.window
                     )
 
             elif matched_metric.type is MetricType.DERIVED or matched_metric.type is MetricType.RATIO:
                 for input_metric in matched_metric.input_metrics:
                     if input_metric.offset_window:
-                        input_metric.offset_window = reparse_window(input_metric.offset_window)
+                        input_metric.offset_window = trim_trailing_s(input_metric.offset_window)
             elif matched_metric.type is MetricType.SIMPLE:
                 pass
             else:

--- a/dbt_semantic_interfaces/validations/agg_time_dimension.py
+++ b/dbt_semantic_interfaces/validations/agg_time_dimension.py
@@ -28,7 +28,7 @@ class AggregationTimeDimensionRule(SemanticManifestValidationRule[SemanticManife
 
     @staticmethod
     @validate_safely(whats_being_done="checking aggregation time dimension for a semantic model")
-    def _validate_semantic_model(semantic_model: SemanticModel) -> List[ValidationIssue]:
+    def _validate_semantic_model(semantic_model: SemanticModel) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         for measure in semantic_model.measures:

--- a/dbt_semantic_interfaces/validations/common_entities.py
+++ b/dbt_semantic_interfaces/validations/common_entities.py
@@ -37,7 +37,7 @@ class CommonEntitysRule(SemanticManifestValidationRule[SemanticManifestT], Gener
         entity: Entity,
         semantic_model: SemanticModel,
         entities_to_semantic_models: Dict[EntityReference, Set[str]],
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
         # If the entity is the dict and if the set of semantic models minus this semantic model is empty,
         # then we warn the user that their entity will be unused in joins
@@ -65,15 +65,17 @@ class CommonEntitysRule(SemanticManifestValidationRule[SemanticManifestT], Gener
     @validate_safely(whats_being_done="running model validation warning if entities are only one one semantic model")
     def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:
         """Issues a warning for any entity that is associated with only one semantic_model."""
-        issues = []
+        issues: List[ValidationIssue] = []
 
         entities_to_semantic_models = CommonEntitysRule._map_semantic_model_entities(semantic_manifest.semantic_models)
         for semantic_model in semantic_manifest.semantic_models or []:
             for entity in semantic_model.entities or []:
-                issues += CommonEntitysRule._check_entity(
-                    entity=entity,
-                    semantic_model=semantic_model,
-                    entities_to_semantic_models=entities_to_semantic_models,
+                issues.extend(
+                    CommonEntitysRule._check_entity(
+                        entity=entity,
+                        semantic_model=semantic_model,
+                        entities_to_semantic_models=entities_to_semantic_models,
+                    )
                 )
 
         return issues

--- a/dbt_semantic_interfaces/validations/dimension_const.py
+++ b/dbt_semantic_interfaces/validations/dimension_const.py
@@ -58,7 +58,7 @@ class DimensionConsistencyRule(SemanticManifestValidationRule[SemanticManifestT]
         dimension: Dimension,
         time_dims_to_granularity: Dict[DimensionReference, TimeGranularity],
         semantic_model: SemanticModel,
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         """Check that time dimensions of the same name and aren't primary have the same time granularity.
 
         Args:
@@ -104,7 +104,7 @@ class DimensionConsistencyRule(SemanticManifestValidationRule[SemanticManifestT]
         semantic_model: SemanticModel,
         dimension_to_invariant: Dict[DimensionReference, DimensionInvariants],
         update_invariant_dict: bool,
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         """Checks that the given semantic model has dimensions consistent with the given invariants.
 
         Args:

--- a/dbt_semantic_interfaces/validations/element_const.py
+++ b/dbt_semantic_interfaces/validations/element_const.py
@@ -1,9 +1,6 @@
 from collections import defaultdict
 from typing import DefaultDict, Generic, List, Sequence
 
-from dbt_semantic_interfaces.implementations.semantic_manifest import (
-    PydanticSemanticManifest,
-)
 from dbt_semantic_interfaces.protocols import SemanticManifestT
 from dbt_semantic_interfaces.references import SemanticModelReference
 from dbt_semantic_interfaces.validations.validator_helpers import (
@@ -28,7 +25,7 @@ class ElementConsistencyRule(SemanticManifestValidationRule[SemanticManifestT], 
 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring model wide element consistency")
-    def validate_manifest(semantic_manifest: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
         issues = []
         element_name_to_types = ElementConsistencyRule._get_element_name_to_types(semantic_manifest=semantic_manifest)
         invalid_elements = {
@@ -54,7 +51,7 @@ class ElementConsistencyRule(SemanticManifestValidationRule[SemanticManifestT], 
 
     @staticmethod
     def _get_element_name_to_types(
-        semantic_manifest: PydanticSemanticManifest,
+        semantic_manifest: SemanticManifestT,
     ) -> DefaultDict[str, DefaultDict[SemanticModelElementType, List[SemanticModelContext]]]:
         """Create a mapping of element names in the semantic manifest to types with a list of associated contexts."""
         element_types: DefaultDict[

--- a/dbt_semantic_interfaces/validations/entities.py
+++ b/dbt_semantic_interfaces/validations/entities.py
@@ -26,7 +26,7 @@ class NaturalEntityConfigurationRule(SemanticManifestValidationRule[SemanticMani
             "natural entities are used in the appropriate contexts"
         )
     )
-    def _validate_semantic_model_natural_entities(semantic_model: SemanticModel) -> List[ValidationIssue]:
+    def _validate_semantic_model_natural_entities(semantic_model: SemanticModel) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
         context = SemanticModelContext(
             file_context=FileContext.from_metadata(metadata=semantic_model.metadata),

--- a/dbt_semantic_interfaces/validations/measures.py
+++ b/dbt_semantic_interfaces/validations/measures.py
@@ -65,7 +65,7 @@ class MeasureConstraintAliasesRule(SemanticManifestValidationRule[SemanticManife
 
     @staticmethod
     @validate_safely(whats_being_done="ensuring measures aliases are set when required")
-    def _validate_required_aliases_are_set(metric: Metric, metric_context: MetricContext) -> List[ValidationIssue]:
+    def _validate_required_aliases_are_set(metric: Metric, metric_context: MetricContext) -> Sequence[ValidationIssue]:
         """Checks if valid aliases are set on the input measure references where they are required.
 
         Aliases are required whenever there are 2 or more input measures with the same measure
@@ -188,7 +188,7 @@ class MetricMeasuresRule(SemanticManifestValidationRule[SemanticManifestT], Gene
 
     @staticmethod
     @validate_safely(whats_being_done="checking all measures referenced by the metric exist")
-    def _validate_metric_measure_references(metric: Metric, valid_measure_names: Set[str]) -> List[ValidationIssue]:
+    def _validate_metric_measure_references(metric: Metric, valid_measure_names: Set[str]) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         for measure_reference in metric.measure_references:

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -120,8 +120,10 @@ class CumulativeMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
                 )
 
             if window:
-                issues += cls.validate_metric_time_window(
-                    metric_context=metric_context, window=window, custom_granularities=custom_granularity_names
+                issues.extend(
+                    cls.validate_metric_time_window(
+                        metric_context=metric_context, window=window, custom_granularities=custom_granularity_names
+                    )
                 )
 
         return issues
@@ -167,7 +169,7 @@ class DerivedMetricRule(SemanticManifestValidationRule[SemanticManifestT], Gener
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the alias set are not unique and distinct")
-    def _validate_alias_collision(metric: Metric) -> List[ValidationIssue]:
+    def _validate_alias_collision(metric: Metric) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         if metric.type == MetricType.DERIVED:
@@ -193,7 +195,7 @@ class DerivedMetricRule(SemanticManifestValidationRule[SemanticManifestT], Gener
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the input metrics exist")
-    def _validate_input_metrics_exist(semantic_manifest: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_input_metrics_exist(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         all_metrics = {m.name for m in semantic_manifest.metrics}
@@ -264,7 +266,7 @@ class DerivedMetricRule(SemanticManifestValidationRule[SemanticManifestT], Gener
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the expr field uses the input metrics")
-    def _validate_expr(metric: Metric) -> List[ValidationIssue]:
+    def _validate_expr(metric: Metric) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         if metric.type == MetricType.DERIVED:
@@ -346,7 +348,7 @@ class ConversionMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
     @validate_safely(whats_being_done="checks that the entity exists in the base/conversion semantic model")
     def _validate_entity_exists(
         metric: Metric, entity: str, base_semantic_model: SemanticModel, conversion_semantic_model: SemanticModel
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         if entity not in {entity.name for entity in base_semantic_model.entities}:
@@ -376,7 +378,7 @@ class ConversionMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
     @validate_safely(whats_being_done="checks that the provided measures are valid for conversion metrics")
     def _validate_measures(
         metric: Metric, base_semantic_model: SemanticModel, conversion_semantic_model: SemanticModel
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         def _validate_measure(
@@ -438,7 +440,7 @@ class ConversionMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
     @validate_safely(whats_being_done="checks that the provided constant properties are valid")
     def _validate_constant_properties(
         metric: Metric, base_semantic_model: SemanticModel, conversion_semantic_model: SemanticModel
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         def _elements_in_model(references: List[str], semantic_model: SemanticModel) -> None:

--- a/dbt_semantic_interfaces/validations/non_empty.py
+++ b/dbt_semantic_interfaces/validations/non_empty.py
@@ -17,7 +17,7 @@ class NonEmptyRule(SemanticManifestValidationRule[SemanticManifestT], Generic[Se
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the model has semantic models")
-    def _check_model_has_semantic_models(semantic_manifest: PydanticSemanticManifest) -> List[ValidationIssue]:
+    def _check_model_has_semantic_models(semantic_manifest: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
         if not semantic_manifest.semantic_models:
             issues.append(
@@ -29,7 +29,7 @@ class NonEmptyRule(SemanticManifestValidationRule[SemanticManifestT], Generic[Se
 
     @staticmethod
     @validate_safely(whats_being_done="checking that the model has metrics")
-    def _check_model_has_metrics(semantic_manifest: PydanticSemanticManifest) -> List[ValidationIssue]:
+    def _check_model_has_metrics(semantic_manifest: PydanticSemanticManifest) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         # If we are going to generate measure proxy metrics that is sufficient as well
@@ -50,8 +50,12 @@ class NonEmptyRule(SemanticManifestValidationRule[SemanticManifestT], Generic[Se
 
     @staticmethod
     @validate_safely("running model validation rule ensuring metrics and semantic models are defined")
-    def validate_manifest(semantic_manifest: PydanticSemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
+    def validate_manifest(  # noqa: D
+        # PydanticSemanticManifest is required here due to a Measure.create_metric call downstream.
+        # TODO: can we add create_metric to the Measure protocol to avoid this type override?
+        semantic_manifest: PydanticSemanticManifest,  # type: ignore[override]
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
-        issues += NonEmptyRule._check_model_has_semantic_models(semantic_manifest=semantic_manifest)
-        issues += NonEmptyRule._check_model_has_metrics(semantic_manifest=semantic_manifest)
+        issues.extend(NonEmptyRule._check_model_has_semantic_models(semantic_manifest=semantic_manifest))
+        issues.extend(NonEmptyRule._check_model_has_metrics(semantic_manifest=semantic_manifest))
         return issues

--- a/dbt_semantic_interfaces/validations/reserved_keywords.py
+++ b/dbt_semantic_interfaces/validations/reserved_keywords.py
@@ -1,4 +1,4 @@
-from typing import Generic, List
+from typing import Generic, List, Sequence
 
 from dbt_semantic_interfaces.protocols import (
     SemanticManifest,
@@ -67,7 +67,7 @@ class ReservedKeywordsRule(SemanticManifestValidationRule[SemanticManifestT], Ge
 
     @staticmethod
     @validate_safely(whats_being_done="checking that semantic model sub element names aren't reserved sql keywords")
-    def _validate_semantic_model_sub_elements(semantic_model: SemanticModel) -> List[ValidationIssue]:
+    def _validate_semantic_model_sub_elements(semantic_model: SemanticModel) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         for dimension in semantic_model.dimensions:
@@ -125,7 +125,7 @@ class ReservedKeywordsRule(SemanticManifestValidationRule[SemanticManifestT], Ge
 
     @classmethod
     @validate_safely(whats_being_done="checking that semantic_model node_relations are not sql reserved keywords")
-    def _validate_semantic_models(cls, semantic_manifest: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_semantic_models(cls, semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         """Checks names of objects that are not nested."""
         issues: List[ValidationIssue] = []
         set_keywords = set(RESERVED_KEYWORDS)
@@ -156,5 +156,5 @@ class ReservedKeywordsRule(SemanticManifestValidationRule[SemanticManifestT], Ge
         whats_being_done="running model validation ensuring elements that aren't selected via a defined expr don't "
         "contain reserved keywords"
     )
-    def validate_manifest(cls, semantic_manifest: SemanticManifest) -> List[ValidationIssue]:  # noqa: D
+    def validate_manifest(cls, semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:  # noqa: D
         return cls._validate_semantic_models(semantic_manifest=semantic_manifest)

--- a/dbt_semantic_interfaces/validations/semantic_models.py
+++ b/dbt_semantic_interfaces/validations/semantic_models.py
@@ -36,7 +36,7 @@ class SemanticModelValidityWindowRule(SemanticManifestValidationRule[SemanticMan
         whats_being_done="checking the semantic model's validity parameters for compatibility with "
         "runtime requirements"
     )
-    def _validate_semantic_model(semantic_model: SemanticModel) -> List[ValidationIssue]:
+    def _validate_semantic_model(semantic_model: SemanticModel) -> Sequence[ValidationIssue]:
         """Runs assertions on semantic models with validity parameters set on one or more time dimensions."""
         issues: List[ValidationIssue] = []
 
@@ -157,7 +157,7 @@ class SemanticModelDefaultsRule(SemanticManifestValidationRule[SemanticManifestT
 
     @staticmethod
     @validate_safely(whats_being_done="checking validity of the semantic model's default agg_time_dimension")
-    def _validate_default_agg_time_dimension(semantic_model: SemanticModel) -> List[ValidationIssue]:
+    def _validate_default_agg_time_dimension(semantic_model: SemanticModel) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         if semantic_model.defaults is None or semantic_model.defaults.agg_time_dimension is None:

--- a/dbt_semantic_interfaces/validations/unique_valid_name.py
+++ b/dbt_semantic_interfaces/validations/unique_valid_name.py
@@ -69,7 +69,9 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     NAME_REGEX = re.compile(r"\A[a-z]((?!__)[a-z0-9_])*[a-z0-9]\Z")
 
     @staticmethod
-    def check_valid_name(name: str, context: Optional[ValidationContext] = None) -> List[ValidationIssue]:  # noqa: D
+    def check_valid_name(  # noqa: D
+        name: str, context: Optional[ValidationContext] = None
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
 
         if not UniqueAndValidNameRule.NAME_REGEX.match(name):
@@ -102,7 +104,9 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
 
     @staticmethod
     @validate_safely(whats_being_done="checking semantic model sub element names are unique")
-    def _validate_semantic_model_elements_and_time_spines(semantic_manifest: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_semantic_model_elements_and_time_spines(
+        semantic_manifest: SemanticManifest,
+    ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
         custom_granularity_restricted_names_and_types: Dict[str, str] = {}
 
@@ -219,9 +223,9 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     @staticmethod
     @validate_safely(whats_being_done="checking top level elements of a specific type have unique and valid names")
     def _validate_top_level_objects_of_type(
-        objects: Union[List[SemanticModel], List[Metric], List[SavedQuery]],
+        objects: Union[Sequence[SemanticModel], Sequence[Metric], Sequence[SavedQuery]],
         object_type: SemanticManifestNodeType,
-    ) -> List[ValidationIssue]:
+    ) -> Sequence[ValidationIssue]:
         """Validates uniqeness and validaty of top level objects of singular type."""
         issues: List[ValidationIssue] = []
         object_names = set()
@@ -247,11 +251,9 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
 
     @staticmethod
     @validate_safely(whats_being_done="checking model top level element names are sufficiently unique")
-    def _validate_top_level_objects(semantic_manifest: SemanticManifest) -> List[ValidationIssue]:
+    def _validate_top_level_objects(semantic_manifest: SemanticManifest) -> Sequence[ValidationIssue]:
         """Checks names of objects that are not nested."""
-        issues: List[ValidationIssue] = []
-
-        issues.extend(
+        issues = list(
             UniqueAndValidNameRule._validate_top_level_objects_of_type(
                 semantic_manifest.semantic_models, SemanticManifestNodeType.SEMANTIC_MODEL
             )
@@ -274,7 +276,7 @@ class UniqueAndValidNameRule(SemanticManifestValidationRule[SemanticManifestT], 
     @staticmethod
     @validate_safely(whats_being_done="running model validation ensuring elements have adequately unique names")
     def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
-        issues = []
+        issues: List[ValidationIssue] = []
         issues += UniqueAndValidNameRule._validate_top_level_objects(semantic_manifest=semantic_manifest)
         issues += UniqueAndValidNameRule._validate_semantic_model_elements_and_time_spines(semantic_manifest)
 
@@ -336,7 +338,7 @@ class PrimaryEntityDimensionPairs(SemanticManifestValidationRule[SemanticManifes
     @staticmethod
     @validate_safely(whats_being_done="validating there are no duplicate dimension primary entity pairs")
     def validate_manifest(semantic_manifest: SemanticManifestT) -> Sequence[ValidationIssue]:  # noqa: D
-        issues = []
+        issues: List[ValidationIssue] = []
         known_pairings: Dict[str, Dict[str, str]] = {}
         for semantic_model in semantic_manifest.semantic_models:
             issues += PrimaryEntityDimensionPairs._check_semantic_model(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.8.1"
+version = "0.8.2"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -304,7 +304,7 @@ def test_derived_metric() -> None:  # noqa: D
                         metrics=[
                             PydanticMetricInput(
                                 name="random_metric",
-                                offset_window=PydanticMetricTimeWindow.parse("3 weeks", custom_granularity_names=()),
+                                offset_window=PydanticMetricTimeWindow.parse("3 weekies"),
                             ),
                             PydanticMetricInput(
                                 name="random_metric",
@@ -322,7 +322,7 @@ def test_derived_metric() -> None:  # noqa: D
                         metrics=[
                             PydanticMetricInput(
                                 name="random_metric",
-                                offset_window=PydanticMetricTimeWindow.parse("3 weeks", custom_granularity_names=()),
+                                offset_window=PydanticMetricTimeWindow.parse("3 weeks"),
                                 offset_to_grain=TimeGranularity.MONTH.value,
                             )
                         ],
@@ -333,7 +333,7 @@ def test_derived_metric() -> None:  # noqa: D
         )
     )
     build_issues = validation_results.all_issues
-    assert len(build_issues) == 6
+    assert len(build_issues) == 7
     expected_substrings = [
         "is already being used. Please choose another alias",
         "does not exist as a configured metric in the model",
@@ -341,6 +341,7 @@ def test_derived_metric() -> None:  # noqa: D
         "is not used in `expr`",
         "No input metrics found for derived metric",
         "No `expr` set for derived metric",
+        "Invalid time granularity",
     ]
     check_error_in_issues(error_substrings=expected_substrings, issues=build_issues)
 
@@ -351,7 +352,7 @@ def test_conversion_metrics() -> None:  # noqa: D
     entity = "entity"
     invalid_entity = "bad"
     invalid_measure = "invalid_measure"
-    window = PydanticMetricTimeWindow.parse("7 days", custom_granularity_names=())
+    window = PydanticMetricTimeWindow.parse("7 days")
     validator = SemanticManifestValidator[PydanticSemanticManifest]([ConversionMetricRule()])
     result = validator.validate_semantic_manifest(
         PydanticSemanticManifest(
@@ -478,7 +479,7 @@ def test_conversion_metrics() -> None:  # noqa: D
                             conversion_measure=PydanticMetricInputMeasure(
                                 name=conversion_measure_name,
                             ),
-                            window=PydanticMetricTimeWindow.parse("7 moons", custom_granularity_names=(), strict=False),
+                            window=PydanticMetricTimeWindow.parse("7 moons"),
                             entity=entity,
                         )
                     ),
@@ -492,9 +493,7 @@ def test_conversion_metrics() -> None:  # noqa: D
                             conversion_measure=PydanticMetricInputMeasure(
                                 name=conversion_measure_name,
                             ),
-                            window=PydanticMetricTimeWindow.parse(
-                                "7 martian_week", custom_granularity_names=("martian_week",)
-                            ),
+                            window=PydanticMetricTimeWindow.parse("7 martian_week"),
                             entity=entity,
                         )
                     ),
@@ -508,9 +507,7 @@ def test_conversion_metrics() -> None:  # noqa: D
                             conversion_measure=PydanticMetricInputMeasure(
                                 name=conversion_measure_name,
                             ),
-                            window=PydanticMetricTimeWindow.parse(
-                                "7 martian_weeks", custom_granularity_names=("martian_week",)
-                            ),
+                            window=PydanticMetricTimeWindow.parse("7 martian_weeks"),
                             entity=entity,
                         )
                     ),
@@ -640,9 +637,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=measure_name),
                         cumulative_type_params=PydanticCumulativeTypeParams(
-                            window=PydanticMetricTimeWindow.parse(
-                                window="3 moons", custom_granularity_names=(), strict=False
-                            ),
+                            window=PydanticMetricTimeWindow.parse(window="3 moons"),
                         ),
                     ),
                 ),
@@ -652,9 +647,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=measure_name),
                         cumulative_type_params=PydanticCumulativeTypeParams(
-                            window=PydanticMetricTimeWindow.parse(
-                                window="3 martian_week", custom_granularity_names=("martian_week",), strict=False
-                            ),
+                            window=PydanticMetricTimeWindow.parse(window="3 martian_week"),
                         ),
                     ),
                 ),
@@ -664,9 +657,7 @@ def test_cumulative_metrics() -> None:  # noqa: D
                     type_params=PydanticMetricTypeParams(
                         measure=PydanticMetricInputMeasure(name=measure_name),
                         cumulative_type_params=PydanticCumulativeTypeParams(
-                            window=PydanticMetricTimeWindow.parse(
-                                window="3 martian_weeks", custom_granularity_names=("martian_week",), strict=False
-                            ),
+                            window=PydanticMetricTimeWindow.parse(window="3 martian_weeks"),
                         ),
                     ),
                 ),

--- a/tests/validations/test_validator_helpers.py
+++ b/tests/validations/test_validator_helpers.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import List
+from typing import List, Sequence
 
 import pytest
 
@@ -25,7 +25,7 @@ from dbt_semantic_interfaces.validations.validator_helpers import (
 
 
 @pytest.fixture
-def list_of_issues() -> List[ValidationIssue]:  # noqa: D
+def list_of_issues() -> Sequence[ValidationIssue]:  # noqa: D
     file_context = FileContext(file_name="foo", line_number=1337)
     semantic_model_name = "My semantic model"
 
@@ -141,7 +141,7 @@ def test_merge_two_model_validation_results(list_of_issues: List[ValidationIssue
 
 def test_validate_safely_handles_exceptions():  # noqa: D
     @validate_safely("testing validate safely handles exceptions gracefully")
-    def checking_validate_safely() -> List[ValidationIssue]:
+    def checking_validate_safely() -> Sequence[ValidationIssue]:
         raise (Exception("Oh no an exception!"))
         return []
 


### PR DESCRIPTION
### Description
This PR does 2 things:
- In [this PR](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/365/files), we unintentionally made `grain_to_date` and `offset_to_grain` fields case sensitive. This needs to be fixed before we can release to core. This PR fixes that.
- Adds validation errors to block using custom grain on any fields except `offset_window`. This is due to a product decision we made to prioritize that feature and defer the rest.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
