### PR TITLE
Handle default of `None` properly for `cumulative_type_params`

### DIFF
--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -209,8 +209,8 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
         data = deepcopy(input)
 
         # Ensure grain_to_date is lowercased
-        type_params = data.get("type_params", {})
-        grain_to_date = type_params.get("cumulative_type_params", {}).get("grain_to_date")
+        type_params = data.get("type_params") or {}
+        grain_to_date = (type_params.get("cumulative_type_params") or {}).get("grain_to_date")
         if isinstance(grain_to_date, str):
             data["type_params"]["cumulative_type_params"]["grain_to_date"] = grain_to_date.lower()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.8.2"
+version = "0.8.3"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
dbt-core parses YAML differently than DSI. There, the YAML dict for a metric ends up with  if that key is empty. Then when we call type_params.get(cumulative_type_params, {}), the result is None because the key does exist in the dict. This results in a key error when we finally call .get(grain_to_date). Thus, we must set the default value outside of .get().

Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
