### PR TITLE
Update importlib-metadata dependency to allow versions 7 and 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "Jinja2>=3.1.6,<4",
   "click>=7.0,<9.0",
   "python-dateutil>=2.0,<3",
-  "importlib_metadata>=6.0,<7",
+  "importlib_metadata>=6.0,<9",
   "typing-extensions>=4.4,<5",
 ]
 


### PR DESCRIPTION
Resolves #

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

Updates the dependencies to allow for importlib-metadata versions 7 + 8. Attempting to fix the dependency conflict between airflow 3 and dbt 1.9+

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
