### PR TITLE
Transform `agg_time_dimension` to lowercase

### DIFF
--- a/dbt_semantic_interfaces/transformations/names.py
+++ b/dbt_semantic_interfaces/transformations/names.py
@@ -41,6 +41,8 @@ class LowerCaseNamesRule(ProtocolHint[SemanticManifestTransformRule[PydanticSema
         if semantic_model.dimensions:
             for dimension in semantic_model.dimensions:
                 dimension.name = dimension.name.lower()
+        if semantic_model.defaults and semantic_model.defaults.agg_time_dimension:
+            semantic_model.defaults.agg_time_dimension = semantic_model.defaults.agg_time_dimension.lower()
 
     @staticmethod
     def _lowercase_top_level_objects(model: PydanticSemanticManifest) -> None:


### PR DESCRIPTION
### Description
Seeing an error in MetricFlow where we can't find the `agg_time_dimension` in the semantic model because it's uppercased in the `defaults` section but lowercased (by transformation, presumably) in the `dimensions` section. This will ensure both are lowercased.

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
