### PR TITLE
Loosen importlib-metadata version range (#378)

### DIFF
--- a/.changes/unreleased/Dependencies-20250618-154743.yaml
+++ b/.changes/unreleased/Dependencies-20250618-154743.yaml
@@ -1,0 +1,6 @@
+kind: Dependencies
+body: Loosen importlib-metadata version range
+time: 2025-06-18T15:47:43.376872-04:00
+custom:
+  Author: courtneyholcomb
+  PR: "378"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "Jinja2>=3.1.3,<4",
   "click>=7.0,<9.0",
   "python-dateutil>=2.0,<3",
-  "importlib_metadata>=6.0,<7",
+  "importlib_metadata>=6.0,<9",
   "typing-extensions>=4.4,<5",
 ]
 


### PR DESCRIPTION
Backport of #378 to `0.7.latest` in prep for a `0.7.5` release.

Airflow 3.0 has a version conflict with this repo's `importlib-metadata` dependency range. Here we only use the `version()` function, which has not changed between 6.0 and 8.x, so we can safely widen the version range we support here to unblock users looking to upgrade Airflow.

### Checklist

- [X] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [X] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [X] This PR includes tests, or tests are not required/relevant for this PR
- [X] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
