### PR TITLE
Saved query order by support

### DIFF
--- a/.changes/unreleased/Features-20250708-155637.yaml
+++ b/.changes/unreleased/Features-20250708-155637.yaml
@@ -1,0 +1,6 @@
+kind: Features
+body: Support for parsing the order by in saved queries
+time: 2025-07-08T15:56:37.073651-07:00
+custom:
+  Author: courtneyholcomb
+  Issue: "382"

--- a/dbt_semantic_interfaces/call_parameter_sets.py
+++ b/dbt_semantic_interfaces/call_parameter_sets.py
@@ -19,6 +19,7 @@ class DimensionCallParameterSet:
 
     entity_path: Tuple[EntityReference, ...]
     dimension_reference: DimensionReference
+    descending: Optional[bool] = None
     # TODO: MFS Jinja allows grain and date part in Dimension(...). Should we allow them here, too, for consistency?
 
 
@@ -30,6 +31,7 @@ class TimeDimensionCallParameterSet:
     time_dimension_reference: TimeDimensionReference
     time_granularity_name: Optional[str] = None
     date_part: Optional[DatePart] = None
+    descending: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -38,6 +40,7 @@ class EntityCallParameterSet:
 
     entity_path: Tuple[EntityReference, ...]
     entity_reference: EntityReference
+    descending: Optional[bool] = None
 
 
 @dataclass(frozen=True)
@@ -45,7 +48,8 @@ class MetricCallParameterSet:
     """When 'Metric(...)' is used in the Jinja template of the where filter, the parameters to that call."""
 
     metric_reference: MetricReference
-    group_by: Tuple[LinkableElementReference, ...]
+    group_by: Tuple[LinkableElementReference, ...] = ()
+    descending: Optional[bool] = None
 
 
 @dataclass(frozen=True)

--- a/dbt_semantic_interfaces/call_parameter_sets.py
+++ b/dbt_semantic_interfaces/call_parameter_sets.py
@@ -58,5 +58,5 @@ class JinjaCallParameterSets:
     metric_call_parameter_sets: Tuple[MetricCallParameterSet, ...] = ()
 
 
-class ParseWhereFilterException(Exception):  # noqa: D
+class ParseJinjaObjectException(Exception):  # noqa: D
     pass

--- a/dbt_semantic_interfaces/call_parameter_sets.py
+++ b/dbt_semantic_interfaces/call_parameter_sets.py
@@ -49,7 +49,7 @@ class MetricCallParameterSet:
 
 
 @dataclass(frozen=True)
-class FilterCallParameterSets:
+class JinjaCallParameterSets:
     """The calls for metric items made in the Jinja template of the where filter."""
 
     dimension_call_parameter_sets: Tuple[DimensionCallParameterSet, ...] = ()

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -8,7 +8,7 @@ from typing_extensions import Self
 
 from dbt_semantic_interfaces.call_parameter_sets import (
     JinjaCallParameterSets,
-    ParseWhereFilterException,
+    ParseJinjaObjectException,
 )
 from dbt_semantic_interfaces.implementations.base import (
     HashableBaseModel,
@@ -142,6 +142,6 @@ class PydanticWhereFilterIntersection(HashableBaseModel):
                 lines.append(textwrap.indent(str(exception), prefix="    "))
                 lines.append("Traceback:")
                 lines.append(textwrap.indent("".join(traceback.format_tb(exception.__traceback__)), prefix="  "))
-            raise ParseWhereFilterException("\n".join(lines))
+            raise ParseJinjaObjectException("\n".join(lines))
 
         return filter_parameter_sets

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -7,7 +7,7 @@ from typing import Callable, Generator, List, Sequence, Tuple
 from typing_extensions import Self
 
 from dbt_semantic_interfaces.call_parameter_sets import (
-    FilterCallParameterSets,
+    JinjaCallParameterSets,
     ParseWhereFilterException,
 )
 from dbt_semantic_interfaces.implementations.base import (
@@ -49,7 +49,7 @@ class PydanticWhereFilter(PydanticCustomInputParser, HashableBaseModel):
         else:
             raise ValueError(f"Expected input to be of type string, but got type {type(input)} with value: {input}")
 
-    def call_parameter_sets(self, custom_granularity_names: Sequence[str]) -> FilterCallParameterSets:  # noqa: D
+    def call_parameter_sets(self, custom_granularity_names: Sequence[str]) -> JinjaCallParameterSets:  # noqa: D
         return WhereFilterParser.parse_call_parameter_sets(
             where_sql_template=self.where_sql_template, custom_granularity_names=custom_granularity_names
         )
@@ -118,9 +118,9 @@ class PydanticWhereFilterIntersection(HashableBaseModel):
 
     def filter_expression_parameter_sets(
         self, custom_granularity_names: Sequence[str]
-    ) -> List[Tuple[str, FilterCallParameterSets]]:
+    ) -> List[Tuple[str, JinjaCallParameterSets]]:
         """Gets the call parameter sets for each filter expression."""
-        filter_parameter_sets: List[Tuple[str, FilterCallParameterSets]] = []
+        filter_parameter_sets: List[Tuple[str, JinjaCallParameterSets]] = []
         invalid_filter_expressions: List[Tuple[str, Exception]] = []
         for where_filter in self.where_filters:
             try:

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -17,6 +17,7 @@ from dbt_semantic_interfaces.implementations.base import (
 )
 from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
     JinjaObjectParser,
+    QueryItemLocation,
 )
 
 
@@ -51,7 +52,9 @@ class PydanticWhereFilter(PydanticCustomInputParser, HashableBaseModel):
 
     def call_parameter_sets(self, custom_granularity_names: Sequence[str]) -> JinjaCallParameterSets:  # noqa: D
         return JinjaObjectParser.parse_call_parameter_sets(
-            where_sql_template=self.where_sql_template, custom_granularity_names=custom_granularity_names
+            where_sql_template=self.where_sql_template,
+            custom_granularity_names=custom_granularity_names,
+            query_item_location=QueryItemLocation.NON_ORDER_BY,
         )
 
 

--- a/dbt_semantic_interfaces/implementations/filters/where_filter.py
+++ b/dbt_semantic_interfaces/implementations/filters/where_filter.py
@@ -15,8 +15,8 @@ from dbt_semantic_interfaces.implementations.base import (
     PydanticCustomInputParser,
     PydanticParseableValueType,
 )
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import (
-    WhereFilterParser,
+from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
+    JinjaObjectParser,
 )
 
 
@@ -50,7 +50,7 @@ class PydanticWhereFilter(PydanticCustomInputParser, HashableBaseModel):
             raise ValueError(f"Expected input to be of type string, but got type {type(input)} with value: {input}")
 
     def call_parameter_sets(self, custom_granularity_names: Sequence[str]) -> JinjaCallParameterSets:  # noqa: D
-        return WhereFilterParser.parse_call_parameter_sets(
+        return JinjaObjectParser.parse_call_parameter_sets(
             where_sql_template=self.where_sql_template, custom_granularity_names=custom_granularity_names
         )
 

--- a/dbt_semantic_interfaces/parsing/where_filter/jinja_object_parser.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/jinja_object_parser.py
@@ -22,7 +22,7 @@ from dbt_semantic_interfaces.parsing.where_filter.parameter_set_factory import (
 )
 
 
-class WhereFilterParser:
+class JinjaObjectParser:
     """Parses the template in the WhereFilter into JinjaCallParameterSets."""
 
     @staticmethod
@@ -43,7 +43,7 @@ class WhereFilterParser:
         where_sql_template: str, custom_granularity_names: Sequence[str]
     ) -> JinjaCallParameterSets:
         """Return the result of extracting the semantic objects referenced in the where SQL template string."""
-        descriptions = WhereFilterParser.parse_item_descriptions(where_sql_template)
+        descriptions = JinjaObjectParser.parse_item_descriptions(where_sql_template)
 
         """
         Dimensions that are created with a grain or date_part parameter, for instance Dimension(...).grain(...), are

--- a/dbt_semantic_interfaces/parsing/where_filter/jinja_object_parser.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/jinja_object_parser.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import Sequence
 
-from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets, ParseJinjaObjectException
+from dbt_semantic_interfaces.call_parameter_sets import (
+    JinjaCallParameterSets,
+    ParseJinjaObjectException,
+)
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.parsing.text_input.ti_description import (
     ObjectBuilderItemDescription,
@@ -80,6 +82,7 @@ class JinjaObjectParser:
                             entity_path=description.entity_path,
                             date_part_name=description.date_part_name,
                             custom_granularity_names=custom_granularity_names,
+                            descending=description.descending,
                         )
                     )
                 else:
@@ -87,6 +90,7 @@ class JinjaObjectParser:
                         ParameterSetFactory.create_dimension(
                             dimension_name=description.item_name,
                             entity_path=description.entity_path,
+                            descending=description.descending,
                         )
                     )
             elif item_type is QueryItemType.TIME_DIMENSION:
@@ -97,6 +101,7 @@ class JinjaObjectParser:
                         entity_path=description.entity_path,
                         date_part_name=description.date_part_name,
                         custom_granularity_names=custom_granularity_names,
+                        descending=description.descending,
                     )
                 )
             elif item_type is QueryItemType.ENTITY:
@@ -104,6 +109,7 @@ class JinjaObjectParser:
                     ParameterSetFactory.create_entity(
                         entity_name=description.item_name,
                         entity_path=description.entity_path,
+                        descending=description.descending,
                     )
                 )
             elif item_type is QueryItemType.METRIC:
@@ -112,6 +118,7 @@ class JinjaObjectParser:
                         metric_name=description.item_name,
                         group_by=description.group_by_for_metric_item,
                         query_item_location=query_item_location,
+                        descending=description.descending,
                     )
                 )
             else:

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -58,6 +58,7 @@ class ParameterSetFactory:
         time_granularity_name: Optional[str] = None,
         entity_path: Sequence[str] = (),
         date_part_name: Optional[str] = None,
+        descending: Optional[bool] = None,
     ) -> TimeDimensionCallParameterSet:
         """Gets called by Jinja when rendering {{ TimeDimension(...) }}.
 
@@ -105,10 +106,13 @@ class ParameterSetFactory:
             ),
             time_granularity_name=time_granularity_name.lower() if time_granularity_name else None,
             date_part=DatePart(date_part_name.lower()) if date_part_name else None,
+            descending=descending,
         )
 
     @staticmethod
-    def create_dimension(dimension_name: str, entity_path: Sequence[str] = ()) -> DimensionCallParameterSet:
+    def create_dimension(
+        dimension_name: str, entity_path: Sequence[str] = (), descending: Optional[bool] = None
+    ) -> DimensionCallParameterSet:
         """Gets called by Jinja when rendering {{ Dimension(...) }}."""
         group_by_item_name = StructuredDunderedName.parse_name(name=dimension_name, custom_granularity_names=())
 
@@ -120,10 +124,13 @@ class ParameterSetFactory:
             entity_path=(
                 tuple(EntityReference(element_name=arg) for arg in entity_path) + group_by_item_name.entity_links
             ),
+            descending=descending,
         )
 
     @staticmethod
-    def create_entity(entity_name: str, entity_path: Sequence[str] = ()) -> EntityCallParameterSet:
+    def create_entity(
+        entity_name: str, entity_path: Sequence[str] = (), descending: Optional[bool] = None
+    ) -> EntityCallParameterSet:
         """Gets called by Jinja when rendering {{ Entity(...) }}."""
         structured_dundered_name = StructuredDunderedName.parse_name(name=entity_name, custom_granularity_names=())
         if structured_dundered_name.time_granularity is not None:
@@ -138,6 +145,7 @@ class ParameterSetFactory:
         return EntityCallParameterSet(
             entity_path=additional_entity_path_elements + structured_dundered_name.entity_links,
             entity_reference=EntityReference(element_name=structured_dundered_name.element_name),
+            descending=descending,
         )
 
     @staticmethod
@@ -145,6 +153,7 @@ class ParameterSetFactory:
         metric_name: str,
         group_by: Sequence[str] = (),
         query_item_location: QueryItemLocation = QueryItemLocation.NON_ORDER_BY,
+        descending: Optional[bool] = None,
     ) -> MetricCallParameterSet:
         """Gets called by Jinja when rendering {{ Metric(...) }}."""
         # Metric(...) syntax is required in saved_query.order_by to apply descending. Don't require group by there.
@@ -156,4 +165,5 @@ class ParameterSetFactory:
         return MetricCallParameterSet(
             metric_reference=MetricReference(element_name=metric_name),
             group_by=tuple([LinkableElementReference(element_name=group_by_name) for group_by_name in group_by]),
+            descending=descending,
         )

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Optional, Sequence
 
 from dbt_semantic_interfaces.call_parameter_sets import (
@@ -17,6 +18,13 @@ from dbt_semantic_interfaces.references import (
     TimeDimensionReference,
 )
 from dbt_semantic_interfaces.type_enums.date_part import DatePart
+
+
+class QueryItemLocation(Enum):
+    """The location of the input string in the query."""
+
+    ORDER_BY = "order_by"
+    NON_ORDER_BY = "non_order_by"
 
 
 class ParameterSetFactory:
@@ -133,9 +141,14 @@ class ParameterSetFactory:
         )
 
     @staticmethod
-    def create_metric(metric_name: str, group_by: Sequence[str] = ()) -> MetricCallParameterSet:
+    def create_metric(
+        metric_name: str,
+        group_by: Sequence[str] = (),
+        query_item_location: QueryItemLocation = QueryItemLocation.NON_ORDER_BY,
+    ) -> MetricCallParameterSet:
         """Gets called by Jinja when rendering {{ Metric(...) }}."""
-        if not group_by:
+        # Metric(...) syntax is required in saved_query.order_by to apply descending. Don't require group by there.
+        if query_item_location == QueryItemLocation.NON_ORDER_BY and not group_by:
             raise ParseJinjaObjectException(
                 "`group_by` parameter is required for Metric in where filter. This is needed to determine 1) the "
                 "granularity to aggregate the metric to and 2) how to join the metric to the rest of the query."

--- a/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/parameter_set_factory.py
@@ -4,7 +4,7 @@ from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     EntityCallParameterSet,
     MetricCallParameterSet,
-    ParseWhereFilterException,
+    ParseJinjaObjectException,
     TimeDimensionCallParameterSet,
 )
 from dbt_semantic_interfaces.naming.dundered import StructuredDunderedName
@@ -70,7 +70,7 @@ class ParameterSetFactory:
             name=time_dimension_name, custom_granularity_names=custom_granularity_names
         )
         if len(group_by_item_name.entity_links) != 1 and not is_metric_time_name(group_by_item_name.element_name):
-            raise ParseWhereFilterException(
+            raise ParseJinjaObjectException(
                 ParameterSetFactory._exception_message_for_incorrect_format(time_dimension_name)
             )
         grain_parsed_from_name = group_by_item_name.time_granularity
@@ -81,7 +81,7 @@ class ParameterSetFactory:
         )
 
         if inputs_are_mismatched:
-            raise ParseWhereFilterException(
+            raise ParseJinjaObjectException(
                 f"Received different grains in `time_dimension_name` parameter ('{time_dimension_name}') "
                 f"and `time_granularity_name` parameter ('{time_granularity_name}'). Remove the grain suffix "
                 f"(`{grain_parsed_from_name}`) from the time dimension name and use the `time_granularity_name` "
@@ -105,7 +105,7 @@ class ParameterSetFactory:
         group_by_item_name = StructuredDunderedName.parse_name(name=dimension_name, custom_granularity_names=())
 
         if len(group_by_item_name.entity_links) != 1 and not is_metric_time_name(group_by_item_name.element_name):
-            raise ParseWhereFilterException(ParameterSetFactory._exception_message_for_incorrect_format(dimension_name))
+            raise ParseJinjaObjectException(ParameterSetFactory._exception_message_for_incorrect_format(dimension_name))
 
         return DimensionCallParameterSet(
             dimension_reference=DimensionReference(element_name=group_by_item_name.element_name),
@@ -119,7 +119,7 @@ class ParameterSetFactory:
         """Gets called by Jinja when rendering {{ Entity(...) }}."""
         structured_dundered_name = StructuredDunderedName.parse_name(name=entity_name, custom_granularity_names=())
         if structured_dundered_name.time_granularity is not None:
-            raise ParseWhereFilterException(
+            raise ParseJinjaObjectException(
                 f"Name is in an incorrect format: {repr(entity_name)}. " f"It should not contain a time grain suffix."
             )
 
@@ -136,7 +136,7 @@ class ParameterSetFactory:
     def create_metric(metric_name: str, group_by: Sequence[str] = ()) -> MetricCallParameterSet:
         """Gets called by Jinja when rendering {{ Metric(...) }}."""
         if not group_by:
-            raise ParseWhereFilterException(
+            raise ParseJinjaObjectException(
                 "`group_by` parameter is required for Metric in where filter. This is needed to determine 1) the "
                 "granularity to aggregate the metric to and 2) how to join the metric to the rest of the query."
             )

--- a/dbt_semantic_interfaces/parsing/where_filter/where_filter_parser.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/where_filter_parser.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Sequence
 
 from dbt_semantic_interfaces.call_parameter_sets import (
-    FilterCallParameterSets,
+    JinjaCallParameterSets,
     ParseWhereFilterException,
 )
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
@@ -23,7 +23,7 @@ from dbt_semantic_interfaces.parsing.where_filter.parameter_set_factory import (
 
 
 class WhereFilterParser:
-    """Parses the template in the WhereFilter into FilterCallParameterSets."""
+    """Parses the template in the WhereFilter into JinjaCallParameterSets."""
 
     @staticmethod
     def parse_item_descriptions(where_sql_template: str) -> Sequence[ObjectBuilderItemDescription]:
@@ -41,7 +41,7 @@ class WhereFilterParser:
     @staticmethod
     def parse_call_parameter_sets(
         where_sql_template: str, custom_granularity_names: Sequence[str]
-    ) -> FilterCallParameterSets:
+    ) -> JinjaCallParameterSets:
         """Return the result of extracting the semantic objects referenced in the where SQL template string."""
         descriptions = WhereFilterParser.parse_item_descriptions(where_sql_template)
 
@@ -102,7 +102,7 @@ class WhereFilterParser:
             else:
                 assert_values_exhausted(item_type)
 
-        return FilterCallParameterSets(
+        return JinjaCallParameterSets(
             dimension_call_parameter_sets=tuple(dimension_call_parameter_sets),
             time_dimension_call_parameter_sets=tuple(time_dimension_call_parameter_sets),
             entity_call_parameter_sets=tuple(entity_call_parameter_sets),

--- a/dbt_semantic_interfaces/parsing/where_filter/where_filter_parser.py
+++ b/dbt_semantic_interfaces/parsing/where_filter/where_filter_parser.py
@@ -4,7 +4,7 @@ from typing import Sequence
 
 from dbt_semantic_interfaces.call_parameter_sets import (
     JinjaCallParameterSets,
-    ParseWhereFilterException,
+    ParseJinjaObjectException,
 )
 from dbt_semantic_interfaces.enum_extension import assert_values_exhausted
 from dbt_semantic_interfaces.parsing.text_input.ti_description import (
@@ -36,7 +36,7 @@ class WhereFilterParser:
                 valid_method_mapping=ConfiguredValidMethodMapping.DEFAULT_MAPPING,
             )
         except Exception as e:
-            raise ParseWhereFilterException(f"Error while parsing Jinja template:\n{where_sql_template}") from e
+            raise ParseJinjaObjectException(f"Error while parsing Jinja template:\n{where_sql_template}") from e
 
     @staticmethod
     def parse_call_parameter_sets(

--- a/dbt_semantic_interfaces/protocols/where_filter.py
+++ b/dbt_semantic_interfaces/protocols/where_filter.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import Protocol, Sequence, Tuple
 
-from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
+from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
 
 
 class WhereFilter(Protocol):
@@ -14,7 +14,7 @@ class WhereFilter(Protocol):
         pass
 
     @abstractmethod
-    def call_parameter_sets(self, custom_granularity_names: Sequence[str]) -> FilterCallParameterSets:
+    def call_parameter_sets(self, custom_granularity_names: Sequence[str]) -> JinjaCallParameterSets:
         """Describe calls like 'dimension(...)' in the SQL template."""
         pass
 
@@ -43,7 +43,7 @@ class WhereFilterIntersection(Protocol):
     @abstractmethod
     def filter_expression_parameter_sets(
         self, custom_granularity_names: Sequence[str]
-    ) -> Sequence[Tuple[str, FilterCallParameterSets]]:
+    ) -> Sequence[Tuple[str, JinjaCallParameterSets]]:
         """Mapping from distinct filter expressions to the call parameter sets associated with them.
 
         We use a tuple, rather than a Mapping, in case the call parameter sets may vary between

--- a/dbt_semantic_interfaces/validations/saved_query.py
+++ b/dbt_semantic_interfaces/validations/saved_query.py
@@ -5,7 +5,7 @@ import traceback
 from dataclasses import dataclass
 from typing import Generic, List, Optional, Sequence, Set
 
-from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
+from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.parsing.text_input.ti_description import (
     ObjectBuilderItemDescription,
@@ -56,7 +56,7 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
 
         for group_by_item in saved_query.query_params.group_by:
             # TODO: Replace with more appropriate abstractions once available.
-            parameter_sets: FilterCallParameterSets
+            parameter_sets: JinjaCallParameterSets
             try:
                 parameter_sets = WhereFilterParser.parse_call_parameter_sets(
                     where_sql_template="{{" + group_by_item + "}}", custom_granularity_names=custom_granularity_names

--- a/dbt_semantic_interfaces/validations/saved_query.py
+++ b/dbt_semantic_interfaces/validations/saved_query.py
@@ -5,7 +5,6 @@ import traceback
 from dataclasses import dataclass
 from typing import Generic, List, Optional, Sequence, Set
 
-from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
 from dbt_semantic_interfaces.naming.keywords import METRIC_TIME_ELEMENT_NAME
 from dbt_semantic_interfaces.parsing.text_input.ti_description import (
     ObjectBuilderItemDescription,
@@ -20,6 +19,7 @@ from dbt_semantic_interfaces.parsing.text_input.valid_method import (
 )
 from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
     JinjaObjectParser,
+    QueryItemLocation,
 )
 from dbt_semantic_interfaces.protocols import SemanticManifestT
 from dbt_semantic_interfaces.protocols.saved_query import SavedQuery
@@ -55,11 +55,11 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
         issues: List[ValidationIssue] = []
 
         for group_by_item in saved_query.query_params.group_by:
-            # TODO: Replace with more appropriate abstractions once available.
-            parameter_sets: JinjaCallParameterSets
             try:
                 parameter_sets = JinjaObjectParser.parse_call_parameter_sets(
-                    where_sql_template="{{" + group_by_item + "}}", custom_granularity_names=custom_granularity_names
+                    where_sql_template="{{" + group_by_item + "}}",
+                    custom_granularity_names=custom_granularity_names,
+                    query_item_location=QueryItemLocation.NON_ORDER_BY,
                 )
             except Exception as e:
                 issues.append(
@@ -117,13 +117,14 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
         return issues
 
     @staticmethod
-    def _parse_query_item(
+    def parse_query_item(
         saved_query: SavedQuery,
         text_processor: ObjectBuilderTextProcessor,
         query_item_input: str,
         element_type: SavedQueryElementType,
         valid_method_mapping: ValidMethodMapping,
     ) -> _ParseQueryItemResult:
+        """Parse a Jinja syntax object into an ObjectBuilderItemDescription."""
         try:
             item_description = text_processor.get_description(query_item_input, valid_method_mapping)
             return _ParseQueryItemResult(item_description=item_description, validation_issue=None)
@@ -165,7 +166,7 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
         for metric in saved_query.query_params.metrics:
             # In an order-by, a metric is specified as "Metric('bookings')" while in the metrics section, it's only the
             # metric name.
-            result = SavedQueryRule._parse_query_item(
+            result = SavedQueryRule.parse_query_item(
                 saved_query=saved_query,
                 text_processor=text_processor,
                 query_item_input=f"{QueryItemType.METRIC.value}('{metric}')",
@@ -178,7 +179,7 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
                 validation_issues.append(result.validation_issue)
 
         for group_by in saved_query.query_params.group_by:
-            result = SavedQueryRule._parse_query_item(
+            result = SavedQueryRule.parse_query_item(
                 saved_query=saved_query,
                 text_processor=text_processor,
                 query_item_input=group_by,
@@ -195,7 +196,7 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
             return validation_issues
 
         for order_by in saved_query.query_params.order_by:
-            result = SavedQueryRule._parse_query_item(
+            result = SavedQueryRule.parse_query_item(
                 saved_query=saved_query,
                 text_processor=text_processor,
                 query_item_input=order_by,

--- a/dbt_semantic_interfaces/validations/saved_query.py
+++ b/dbt_semantic_interfaces/validations/saved_query.py
@@ -18,8 +18,8 @@ from dbt_semantic_interfaces.parsing.text_input.valid_method import (
     ConfiguredValidMethodMapping,
     ValidMethodMapping,
 )
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import (
-    WhereFilterParser,
+from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
+    JinjaObjectParser,
 )
 from dbt_semantic_interfaces.protocols import SemanticManifestT
 from dbt_semantic_interfaces.protocols.saved_query import SavedQuery
@@ -58,7 +58,7 @@ class SavedQueryRule(SemanticManifestValidationRule[SemanticManifestT], Generic[
             # TODO: Replace with more appropriate abstractions once available.
             parameter_sets: JinjaCallParameterSets
             try:
-                parameter_sets = WhereFilterParser.parse_call_parameter_sets(
+                parameter_sets = JinjaObjectParser.parse_call_parameter_sets(
                     where_sql_template="{{" + group_by_item + "}}", custom_granularity_names=custom_granularity_names
                 )
             except Exception as e:

--- a/dbt_semantic_interfaces/validations/where_filters.py
+++ b/dbt_semantic_interfaces/validations/where_filters.py
@@ -2,7 +2,7 @@ import traceback
 from enum import Enum
 from typing import Generic, List, Sequence, Tuple
 
-from dbt_semantic_interfaces.call_parameter_sets import FilterCallParameterSets
+from dbt_semantic_interfaces.call_parameter_sets import JinjaCallParameterSets
 from dbt_semantic_interfaces.protocols import Metric, SemanticManifestT
 from dbt_semantic_interfaces.protocols.saved_query import SavedQuery
 from dbt_semantic_interfaces.references import MetricModelReference
@@ -36,7 +36,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
         element_name: str,
         object_type: SemanticManifestNodeType,
         context: ValidationContext,
-        filter_call_param_sets: FilterCallParameterSets,
+        filter_call_param_sets: JinjaCallParameterSets,
         valid_granularity_names: List[str],
     ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []
@@ -84,7 +84,7 @@ class WhereFiltersAreParseable(SemanticManifestValidationRule[SemanticManifestT]
     @staticmethod
     def _validate_time_granularity_names_for_metric(
         context: MetricContext,
-        filter_expression_parameter_sets: Sequence[Tuple[str, FilterCallParameterSets]],
+        filter_expression_parameter_sets: Sequence[Tuple[str, JinjaCallParameterSets]],
         valid_granularity_names: List[str],
     ) -> Sequence[ValidationIssue]:
         issues: List[ValidationIssue] = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.8.5"
+version = "0.8.6"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -5,7 +5,7 @@ import pytest
 from dbt_semantic_interfaces.call_parameter_sets import (
     DimensionCallParameterSet,
     EntityCallParameterSet,
-    FilterCallParameterSets,
+    JinjaCallParameterSets,
     MetricCallParameterSet,
     ParseWhereFilterException,
     TimeDimensionCallParameterSet,
@@ -36,7 +36,7 @@ def test_extract_dimension_call_parameter_sets() -> None:  # noqa: D
         )
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(
             DimensionCallParameterSet(
                 dimension_reference=DimensionReference(element_name="is_instant"),
@@ -63,7 +63,7 @@ def test_extract_dimension_with_grain_call_parameter_sets() -> None:  # noqa: D
         )
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
@@ -83,7 +83,7 @@ def test_extract_time_dimension_call_parameter_sets() -> None:  # noqa: D
         )
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
                 time_dimension_reference=TimeDimensionReference(element_name="created_at"),
@@ -102,7 +102,7 @@ def test_extract_time_dimension_call_parameter_sets() -> None:  # noqa: D
         )
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
                 time_dimension_reference=TimeDimensionReference(element_name="created_at"),
@@ -121,7 +121,7 @@ def test_extract_metric_time_dimension_call_parameter_sets() -> None:  # noqa: D
         where_sql_template="""{{ TimeDimension('metric_time', 'month') }} = '2020-01-01'"""
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
                 time_dimension_reference=TimeDimensionReference(element_name="metric_time"),
@@ -139,7 +139,7 @@ def test_extract_entity_call_parameter_sets() -> None:  # noqa: D
         )
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         entity_call_parameter_sets=(
             EntityCallParameterSet(
@@ -159,7 +159,7 @@ def test_extract_metric_call_parameter_sets() -> None:  # noqa: D
         where_sql_template=("{{ Metric('bookings', group_by=['listing']) }} > 2")
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         entity_call_parameter_sets=(),
         metric_call_parameter_sets=(
@@ -174,7 +174,7 @@ def test_extract_metric_call_parameter_sets() -> None:  # noqa: D
         where_sql_template=("{{ Metric('bookings', group_by=['listing', 'metric_time']) }} > 2")
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         entity_call_parameter_sets=(),
         metric_call_parameter_sets=(
@@ -213,7 +213,7 @@ def test_where_filter_interesection_extract_call_parameter_sets() -> None:
 
     parse_result = dict(filter_intersection.filter_expression_parameter_sets(custom_granularity_names=()))
 
-    assert parse_result.get(time_filter.where_sql_template) == FilterCallParameterSets(
+    assert parse_result.get(time_filter.where_sql_template) == JinjaCallParameterSets(
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
                 time_dimension_reference=TimeDimensionReference(element_name="metric_time"),
@@ -222,7 +222,7 @@ def test_where_filter_interesection_extract_call_parameter_sets() -> None:
             ),
         )
     )
-    assert parse_result.get(entity_filter.where_sql_template) == FilterCallParameterSets(
+    assert parse_result.get(entity_filter.where_sql_template) == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         entity_call_parameter_sets=(
             EntityCallParameterSet(
@@ -265,7 +265,7 @@ def test_time_dimension_without_granularity() -> None:  # noqa: D
         where_sql_template="{{ TimeDimension('booking__created_at') }} > 2023-09-18"
     ).call_parameter_sets(custom_granularity_names=())
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(
@@ -283,7 +283,7 @@ def test_time_dimension_with_custom_granularity() -> None:  # noqa: D
         where_sql_template="{{ TimeDimension('booking__created_at', 'martian_week') }} > 2023-09-18"
     ).call_parameter_sets(custom_granularity_names=("martian_week",))
 
-    assert parse_result == FilterCallParameterSets(
+    assert parse_result == JinjaCallParameterSets(
         dimension_call_parameter_sets=(),
         time_dimension_call_parameter_sets=(
             TimeDimensionCallParameterSet(

--- a/tests/implementations/where_filter/test_parse_calls.py
+++ b/tests/implementations/where_filter/test_parse_calls.py
@@ -7,7 +7,7 @@ from dbt_semantic_interfaces.call_parameter_sets import (
     EntityCallParameterSet,
     JinjaCallParameterSets,
     MetricCallParameterSet,
-    ParseWhereFilterException,
+    ParseJinjaObjectException,
     TimeDimensionCallParameterSet,
 )
 from dbt_semantic_interfaces.implementations.filters.where_filter import (
@@ -185,7 +185,7 @@ def test_extract_metric_call_parameter_sets() -> None:  # noqa: D
         ),
     )
 
-    with pytest.raises(ParseWhereFilterException):
+    with pytest.raises(ParseJinjaObjectException):
         PydanticWhereFilter(where_sql_template=("{{ Metric('bookings') }} > 2")).call_parameter_sets(
             custom_granularity_names=()
         )
@@ -195,7 +195,7 @@ def test_invalid_entity_name_error() -> None:
     """Test to ensure we throw an error if an entity name is invalid."""
     bad_entity_filter = PydanticWhereFilter(where_sql_template="{{ Entity('is_food_order__day' )}}")
 
-    with pytest.raises(ParseWhereFilterException, match="Name is in an incorrect format"):
+    with pytest.raises(ParseJinjaObjectException, match="Name is in an incorrect format"):
         bad_entity_filter.call_parameter_sets(custom_granularity_names=())
 
 
@@ -251,7 +251,7 @@ def test_where_filter_intersection_error_collection() -> None:
         where_filters=[metric_time_in_dimension_error, valid_dimension, entity_format_error]
     )
 
-    with pytest.raises(ParseWhereFilterException) as exc_info:
+    with pytest.raises(ParseJinjaObjectException) as exc_info:
         filter_intersection.filter_expression_parameter_sets(custom_granularity_names=())
 
     error_string = str(exc_info.value)

--- a/tests/parsing/test_where_filter_parsing.py
+++ b/tests/parsing/test_where_filter_parsing.py
@@ -27,6 +27,7 @@ from dbt_semantic_interfaces.implementations.filters.where_filter import (
 )
 from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
     JinjaObjectParser,
+    QueryItemLocation,
 )
 from dbt_semantic_interfaces.references import (
     EntityReference,
@@ -165,14 +166,18 @@ def test_where_filter_intersection_from_partially_deserialized_list_of_strings()
     ],
 )
 def test_time_dimension_date_part(where: str) -> None:  # noqa
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=(), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.time_dimension_call_parameter_sets) == 1
     assert param_sets.time_dimension_call_parameter_sets[0].date_part == DatePart.YEAR
 
 
 def test_dimension_date_part() -> None:  # noqa
     where = "{{ Dimension('metric_time').grain('DAY').date_part('YEAR') }} > '2023-01-01'"
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=(), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.time_dimension_call_parameter_sets) == 1
     assert param_sets.time_dimension_call_parameter_sets[0].date_part == DatePart.YEAR
 
@@ -218,14 +223,18 @@ def test_time_dimension_grain(  # noqa
     where_and_expected_call_params: Tuple[str, Union[TimeDimensionCallParameterSet, DimensionCallParameterSet]],
 ) -> None:
     where, expected_call_params = where_and_expected_call_params
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=("martian_week",))
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=("martian_week",), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.time_dimension_call_parameter_sets) == 1
     assert param_sets.time_dimension_call_parameter_sets[0] == expected_call_params
 
 
 def test_entity_without_primary_entity_prefix() -> None:  # noqa
     where = "{{ Entity('non_primary_entity') }} = '1'"
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=(), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.entity_call_parameter_sets) == 1
     assert param_sets.entity_call_parameter_sets[0] == EntityCallParameterSet(
         entity_path=(),
@@ -235,7 +244,9 @@ def test_entity_without_primary_entity_prefix() -> None:  # noqa
 
 def test_entity() -> None:  # noqa
     where = "{{ Entity('entity_1__entity_2', entity_path=['entity_0']) }} = '1'"
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=(), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.entity_call_parameter_sets) == 1
     assert param_sets.entity_call_parameter_sets[0] == EntityCallParameterSet(
         entity_path=(
@@ -248,7 +259,9 @@ def test_entity() -> None:  # noqa
 
 def test_metric() -> None:  # noqa
     where = "{{ Metric('metric', group_by=['dimension']) }} = 10"
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=(), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.metric_call_parameter_sets) == 1
     assert param_sets.metric_call_parameter_sets[0] == MetricCallParameterSet(
         group_by=(LinkableElementReference(element_name="dimension"),),
@@ -257,7 +270,9 @@ def test_metric() -> None:  # noqa
 
     # Without kwarg syntax
     where = "{{ Metric('metric', ['dimension']) }} = 10"
-    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(
+        where, custom_granularity_names=(), query_item_location=QueryItemLocation.NON_ORDER_BY
+    )
     assert len(param_sets.metric_call_parameter_sets) == 1
     assert param_sets.metric_call_parameter_sets[0] == MetricCallParameterSet(
         group_by=(LinkableElementReference(element_name="dimension"),),

--- a/tests/parsing/test_where_filter_parsing.py
+++ b/tests/parsing/test_where_filter_parsing.py
@@ -25,8 +25,8 @@ from dbt_semantic_interfaces.implementations.filters.where_filter import (
     PydanticWhereFilter,
     PydanticWhereFilterIntersection,
 )
-from dbt_semantic_interfaces.parsing.where_filter.where_filter_parser import (
-    WhereFilterParser,
+from dbt_semantic_interfaces.parsing.where_filter.jinja_object_parser import (
+    JinjaObjectParser,
 )
 from dbt_semantic_interfaces.references import (
     EntityReference,
@@ -165,14 +165,14 @@ def test_where_filter_intersection_from_partially_deserialized_list_of_strings()
     ],
 )
 def test_time_dimension_date_part(where: str) -> None:  # noqa
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
     assert len(param_sets.time_dimension_call_parameter_sets) == 1
     assert param_sets.time_dimension_call_parameter_sets[0].date_part == DatePart.YEAR
 
 
 def test_dimension_date_part() -> None:  # noqa
     where = "{{ Dimension('metric_time').grain('DAY').date_part('YEAR') }} > '2023-01-01'"
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
     assert len(param_sets.time_dimension_call_parameter_sets) == 1
     assert param_sets.time_dimension_call_parameter_sets[0].date_part == DatePart.YEAR
 
@@ -215,17 +215,17 @@ def test_dimension_date_part() -> None:  # noqa
     ],
 )
 def test_time_dimension_grain(  # noqa
-    where_and_expected_call_params: Tuple[str, Union[TimeDimensionCallParameterSet, DimensionCallParameterSet]]
+    where_and_expected_call_params: Tuple[str, Union[TimeDimensionCallParameterSet, DimensionCallParameterSet]],
 ) -> None:
     where, expected_call_params = where_and_expected_call_params
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=("martian_week",))
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=("martian_week",))
     assert len(param_sets.time_dimension_call_parameter_sets) == 1
     assert param_sets.time_dimension_call_parameter_sets[0] == expected_call_params
 
 
 def test_entity_without_primary_entity_prefix() -> None:  # noqa
     where = "{{ Entity('non_primary_entity') }} = '1'"
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
     assert len(param_sets.entity_call_parameter_sets) == 1
     assert param_sets.entity_call_parameter_sets[0] == EntityCallParameterSet(
         entity_path=(),
@@ -235,7 +235,7 @@ def test_entity_without_primary_entity_prefix() -> None:  # noqa
 
 def test_entity() -> None:  # noqa
     where = "{{ Entity('entity_1__entity_2', entity_path=['entity_0']) }} = '1'"
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
     assert len(param_sets.entity_call_parameter_sets) == 1
     assert param_sets.entity_call_parameter_sets[0] == EntityCallParameterSet(
         entity_path=(
@@ -248,7 +248,7 @@ def test_entity() -> None:  # noqa
 
 def test_metric() -> None:  # noqa
     where = "{{ Metric('metric', group_by=['dimension']) }} = 10"
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
     assert len(param_sets.metric_call_parameter_sets) == 1
     assert param_sets.metric_call_parameter_sets[0] == MetricCallParameterSet(
         group_by=(LinkableElementReference(element_name="dimension"),),
@@ -257,7 +257,7 @@ def test_metric() -> None:  # noqa
 
     # Without kwarg syntax
     where = "{{ Metric('metric', ['dimension']) }} = 10"
-    param_sets = WhereFilterParser.parse_call_parameter_sets(where, custom_granularity_names=())
+    param_sets = JinjaObjectParser.parse_call_parameter_sets(where, custom_granularity_names=())
     assert len(param_sets.metric_call_parameter_sets) == 1
     assert param_sets.metric_call_parameter_sets[0] == MetricCallParameterSet(
         group_by=(LinkableElementReference(element_name="dimension"),),


### PR DESCRIPTION
### Description
Currently, the `order_by` param in saved query YAML doesn't work in MetricFlow. This PR is part of the work to unblock that. 
A few things to get there:
- Supports differentiating between whether you're parsing Jinja in an order by or elsewhere. This is necessary because the `descending` method should only be supported in the order by, and `group_by` should not be required for order by metrics.
- Renames a few classes & one file to be more generic - to reflect the fact that the Jinja may not only be in the where filter
- Adds the descending attribute to the call parameter set objects, which is needed to pass that attribute around in MF

I highly recommend reviewing by commit!

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
