### PR TITLE
Validate that simple metrics have a measure XOR agg params

### DIFF
--- a/.changes/unreleased/Under the Hood-20250828-002203.yaml
+++ b/.changes/unreleased/Under the Hood-20250828-002203.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Added validation that simple metrics have agg params XOR an input measure.
+time: 2025-08-28T00:22:03.808349-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"


### PR DESCRIPTION
Towards Issue [#387](https://github.com/dbt-labs/dbt-semantic-interfaces/issues/387)
Internal SL-4116

### Description

This builds on top of the work in #399 , #400 , and #401 , #402 .

TSIA again.  A simple metric must define either an input measure or the new measure-like fields, but it cannot have both.

One thing to note in these tests - the actual body of a lot of these tests is repetitive, and I might be able to combine 2 or three of these tests.  I've opted not to so far because keeping the test cases separate is a lot cleaner and easier to understand when one fails, but I could be convinced to change that approach to be a little more DRY.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)