### PR TITLE
Make 'agg' field statically required

### DIFF
--- a/.changes/unreleased/Under the Hood-20250828-102053.yaml
+++ b/.changes/unreleased/Under the Hood-20250828-102053.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Make the 'agg' param statically required when metrics use the new measure-like arguments.
+time: 2025-08-28T10:20:53.877714-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -183,7 +183,7 @@ class PydanticMetricAggregationParams(HashableBaseModel):
 
     # TODO SL-4116: make sure we recreate/reuse all the validations for measures
     # for these fields, too.
-    agg: Optional[AggregationType]
+    agg: AggregationType
     agg_params: Optional[PydanticMeasureAggregationParameters]
     agg_time_dimension: Optional[str]
     non_additive_dimension: Optional[PydanticNonAdditiveDimensionParameters]

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -251,7 +251,7 @@ class MetricAggregationParams(Protocol):
 
     @property
     @abstractmethod
-    def agg(self) -> Optional[AggregationType]:  # noqa: D
+    def agg(self) -> AggregationType:  # noqa: D
         pass
 
     @property

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -88,6 +88,7 @@ def check_error_in_issues(error_substrings: List[str], issues: Tuple[ValidationI
                 type=MetricType.SIMPLE,
                 type_params=PydanticMetricTypeParams(
                     metric_aggregation_params=PydanticMetricAggregationParams(
+                        agg=AggregationType.SUM,
                         semantic_model="sum_measure2",
                         non_additive_dimension=PydanticNonAdditiveDimensionParameters(
                             name="this_name_does_not_exist",
@@ -106,6 +107,7 @@ def check_error_in_issues(error_substrings: List[str], issues: Tuple[ValidationI
                 type=MetricType.SIMPLE,
                 type_params=PydanticMetricTypeParams(
                     metric_aggregation_params=PydanticMetricAggregationParams(
+                        agg=AggregationType.SUM,
                         semantic_model="sum_measure2",
                         non_additive_dimension=PydanticNonAdditiveDimensionParameters(
                             name="country",
@@ -124,6 +126,7 @@ def check_error_in_issues(error_substrings: List[str], issues: Tuple[ValidationI
                 type=MetricType.SIMPLE,
                 type_params=PydanticMetricTypeParams(
                     metric_aggregation_params=PydanticMetricAggregationParams(
+                        agg=AggregationType.SUM,
                         semantic_model="sum_measure2",
                         non_additive_dimension=PydanticNonAdditiveDimensionParameters(
                             name="country",
@@ -141,6 +144,7 @@ def check_error_in_issues(error_substrings: List[str], issues: Tuple[ValidationI
                 type=MetricType.SIMPLE,
                 type_params=PydanticMetricTypeParams(
                     metric_aggregation_params=PydanticMetricAggregationParams(
+                        agg=AggregationType.SUM,
                         semantic_model="sum_measure2",
                         non_additive_dimension=PydanticNonAdditiveDimensionParameters(
                             name="weekly_dim",


### PR DESCRIPTION
Towards Issue [#387](https://github.com/dbt-labs/dbt-semantic-interfaces/issues/387)
Internal SL-4116

### Description


If you pass in the new metric_agg_params to metrics, the agg type should be required.  After discussing offline with @courtneyholcomb and @dave-connors-3 , I've verified that design change, so this PR makes that statically enforced.


### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)