### PR TITLE
Remove non-working validation

### DIFF
--- a/dbt_semantic_interfaces/validations/validator_helpers.py
+++ b/dbt_semantic_interfaces/validations/validator_helpers.py
@@ -189,7 +189,7 @@ class ValidationIssue(ABC, BaseModel):
 
     message: str
     context: Optional[ValidationContext] = None
-    extra_detail: Optional[str]
+    extra_detail: Optional[str] = None
 
     @property
     @abstractmethod
@@ -396,7 +396,7 @@ def validate_safely(
     """Decorator to safely run validation checks."""
 
     def decorator_check_element_safely(
-        func: Callable[P, Sequence[ValidationIssue]]
+        func: Callable[P, Sequence[ValidationIssue]],
     ) -> Callable[P, Sequence[ValidationIssue]]:
         @functools.wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> Sequence[ValidationIssue]:  # type: ignore


### PR DESCRIPTION
### Description
This validation was never actually working due to contradictory lines of code. Removing it so that no one makes the false assumption that dimensions with the same element name must have the same grain.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
