### PR TITLE
Remove duplicate `expr` field

### DIFF
--- a/.changes/unreleased/Under the Hood-20250910-131639.yaml
+++ b/.changes/unreleased/Under the Hood-20250910-131639.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Remove duplicate expr field from metric agg params
+time: 2025-09-10T13:16:39.06032-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -182,13 +182,12 @@ class PydanticMetricAggregationParams(HashableBaseModel):
 
     semantic_model: str
 
-    # TODO SL-4116: make sure we recreate/reuse all the validations for measures
-    # for these fields, too.
+    # If you add fields to this, please make sure to update the transformation
+    # helper PydanticMeasure.to_metric_aggregation_params()
     agg: AggregationType
     agg_params: Optional[PydanticMeasureAggregationParameters]
     agg_time_dimension: Optional[str]
     non_additive_dimension: Optional[PydanticNonAdditiveDimensionParameters]
-    expr: Optional[str]
 
 
 class PydanticMetricTypeParams(HashableBaseModel):

--- a/dbt_semantic_interfaces/protocols/metric.py
+++ b/dbt_semantic_interfaces/protocols/metric.py
@@ -269,11 +269,6 @@ class MetricAggregationParams(Protocol):
     def non_additive_dimension(self) -> Optional[NonAdditiveDimensionParameters]:  # noqa: D
         pass
 
-    @property
-    @abstractmethod
-    def expr(self) -> Optional[str]:  # noqa: D
-        pass
-
 
 class MetricTypeParams(Protocol):
     """Type params add additional context to certain metric types (the context depends on the metric type)."""

--- a/dbt_semantic_interfaces/validations/metrics.py
+++ b/dbt_semantic_interfaces/validations/metrics.py
@@ -610,7 +610,7 @@ class ConversionMetricRule(SemanticManifestValidationRule[SemanticManifestT], Ge
             issues.extend(
                 ConversionMetricRule._validate_agg_and_expr(
                     agg_type=agg_params.agg,
-                    expr=agg_params.expr,
+                    expr=metric.type_params.expr,
                     input_name=metric.name,
                     input_object_type="Metric",
                     main_metric=metric,
@@ -960,7 +960,7 @@ class MetricsCountAggregationExprRule(SemanticManifestValidationRule[SemanticMan
                         object_name=metric.name,
                         object_type="Metric",
                         agg_type=metric.type_params.metric_aggregation_params.agg,
-                        expr=metric.type_params.metric_aggregation_params.expr,
+                        expr=metric.type_params.expr,
                     )
                 )
         return issues

--- a/tests/validations/metrics/test_conversion_metrics.py
+++ b/tests/validations/metrics/test_conversion_metrics.py
@@ -58,8 +58,8 @@ INPUT_CONVERSION_METRIC = metric_with_guaranteed_meta(
         metric_aggregation_params=PydanticMetricAggregationParams(
             agg=AggregationType.COUNT,
             semantic_model="conversion",
-            expr="1",
         ),
+        expr="1",
     ),
 )
 
@@ -71,8 +71,8 @@ INPUT_BASE_METRIC = metric_with_guaranteed_meta(
         metric_aggregation_params=PydanticMetricAggregationParams(
             agg=AggregationType.COUNT,
             semantic_model="base",
-            expr="1",
         ),
+        expr="1",
     ),
 )
 
@@ -84,8 +84,8 @@ METRIC_WITH_NON_EXISTENT_MODEL = metric_with_guaranteed_meta(
         metric_aggregation_params=PydanticMetricAggregationParams(
             agg=AggregationType.COUNT,
             semantic_model="this_model_does_not_exist",
-            expr="1",
         ),
+        expr="1",
     ),
 )
 

--- a/tests/validations/test_metrics.py
+++ b/tests/validations/test_metrics.py
@@ -228,8 +228,8 @@ def test_simple_metrics_non_additive_dimension(  # noqa: D
                     metric_aggregation_params=PydanticMetricAggregationParams(
                         semantic_model="sum_measure",
                         agg=AggregationType.COUNT,
-                        expr="distinct 1",
                     ),
+                    expr="distinct 1",
                 ),
             ),
             "uses a 'count' aggregation with a DISTINCT expr: 'distinct 1'. This is not supported as it "


### PR DESCRIPTION
Resolves #387

### Description

We added an `expr` field to the metric aggregation params for metrics to enable us to replace measures with metrics.

However, there was already an `expr` field in the regular type params for a metric, making this redundant.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
