### PR TITLE
Transform measures with create_metric true to actual metrics

### DIFF
--- a/.changes/unreleased/Under the Hood-20250910-172813.yaml
+++ b/.changes/unreleased/Under the Hood-20250910-172813.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: 'Updated transformation for measures with create_metric: True to create an independent metric.'
+time: 2025-09-10T17:28:13.240814-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/dbt_semantic_interfaces/implementations/metric.py
+++ b/dbt_semantic_interfaces/implementations/metric.py
@@ -17,6 +17,7 @@ from dbt_semantic_interfaces.implementations.element_config import (
     PydanticSemanticLayerElementConfig,
 )
 from dbt_semantic_interfaces.implementations.elements.measure import (
+    PydanticMeasure,
     PydanticMeasureAggregationParameters,
     PydanticNonAdditiveDimensionParameters,
 )
@@ -336,3 +337,20 @@ class PydanticMetric(HashableBaseModel, ModelWithMetadataParsing, ProtocolHint[M
         conversion_type_params = metric.type_params.conversion_type_params
         assert conversion_type_params, f"Conversion metric '{metric.name}' must have conversion_type_params."
         return conversion_type_params
+
+    @staticmethod
+    def get_metric_aggregation_params(
+        measure: PydanticMeasure,
+        semantic_model_name: str,
+    ) -> PydanticMetricAggregationParams:
+        """This helps us create simple metrics from measures.
+
+        It lives here instead of measures to avoid circular import issues.
+        """
+        return PydanticMetricAggregationParams(
+            semantic_model=semantic_model_name,
+            agg=measure.agg,
+            agg_params=measure.agg_params,
+            agg_time_dimension=measure.agg_time_dimension,
+            non_additive_dimension=measure.non_additive_dimension,
+        )

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -35,10 +35,7 @@ class AddInputMetricMeasuresRule(ProtocolHint[SemanticManifestTransformRule[Pyda
             iter((metric for metric in semantic_manifest.metrics if metric.name == metric_name)), None
         )
         if matched_metric:
-            if matched_metric.type is MetricType.SIMPLE:
-                if matched_metric.type_params.measure is not None:
-                    measures.add(matched_metric.type_params.measure)
-            elif matched_metric.type is MetricType.CUMULATIVE:
+            if matched_metric.type is MetricType.SIMPLE or matched_metric.type is MetricType.CUMULATIVE:
                 assert (
                     matched_metric.type_params.measure is not None
                 ), f"{matched_metric} should have a measure defined, but it does not."

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -35,7 +35,10 @@ class AddInputMetricMeasuresRule(ProtocolHint[SemanticManifestTransformRule[Pyda
             iter((metric for metric in semantic_manifest.metrics if metric.name == metric_name)), None
         )
         if matched_metric:
-            if matched_metric.type is MetricType.SIMPLE or matched_metric.type is MetricType.CUMULATIVE:
+            if matched_metric.type is MetricType.SIMPLE:
+                if matched_metric.type_params.measure is not None:
+                    measures.add(matched_metric.type_params.measure)
+            elif matched_metric.type is MetricType.CUMULATIVE:
                 assert (
                     matched_metric.type_params.measure is not None
                 ), f"{matched_metric} should have a measure defined, but it does not."

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -5,7 +5,6 @@ from typing_extensions import override
 from dbt_semantic_interfaces.errors import ModelTransformError
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
-    PydanticMetricInputMeasure,
     PydanticMetricTypeParams,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
@@ -53,14 +52,21 @@ class CreateProxyMeasureRule(ProtocolHint[SemanticManifestTransformRule[Pydantic
                         add_metric = False
 
                 if add_metric is True:
+                    # just need to edit this and then add tests!
                     semantic_manifest.metrics.append(
                         PydanticMetric(
                             name=measure.name,
                             type=MetricType.SIMPLE,
                             type_params=PydanticMetricTypeParams(
-                                measure=PydanticMetricInputMeasure(name=measure.name),
-                                expr=measure.name,
+                                metric_aggregation_params=PydanticMetric.get_metric_aggregation_params(
+                                    measure=measure,
+                                    semantic_model_name=semantic_model.name,
+                                ),
+                                expr=measure.expr,
                             ),
+                            description=measure.description,
+                            label=measure.label,
+                            config=measure.config,
                         )
                     )
 

--- a/tests/transformations/test_proxy_measure_transformation_rule.py
+++ b/tests/transformations/test_proxy_measure_transformation_rule.py
@@ -5,6 +5,7 @@ from dbt_semantic_interfaces.implementations.elements.measure import PydanticMea
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
     PydanticMetricAggregationParams,
+    PydanticMetricInputMeasure,
 )
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
@@ -20,7 +21,7 @@ from tests.example_project_configuration import (
 )
 
 
-def test_proxy_measure_create_metric_generates_metric_with_equivalent_agg_params() -> None:
+def test_measure_with_create_metric_generates_metric_with_equivalent_agg_params() -> None:
     """Test that a measure with create_metric: true generates a metric with equivalent agg params."""
     primary_entity_name = "example_entity"
     measure_name = "my_sum_measure"
@@ -133,3 +134,8 @@ def test_proxy_measure_create_metric_generates_metric_with_equivalent_agg_params
     ], "Metric was constructed with the wrong non-additive dimension window groupings."
 
     assert metric.type_params.expr == measure_expr, "Metric was constructed with the wrong expr."
+
+    # Finally, make sure it still references the measure
+    assert metric.type_params.measure == PydanticMetricInputMeasure(
+        name=measure_name
+    ), "Metric was constructed with the wrong measure."

--- a/tests/transformations/test_proxy_measure_transformation_rule.py
+++ b/tests/transformations/test_proxy_measure_transformation_rule.py
@@ -1,0 +1,135 @@
+import textwrap
+from typing import List, Optional
+
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
+from dbt_semantic_interfaces.implementations.metric import (
+    PydanticMetric,
+    PydanticMetricAggregationParams,
+)
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.parsing.dir_to_model import (
+    SemanticManifestBuildResult,
+    parse_yaml_files_to_validation_ready_semantic_manifest,
+)
+from dbt_semantic_interfaces.parsing.objects import YamlConfigFile
+from dbt_semantic_interfaces.type_enums.metric_type import MetricType
+from tests.example_project_configuration import (
+    EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE,
+)
+
+
+def test_proxy_measure_create_metric_generates_metric_with_equivalent_agg_params() -> None:
+    """Test that a measure with create_metric: true generates a metric with equivalent agg params."""
+    primary_entity_name = "example_entity"
+    measure_name = "my_sum_measure"
+    measure_agg = "percentile"
+    measure_expr = "this_expr"
+    measure_agg_time_dimension = "ds"
+    semantic_model_name = "proxy_measure_test_model"
+    measure_non_additive_dimension_time_dimension = "ds"
+    measure_non_additive_dimension = "is_instant"
+    measure_non_additive_dimension_window_choice = "min"
+    measure_non_additive_dimension_window_grouping = primary_entity_name
+    measure_description = "A beautiful description for a beautiful measure!"
+    measure_label = "Read me, human!  I'm a label!"
+
+    yaml_contents = textwrap.dedent(
+        f"""\
+        semantic_model:
+          name: {semantic_model_name}
+          node_relation:
+            schema_name: some_schema
+            alias: source_table
+          entities:
+            - name: {primary_entity_name}
+              type: primary
+              role: test_role
+              expr: example_id
+          measures:
+            - name: {measure_name}
+              description: {measure_description}
+              label: {measure_label}
+              agg: {measure_agg}
+              agg: percentile
+              agg_params:
+                percentile: 0.99
+              agg_time_dimension: {measure_agg_time_dimension}
+              expr: {measure_expr}
+              non_additive_dimension:
+                name: {measure_non_additive_dimension}
+                window_choice: {measure_non_additive_dimension_window_choice}
+                window_groupings:
+                  - {measure_non_additive_dimension_window_grouping}
+              config:
+                meta:
+                  text_tag_1: whoot
+                  text_tag_2: beepboop
+              create_metric: true
+          dimensions:
+            - name: {measure_agg_time_dimension}
+              type: time
+              type_params:
+                time_granularity: day
+            - name: {measure_non_additive_dimension_time_dimension}
+              type: time
+              type_params:
+                time_granularity: day
+            - name: {measure_non_additive_dimension}
+              type: time
+              type_params:
+                time_granularity: day
+        """
+    )
+    yaml_file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+    model_build_result: SemanticManifestBuildResult = parse_yaml_files_to_validation_ready_semantic_manifest(
+        [EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE, yaml_file],
+        apply_transformations=True,
+        raise_issues_as_exceptions=True,
+    )
+
+    # Sanity check - there should exactly 1 measure and 1 metric
+    measures: List[PydanticMeasure] = []
+    manifest: PydanticSemanticManifest = model_build_result.semantic_manifest
+    for sm in manifest.semantic_models:
+        measures.extend(sm.measures)
+    metrics: List[PydanticMetric] = manifest.metrics
+    assert len(measures) == 1
+    assert len(metrics) == 1
+
+    # Get the metric we expect with correct metadata
+    metric = metrics[0]
+    assert metric.name == measure_name, "Metric was constructed with the wrong name."
+    assert metric.type == MetricType.SIMPLE, "Constructed metric MUST be a simple metric."
+    assert metric.description == measure_description, "Metric was constructed with the wrong description."
+    assert metric.label == measure_label, "Metric was constructed with the wrong label."
+    assert metric.config is not None, "Metric should have a config, but it is missing."
+    meta = metric.config.meta
+    assert meta is not None, "Metric should have a 'meta' value in its config."
+    assert meta.get("text_tag_1") == "whoot", "Metric was constructed with the wrong config values."
+    assert meta.get("text_tag_2") == "beepboop", "Metric was constructed with the wrong config values."
+
+    # Metric fields that specific to metrics that replace measures
+    metric_agg_params: Optional[PydanticMetricAggregationParams] = metric.type_params.metric_aggregation_params
+    assert metric_agg_params is not None, "Metric aggregation params were not populated but they should have been."
+    assert (
+        metric_agg_params.semantic_model == semantic_model_name
+    ), "Metric was constructed with the wrong semantic model name."
+    assert metric_agg_params.agg.value == measure_agg, "Metric was constructed with the wrong aggregation type."
+    assert (
+        metric_agg_params.agg_time_dimension == measure_agg_time_dimension
+    ), "Metric was constructed with the wrong agg time dimension."
+    non_additive_dimension = metric_agg_params.non_additive_dimension
+    assert non_additive_dimension is not None, "Metric should have been constructed with a non-additive dimension."
+    assert (
+        non_additive_dimension.name == measure_non_additive_dimension
+    ), "Metric was constructed with the wrong non-additive dimension name."
+    assert (
+        non_additive_dimension.window_choice.value == measure_non_additive_dimension_window_choice
+    ), "Metric was constructed with the wrong non-additive dimension window choice."
+    assert non_additive_dimension.window_groupings == [
+        measure_non_additive_dimension_window_grouping
+    ], "Metric was constructed with the wrong non-additive dimension window groupings."
+
+    assert metric.type_params.expr == measure_expr, "Metric was constructed with the wrong expr."


### PR DESCRIPTION
Towards #387
Internal SL-4209

### Description

Since we're eventually transforming away measures entirely and replacing them with SImple metrics with a superset of their parameters and capabilities, this is a logical place to start.

Previously, setting `create_metric: True` in your measure yaml definition would cause us to create a simple metric with that measure as an input for you.

Now, we'll create a simple metric with all the correct settings to replace that measure.  This should not impact the final queries executed in MetricFlow.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
