### PR TITLE
Use pydantic shim where missed

### DIFF
--- a/dbt_semantic_interfaces/implementations/element_config.py
+++ b/dbt_semantic_interfaces/implementations/element_config.py
@@ -1,11 +1,11 @@
 from typing import Any, Dict
 
-from pydantic import Field
 from typing_extensions import override
 
 from dbt_semantic_interfaces.implementations.base import HashableBaseModel
 from dbt_semantic_interfaces.protocols.meta import SemanticLayerElementConfig
 from dbt_semantic_interfaces.protocols.protocol_hint import ProtocolHint
+from dsi_pydantic_shim import Field
 
 
 class PydanticSemanticLayerElementConfig(HashableBaseModel, ProtocolHint[SemanticLayerElementConfig]):


### PR DESCRIPTION
Resolves #

We use a shim to resolve pydantic 2 to pydantic 1, which allows users to use either version without a breaking change. Looks like we missed using the shim in one place.
<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
