### PR TITLE
Add test for existing boolean aggregation transformation

### DIFF
--- a/tests/transformations/test_boolean_measure_aggregation_rule.py
+++ b/tests/transformations/test_boolean_measure_aggregation_rule.py
@@ -13,7 +13,10 @@ from tests.example_project_configuration import EXAMPLE_PROJECT_CONFIGURATION
 
 
 def test_boolean_measure_aggregation_rule_transforms_only_sum_boolean_measures() -> None:
-    """Validate SUM_BOOLEAN measures get wrapped expr and SUM agg; others unchanged."""
+    """Validate SUM_BOOLEAN measures correctly mutate their expr and agg types.
+
+    (Also validate that other measures are unchanged.)
+    """
     # Three measures:
     # - other_measure: not SUM_BOOLEAN -> unchanged
     # - measure_with_expr: SUM_BOOLEAN with existing expr -> wrap expr, change agg to SUM

--- a/tests/transformations/test_boolean_measure_aggregation_rule.py
+++ b/tests/transformations/test_boolean_measure_aggregation_rule.py
@@ -1,0 +1,57 @@
+from dbt_semantic_interfaces.implementations.elements.entity import PydanticEntity
+from dbt_semantic_interfaces.implementations.elements.measure import PydanticMeasure
+from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
+from dbt_semantic_interfaces.implementations.semantic_manifest import (
+    PydanticSemanticManifest,
+)
+from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
+from dbt_semantic_interfaces.transformations.boolean_measure import (
+    BooleanMeasureAggregationRule,
+)
+from dbt_semantic_interfaces.type_enums import AggregationType, EntityType
+from tests.example_project_configuration import EXAMPLE_PROJECT_CONFIGURATION
+
+
+def test_boolean_measure_aggregation_rule_transforms_only_sum_boolean_measures() -> None:
+    """Validate SUM_BOOLEAN measures get wrapped expr and SUM agg; others unchanged."""
+    # Three measures:
+    # - other_measure: not SUM_BOOLEAN -> unchanged
+    # - measure_with_expr: SUM_BOOLEAN with existing expr -> wrap expr, change agg to SUM
+    # - measure_without_expr: SUM_BOOLEAN with no expr -> use measure name, change agg to SUM
+    semantic_model = PydanticSemanticModel(
+        name="this_semantic_model",
+        node_relation=PydanticNodeRelation(alias="this_semantic_model", schema_name="schema"),
+        entities=[PydanticEntity(name="e1", type=EntityType.PRIMARY)],
+        measures=[
+            PydanticMeasure(name="other_measure", agg=AggregationType.COUNT, expr="1"),
+            PydanticMeasure(name="measure_with_expr", agg=AggregationType.SUM_BOOLEAN, expr="is_active"),
+            PydanticMeasure(name="measure_without_expr", agg=AggregationType.SUM_BOOLEAN),
+        ],
+    )
+
+    manifest = PydanticSemanticManifest(
+        semantic_models=[semantic_model],
+        metrics=[],
+        project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
+    )
+
+    out = BooleanMeasureAggregationRule.transform_model(manifest)
+    out_sm = out.semantic_models[0]
+
+    # Sanity: still three measures
+    assert len(out_sm.measures) == 3
+
+    # Unchanged non-boolean measure
+    other_measure = next(m for m in out_sm.measures if m.name == "other_measure")
+    assert other_measure.agg == AggregationType.COUNT
+    assert other_measure.expr == "1"
+
+    # SUM_BOOLEAN with existing expr -> wrapped and agg becomes SUM
+    measure_with_expr = next(m for m in out_sm.measures if m.name == "measure_with_expr")
+    assert measure_with_expr.agg == AggregationType.SUM
+    assert measure_with_expr.expr == "CASE WHEN is_active THEN 1 ELSE 0 END"
+
+    # SUM_BOOLEAN with no expr -> use measure name and agg becomes SUM
+    measure_without_expr = next(m for m in out_sm.measures if m.name == "measure_without_expr")
+    assert measure_without_expr.agg == AggregationType.SUM
+    assert measure_without_expr.expr == "CASE WHEN measure_without_expr THEN 1 ELSE 0 END"


### PR DESCRIPTION
Towards #387

### Description

Downstream (i.e. up-stack), we need to refactor the BooleanMeasureAggregationRule transformation logic a bit, but we don't have any tests in place to make sure this is working correctly.

This test canonizes the current behavior of the transformation so that we know the behavior is unchanged in subsequent PRs.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [ ] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
