### PR TITLE
Convert median to percentile in metrics (like in measures)

### DIFF
--- a/.changes/unreleased/Under the Hood-20250929-143250.yaml
+++ b/.changes/unreleased/Under the Hood-20250929-143250.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add transformation for new simple metrics that matches the one for measures with MEDIAN agg types.
+time: 2025-09-29T14:32:50.563028-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/dbt_semantic_interfaces/transformations/convert_median.py
+++ b/dbt_semantic_interfaces/transformations/convert_median.py
@@ -1,3 +1,5 @@
+from typing import Literal, NoReturn
+
 from typing_extensions import override
 
 from dbt_semantic_interfaces.errors import ModelTransformError
@@ -12,11 +14,80 @@ from dbt_semantic_interfaces.transformations.transform_rule import (
     SemanticManifestTransformRule,
 )
 from dbt_semantic_interfaces.type_enums import AggregationType
+from dbt_semantic_interfaces.type_enums.metric_type import MetricType
 
-MEDIAN_PERCENTILE = 0.5
+
+class ConvertMedianMetricToPercentile(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+    """Converts any MEDIAN metrics to percentile equivalent.
+
+    Applies to SIMPLE metrics that aggregate an expression directly via
+    `type_params.metric_aggregation_params`.
+    """
+
+    TRANSFORMED_AGG_TYPE = AggregationType.PERCENTILE
+    MEDIAN_PERCENTILE = 0.5
+
+    @override
+    def _implements_protocol(self) -> SemanticManifestTransformRule[PydanticSemanticManifest]:  # noqa: D
+        return self
+
+    @staticmethod
+    def _throw_conflicting_percentile_error(
+        object_name: str,
+        object_type: Literal["Metric", "Measure"],
+        percentile: float,
+    ) -> NoReturn:
+        raise ModelTransformError(
+            f"{object_type} '{object_name}' uses a MEDIAN aggregation, while percentile "
+            f"is set to '{percentile}', a conflicting value. Please remove the parameter "
+            "or set to '0.5'."
+        )
+
+    @staticmethod
+    def _throw_conflicting_discrete_percentile_error(
+        object_name: str,
+        object_type: Literal["Metric", "Measure"],
+    ) -> NoReturn:
+        raise ModelTransformError(
+            f"{object_type} '{object_name}' uses a MEDIAN aggregation, while use_discrete_percentile "
+            f"is set to true. Please remove the parameter or set to False."
+        )
+
+    @staticmethod
+    def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
+        for metric in semantic_manifest.metrics:
+            if (
+                metric.type == MetricType.SIMPLE
+                and metric.type_params.metric_aggregation_params is not None
+                and metric.type_params.metric_aggregation_params.agg == AggregationType.MEDIAN
+            ):
+                # Update aggregation type first
+                metric.type_params.metric_aggregation_params.agg = ConvertMedianMetricToPercentile.TRANSFORMED_AGG_TYPE
+
+                # Ensure aggregation parameters exist, then validate
+                if metric.type_params.metric_aggregation_params.agg_params is None:
+                    metric.type_params.metric_aggregation_params.agg_params = PydanticMeasureAggregationParameters()
+                else:
+                    agg_params = metric.type_params.metric_aggregation_params.agg_params
+                    if agg_params.percentile is not None and agg_params.percentile != MEDIAN_PERCENTILE:
+                        ConvertMedianMetricToPercentile._throw_conflicting_percentile_error(
+                            object_name=metric.name,
+                            object_type="Metric",
+                            percentile=agg_params.percentile,
+                        )
+                    if agg_params.use_discrete_percentile:
+                        ConvertMedianMetricToPercentile._throw_conflicting_discrete_percentile_error(
+                            object_name=metric.name,
+                            object_type="Metric",
+                        )
+
+                # Set the median percentile
+                metric.type_params.metric_aggregation_params.agg_params.percentile = MEDIAN_PERCENTILE
+
+        return semantic_manifest
 
 
-class ConvertMedianToPercentileRule(ProtocolHint[SemanticManifestTransformRule[PydanticSemanticManifest]]):
+class ConvertMedianToPercentileRule(ConvertMedianMetricToPercentile):
     """Converts any MEDIAN measures to percentile equivalent."""
 
     @override
@@ -28,22 +99,27 @@ class ConvertMedianToPercentileRule(ProtocolHint[SemanticManifestTransformRule[P
         for semantic_model in semantic_manifest.semantic_models:
             for measure in semantic_model.measures:
                 if measure.agg == AggregationType.MEDIAN:
-                    measure.agg = AggregationType.PERCENTILE
+                    measure.agg = ConvertMedianToPercentileRule.TRANSFORMED_AGG_TYPE
 
                     if not measure.agg_params:
                         measure.agg_params = PydanticMeasureAggregationParameters()
                     else:
                         if measure.agg_params.percentile is not None and measure.agg_params.percentile != 0.5:
-                            raise ModelTransformError(
-                                f"Measure '{measure.name}' uses a MEDIAN aggregation, while percentile is set to "
-                                f"'{measure.agg_params.percentile}', a conflicting value. Please remove the parameter "
-                                "or set to '0.5'."
+                            ConvertMedianToPercentileRule._throw_conflicting_percentile_error(
+                                object_name=measure.name,
+                                object_type="Measure",
+                                percentile=measure.agg_params.percentile,
                             )
                         if measure.agg_params.use_discrete_percentile:
-                            raise ModelTransformError(
-                                f"Measure '{measure.name}' uses a MEDIAN aggregation, while use_discrete_percentile "
-                                f"is set to true. Please remove the parameter or set to False."
+                            ConvertMedianToPercentileRule._throw_conflicting_discrete_percentile_error(
+                                object_name=measure.name,
+                                object_type="Measure",
                             )
-                    measure.agg_params.percentile = MEDIAN_PERCENTILE
+                    measure.agg_params.percentile = ConvertMedianToPercentileRule.MEDIAN_PERCENTILE
                     # let's not set use_approximate_percentile to be false due to valid performance reasons
         return semantic_manifest
+
+
+# Just left here for legacy reasons.  Maybe we can get rid of this when we remove
+# measures?
+MEDIAN_PERCENTILE = ConvertMedianMetricToPercentile.MEDIAN_PERCENTILE

--- a/tests/transformations/test_convert_median_rule.py
+++ b/tests/transformations/test_convert_median_rule.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pytest
 
 from dbt_semantic_interfaces.errors import ModelTransformError
@@ -6,15 +8,23 @@ from dbt_semantic_interfaces.implementations.elements.measure import (
     PydanticMeasure,
     PydanticMeasureAggregationParameters,
 )
+from dbt_semantic_interfaces.implementations.metric import (
+    PydanticMetric,
+    PydanticMetricAggregationParams,
+    PydanticMetricInput,
+    PydanticMetricTypeParams,
+)
 from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
 from dbt_semantic_interfaces.implementations.semantic_manifest import (
     PydanticSemanticManifest,
 )
 from dbt_semantic_interfaces.implementations.semantic_model import PydanticSemanticModel
 from dbt_semantic_interfaces.transformations.convert_median import (
+    ConvertMedianMetricToPercentile,
     ConvertMedianToPercentileRule,
 )
 from dbt_semantic_interfaces.type_enums import AggregationType, EntityType
+from dbt_semantic_interfaces.type_enums.metric_type import MetricType
 from tests.example_project_configuration import EXAMPLE_PROJECT_CONFIGURATION
 
 
@@ -33,7 +43,268 @@ def build_manifest_with_single_measure(measure: PydanticMeasure) -> PydanticSema
     )
 
 
-def test_median_rule_does_not_change_non_median_agg() -> None:
+def build_manifest_with_metrics(metrics: List[PydanticMetric]) -> PydanticSemanticManifest:
+    """Helper to construct a manifest with a single semantic model and a list of metrics."""
+    semantic_model = PydanticSemanticModel(
+        name="example_model",
+        node_relation=PydanticNodeRelation(alias="example_model", schema_name="example_schema"),
+        entities=[],
+        measures=[],
+    )
+    return PydanticSemanticManifest(
+        semantic_models=[semantic_model],
+        metrics=metrics,
+        project_configuration=EXAMPLE_PROJECT_CONFIGURATION,
+    )
+
+
+def test_metric_median_rule_does_not_change_non_median_agg() -> None:
+    """A metric with agg not MEDIAN remains unchanged."""
+    original_metric = PydanticMetric(
+        name="not_median_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.SUM,
+            ),
+            expr="revenue",
+        ),
+    )
+
+    manifest = build_manifest_with_metrics([original_metric.copy(deep=True)])
+
+    out = ConvertMedianMetricToPercentile.transform_model(manifest)
+    out_metric = next(m for m in out.metrics if m.name == "not_median_metric")
+    assert out_metric == original_metric
+
+
+def test_metric_median_rule_does_not_change_non_simple_type() -> None:
+    """If a metric is not SIMPLE, it remains unchanged."""
+    base_average_metric = PydanticMetric(
+        name="base_avg_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.AVERAGE,
+            ),
+            expr="price",
+        ),
+    )
+
+    original_derived_metric = PydanticMetric(
+        name="derived_metric",
+        type=MetricType.DERIVED,
+        type_params=PydanticMetricTypeParams(
+            metrics=[PydanticMetricInput(name="base_avg_metric")],
+        ),
+    )
+
+    manifest = build_manifest_with_metrics([base_average_metric, original_derived_metric.copy(deep=True)])
+
+    out = ConvertMedianMetricToPercentile.transform_model(manifest)
+    out_metric = next(m for m in out.metrics if m.name == "derived_metric")
+    assert out_metric == original_derived_metric
+
+
+def test_metric_median_rule_sets_percentile_params_when_missing_and_changes_agg() -> None:
+    """MEDIAN metric without params gets percentile 0.5 and agg becomes PERCENTILE."""
+    metric = PydanticMetric(
+        name="median_no_params_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.MEDIAN,
+            ),
+            expr="value",
+        ),
+    )
+
+    manifest = build_manifest_with_metrics([metric])
+
+    out = ConvertMedianMetricToPercentile.transform_model(manifest)
+    out_metric = next(m for m in out.metrics if m.name == "median_no_params_metric")
+    assert out_metric.type_params.metric_aggregation_params is not None
+    assert (
+        out_metric.type_params.metric_aggregation_params.agg == AggregationType.PERCENTILE
+    ), "Aggregation type should be changed to PERCENTILE for MEDIAN metric, but was not."
+    assert out_metric.type_params.metric_aggregation_params.agg_params is not None
+    assert (
+        out_metric.type_params.metric_aggregation_params.agg_params.percentile == 0.5
+    ), "Percentile should be set to 0.5 for MEDIAN metric, but was different."
+
+
+def test_metric_median_rule_raises_when_percentile_not_median() -> None:
+    """MEDIAN metric with percentile != 0.5 raises an error."""
+    metric = PydanticMetric(
+        name="median_bad_percentile_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.MEDIAN,
+                agg_params=PydanticMeasureAggregationParameters(percentile=0.9),
+            ),
+            expr="value",
+        ),
+    )
+
+    manifest = build_manifest_with_metrics([metric])
+
+    with pytest.raises(
+        ModelTransformError,
+        match="uses a MEDIAN aggregation, while percentile is set to '0.9', a conflicting value",
+    ):
+        ConvertMedianMetricToPercentile.transform_model(manifest)
+
+
+def test_metric_median_rule_raises_when_discrete_percentile_true() -> None:
+    """MEDIAN metric with use_discrete_percentile set raises an error."""
+    metric = PydanticMetric(
+        name="median_discrete_percentile_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.MEDIAN,
+                agg_params=PydanticMeasureAggregationParameters(use_discrete_percentile=True),
+            ),
+            expr="value",
+        ),
+    )
+
+    manifest = build_manifest_with_metrics([metric])
+
+    with pytest.raises(
+        ModelTransformError,
+        match="uses a MEDIAN aggregation, while use_discrete_percentile is set to true",
+    ):
+        ConvertMedianMetricToPercentile.transform_model(manifest)
+
+
+def test_metric_median_rule_preserves_existing_median_percentile_value() -> None:
+    """MEDIAN metric with percentile == 0.5 remains 0.5 after transform and agg becomes PERCENTILE."""
+    metric = PydanticMetric(
+        name="median_ok_percentile_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.MEDIAN,
+                agg_params=PydanticMeasureAggregationParameters(percentile=0.5),
+            ),
+            expr="value",
+        ),
+    )
+
+    manifest = build_manifest_with_metrics([metric])
+
+    out = ConvertMedianMetricToPercentile.transform_model(manifest)
+    out_metric = next(m for m in out.metrics if m.name == "median_ok_percentile_metric")
+    assert out_metric.type_params.metric_aggregation_params is not None
+    assert (
+        out_metric.type_params.metric_aggregation_params.agg == AggregationType.PERCENTILE
+    ), "Aggregation type should be changed to PERCENTILE for MEDIAN metric, but was not."
+    assert out_metric.type_params.metric_aggregation_params.agg_params is not None
+    assert (
+        out_metric.type_params.metric_aggregation_params.agg_params.percentile == 0.5
+    ), "Percentile should remain 0.5 for MEDIAN metric, but was changed."
+
+
+def test_metric_median_rule_iterates_across_multiple_metrics() -> None:
+    """Two MEDIAN metrics are converted; two non-MEDIAN metrics remain unchanged."""
+    # MEDIAN metrics
+    metric_median_no_params = PydanticMetric(
+        name="median_value_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.MEDIAN,
+            ),
+            expr="value",
+        ),
+    )
+    metric_median_with_params = PydanticMetric(
+        name="median_latency_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.MEDIAN,
+                agg_params=PydanticMeasureAggregationParameters(percentile=0.5),
+            ),
+            expr="latency",
+        ),
+    )
+
+    # Non-MEDIAN metrics
+    original_non_median_sum_metric = PydanticMetric(
+        name="total_revenue_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.SUM,
+            ),
+            expr="revenue",
+        ),
+    )
+    original_non_median_average_metric = PydanticMetric(
+        name="average_price_metric",
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            metric_aggregation_params=PydanticMetricAggregationParams(
+                semantic_model="example_model",
+                agg=AggregationType.AVERAGE,
+            ),
+            expr="price",
+        ),
+    )
+
+    manifest = build_manifest_with_metrics(
+        [
+            metric_median_no_params,
+            metric_median_with_params,
+            original_non_median_sum_metric.copy(deep=True),
+            original_non_median_average_metric.copy(deep=True),
+        ]
+    )
+
+    out = ConvertMedianMetricToPercentile.transform_model(manifest)
+
+    # MEDIAN metrics changed to PERCENTILE with percentile 0.5
+    out_median_no_params = next(m for m in out.metrics if m.name == "median_value_metric")
+    assert out_median_no_params.type_params.metric_aggregation_params is not None
+    assert (
+        out_median_no_params.type_params.metric_aggregation_params.agg == AggregationType.PERCENTILE
+    ), "Aggregation type should be changed to PERCENTILE for MEDIAN metric, but was not."
+    assert out_median_no_params.type_params.metric_aggregation_params.agg_params is not None
+    assert (
+        out_median_no_params.type_params.metric_aggregation_params.agg_params.percentile == 0.5
+    ), "Percentile should be set to 0.5 for MEDIAN metric, but was different."
+
+    out_median_with_params = next(m for m in out.metrics if m.name == "median_latency_metric")
+    assert out_median_with_params.type_params.metric_aggregation_params is not None
+    assert (
+        out_median_with_params.type_params.metric_aggregation_params.agg == AggregationType.PERCENTILE
+    ), "Aggregation type should be changed to PERCENTILE for MEDIAN metric, but was not."
+    assert out_median_with_params.type_params.metric_aggregation_params.agg_params is not None
+    assert (
+        out_median_with_params.type_params.metric_aggregation_params.agg_params.percentile == 0.5
+    ), "Percentile should remain 0.5 for MEDIAN metric, but was changed."
+
+    # Non-MEDIAN metrics unchanged
+    out_sum_metric = next(m for m in out.metrics if m.name == "total_revenue_metric")
+    assert out_sum_metric == original_non_median_sum_metric
+
+    out_average_metric = next(m for m in out.metrics if m.name == "average_price_metric")
+    assert out_average_metric == original_non_median_average_metric
+
+
+def test_legacy_measure_median_rule_does_not_change_non_median_agg() -> None:
     """A measure with agg not MEDIAN remains unchanged."""
     original = PydanticMeasure(name="not_median", agg=AggregationType.SUM, expr="revenue")
     manifest = build_manifest_with_single_measure(original.copy(deep=True))
@@ -43,8 +314,8 @@ def test_median_rule_does_not_change_non_median_agg() -> None:
     assert out_measure == original
 
 
-def test_median_rule_sets_percentile_params_when_missing_and_changes_agg() -> None:
-    """MEDIAN without agg_params gets params with percentile 0.5 and agg becomes PERCENTILE."""
+def test_legacy_measure_median_rule_sets_percentile_params_when_missing_and_changes_agg() -> None:
+    """MEDIAN measure without agg_params gets params with percentile 0.5 and agg becomes PERCENTILE."""
     measure = PydanticMeasure(name="median_no_params", agg=AggregationType.MEDIAN, expr="value")
     manifest = build_manifest_with_single_measure(measure)
 
@@ -55,8 +326,8 @@ def test_median_rule_sets_percentile_params_when_missing_and_changes_agg() -> No
     assert out_measure.agg_params.percentile == 0.5
 
 
-def test_median_rule_raises_when_percentile_not_median() -> None:
-    """MEDIAN with agg_params.percentile != 0.5 raises an error."""
+def test_legacy_measure_median_rule_raises_when_percentile_not_median() -> None:
+    """MEDIAN measure with agg_params.percentile != 0.5 raises an error."""
     measure = PydanticMeasure(
         name="median_bad_percentile",
         agg=AggregationType.MEDIAN,
@@ -72,8 +343,8 @@ def test_median_rule_raises_when_percentile_not_median() -> None:
         ConvertMedianToPercentileRule.transform_model(manifest)
 
 
-def test_median_rule_raises_when_discrete_percentile_true() -> None:
-    """MEDIAN with agg_params.use_discrete_percentile set raises an error."""
+def test_legacy_measure_median_rule_raises_when_discrete_percentile_true() -> None:
+    """MEDIAN measure with agg_params.use_discrete_percentile set raises an error."""
     measure = PydanticMeasure(
         name="median_discrete_percentile",
         agg=AggregationType.MEDIAN,
@@ -89,8 +360,8 @@ def test_median_rule_raises_when_discrete_percentile_true() -> None:
         ConvertMedianToPercentileRule.transform_model(manifest)
 
 
-def test_median_rule_preserves_existing_median_percentile_value() -> None:
-    """MEDIAN with agg_params.percentile == 0.5 remains 0.5 after transform and agg becomes PERCENTILE."""
+def test_legacy_measure_median_rule_preserves_existing_median_percentile_value() -> None:
+    """MEDIAN measure with agg_params.percentile == 0.5 remains 0.5 after transform and agg becomes PERCENTILE."""
     measure = PydanticMeasure(
         name="median_ok_percentile",
         agg=AggregationType.MEDIAN,
@@ -106,7 +377,7 @@ def test_median_rule_preserves_existing_median_percentile_value() -> None:
     assert out_measure.agg_params.percentile == 0.5
 
 
-def test_median_rule_iterates_across_multiple_measures() -> None:
+def test_legacy_measure_median_rule_iterates_across_multiple_measures() -> None:
     """Test that we can apply (and not apply) this to multiple measures in a single model.
 
     The expectation is that we have two MEDIAN measures that are converted and two


### PR DESCRIPTION
Towards #387

### Description

Depends on #432 

We already convert measures with agg value MEDIAN to be percentile measures.  Since we're replacing measures with simple metrics, this PR does the same for simple metrics.

Notes:
* Learning from several previous PRs, including especially #431 , we use some inheritance to keep all the good, non-legacy code in the transformation class for metrics while still allowing a lot of reuse for the measures-related class.
* I also did a little renaming and re-documenting to the test cases I added to show make it clear what was legacy and for measures and what was not.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
