### PR TITLE
Fix other transformations instead of using FixSimpleMetricRule at end.

### DIFF
--- a/.changes/unreleased/Fixes-20251007-165017.yaml
+++ b/.changes/unreleased/Fixes-20251007-165017.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Correctly construct filters and expr values for metrics created by transformations.
+time: 2025-10-07T16:50:17.610347-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
+++ b/dbt_semantic_interfaces/transformations/add_input_metric_measures.py
@@ -58,8 +58,11 @@ class AddInputMetricMeasuresRule(ProtocolHint[SemanticManifestTransformRule[Pyda
     @staticmethod
     def transform_model(semantic_manifest: PydanticSemanticManifest) -> PydanticSemanticManifest:  # noqa: D
         for metric in semantic_manifest.metrics:
+            if len(metric.type_params.input_measures) > 0:
+                # These aren't missing and have already been added by an enterprising parser or earlier
+                # transformation rule.
+                continue
             measures = AddInputMetricMeasuresRule._get_measures_for_metric(semantic_manifest, metric.name)
-            assert len(metric.type_params.input_measures) == 0, f"{metric} should not have measures predefined"
             metric.type_params.input_measures = list(measures)
 
         return semantic_manifest

--- a/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
+++ b/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
@@ -135,9 +135,9 @@ class MeasureFeaturesToMetricNameMapper:
         if metric.type_params.expr is None:
             metric.type_params.expr = measure.expr or measure.name
 
-        filters = metric.filter.where_filters if metric.filter else []
-        if measure_input_filters is not None:
-            filters.extend(measure_input_filters.where_filters)
+        filters = measure_input_filters.where_filters if measure_input_filters else []
+        if metric.filter is not None:
+            filters.extend(metric.filter.where_filters)
         if len(filters) > 0:
             metric.filter = PydanticWhereFilterIntersection(where_filters=filters)
 

--- a/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
+++ b/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
@@ -115,7 +115,7 @@ class MeasureFeaturesToMetricNameMapper:
 
         This will update the metric in place rather than returning a new one.
         """
-        assert metric.type == MetricType.SIMPLE, "Attempted to set measure features on a non-simple metric"
+        assert metric.type is MetricType.SIMPLE, f"Attempted to set measure features on a non-simple metric: {metric}"
         if metric.type_params.metric_aggregation_params is not None:
             # these values have already been set.
             return

--- a/dbt_semantic_interfaces/transformations/proxy_measure.py
+++ b/dbt_semantic_interfaces/transformations/proxy_measure.py
@@ -59,6 +59,7 @@ class CreateProxyMeasureRule(ProtocolHint[SemanticManifestTransformRule[Pydantic
                         join_to_timespine=False,
                         # we override the default here; this metric was explicitly created by the user.
                         is_private=False,
+                        measure_input_filters=None,
                     )
                     metric.name = measure.name
                     metric.type_params.measure = PydanticMetricInputMeasure(name=measure.name)

--- a/tests/transformations/test_flatten_simple_metrics_with_measure_inputs_rule.py
+++ b/tests/transformations/test_flatten_simple_metrics_with_measure_inputs_rule.py
@@ -1,3 +1,7 @@
+from typing import List, Optional
+
+import pytest
+
 from dbt_semantic_interfaces.implementations.elements.dimension import (
     PydanticDimension,
     PydanticDimensionTypeParams,
@@ -6,6 +10,10 @@ from dbt_semantic_interfaces.implementations.elements.entity import PydanticEnti
 from dbt_semantic_interfaces.implementations.elements.measure import (
     PydanticMeasure,
     PydanticMeasureAggregationParameters,
+)
+from dbt_semantic_interfaces.implementations.filters.where_filter import (
+    PydanticWhereFilter,
+    PydanticWhereFilterIntersection,
 )
 from dbt_semantic_interfaces.implementations.metric import (
     PydanticMetric,
@@ -39,6 +47,31 @@ from dbt_semantic_interfaces.type_enums import (
 def _project_config() -> PydanticProjectConfiguration:
     # Minimal project configuration for constructing a manifest directly in tests
     return PydanticProjectConfiguration()
+
+
+DEFAULT_MEASURE_NAME = "orders"
+
+
+def _make_semantic_model_with_measure(
+    *,
+    name: str,
+    time_dimension: str,
+    measures: List[PydanticMeasure],
+) -> PydanticSemanticModel:
+    """Helper to build a semantic model with a single time dimension and provided measures."""
+    return PydanticSemanticModel(
+        name=name,
+        node_relation=PydanticNodeRelation(alias=name, schema_name="schema"),
+        entities=[PydanticEntity(name="e", type=EntityType.PRIMARY)],
+        dimensions=[
+            PydanticDimension(
+                name=time_dimension,
+                type=DimensionType.TIME,
+                type_params=PydanticDimensionTypeParams(time_granularity=TimeGranularity.DAY),
+            )
+        ],
+        measures=measures,
+    )
 
 
 def test_metric_with_measure_and_metric_agg_params_is_unchanged() -> None:
@@ -119,6 +152,77 @@ def test_metric_with_measure_and_metric_agg_params_is_unchanged() -> None:
 def test_metric_with_measure_only_gets_populated_and_referenced_metric_uses_values() -> None:
     """Populates fields for simple metric with only measure; referencing metric remains intact across models."""
     # Two semantic models, the measure lives in sm2
+    sm1 = _make_semantic_model_with_measure(name="sm1", time_dimension="ds", measures=[])
+
+    sm2 = _make_semantic_model_with_measure(
+        name="sm2",
+        time_dimension="event_time",
+        measures=[
+            PydanticMeasure(
+                name=DEFAULT_MEASURE_NAME,
+                agg=AggregationType.PERCENTILE,
+                agg_time_dimension="event_time",
+                expr="amount",
+                agg_params=PydanticMeasureAggregationParameters(percentile=50.0, use_discrete_percentile=True),
+            )
+        ],
+    )
+
+    # Metric that should get populated by the rule (has a measure, no metric_aggregation_params)
+    metric_to_flatten = PydanticMetric(
+        name=DEFAULT_MEASURE_NAME,
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            measure=PydanticMetricInputMeasure(
+                name=DEFAULT_MEASURE_NAME,
+                join_to_timespine=True,
+                fill_nulls_with=7,
+            ),
+        ),
+    )
+
+    manifest = PydanticSemanticManifest(
+        semantic_models=[sm1, sm2],
+        metrics=[metric_to_flatten],
+        project_configuration=_project_config(),
+    )
+
+    transformed = FlattenSimpleMetricsWithMeasureInputsRule.transform_model(manifest)
+
+    # Ensure both metrics are present
+    assert len(transformed.metrics) == 1
+
+    # Find updated simple metric
+    updated_simple = next(m for m in transformed.metrics if m.name == "orders")
+    assert updated_simple.type == MetricType.SIMPLE
+    # The rule should populate aggregation params from the measure in sm2
+    assert updated_simple.type_params.metric_aggregation_params is not None
+    agg_params = updated_simple.type_params.metric_aggregation_params
+    assert agg_params.semantic_model == "sm2"
+    assert agg_params.agg == AggregationType.PERCENTILE
+    assert agg_params.agg_time_dimension == "event_time"
+    assert updated_simple.type_params.expr == "amount"
+    # join_to_timespine should be set to True and fill_nulls_with to 7 by
+    # pulling from the measure
+    assert updated_simple.type_params.join_to_timespine is True
+    assert updated_simple.type_params.fill_nulls_with == 7
+
+
+@pytest.mark.parametrize(
+    "join_to_timespine,fill_nulls_with",
+    [
+        (True, None),  # join_to_timespine only
+        (False, 12),  # fill_nulls_with only
+        (True, 45),  # both set
+        (False, None),  # neither set
+    ],
+)
+def test_measure_input_non_filter_fields_applied_with_measure_filter(
+    join_to_timespine: bool,
+    fill_nulls_with: Optional[int],
+) -> None:
+    """Verifies join_to_timespine and fill_nulls_with are copied from measure input; measure filter merges."""
+    # Build semantic models; measure lives in sm2
     sm1 = PydanticSemanticModel(
         name="sm1",
         node_relation=PydanticNodeRelation(alias="sm1", schema_name="schema"),
@@ -155,43 +259,164 @@ def test_metric_with_measure_only_gets_populated_and_referenced_metric_uses_valu
         ],
     )
 
-    # Metric that should get populated by the rule (has a measure, no metric_aggregation_params)
+    # Measure input has a filter, metric has none
+    measure_filter = PydanticWhereFilterIntersection(
+        where_filters=[PydanticWhereFilter(where_sql_template="ds >= '2020-01-01'")]
+    )
+
     metric_to_flatten = PydanticMetric(
         name="orders",
         description="needs flatten",
         type=MetricType.SIMPLE,
         type_params=PydanticMetricTypeParams(
-            # intentionally no metric_aggregation_params here
-            measure=PydanticMetricInputMeasure(name="orders", fill_nulls_with=7, join_to_timespine=True),
-            # These fields should have triggered a validation error, but here just
-            # to guarantee behavior
-            fill_nulls_with=1,
-            join_to_timespine=False,
+            measure=PydanticMetricInputMeasure(
+                name="orders",
+                fill_nulls_with=fill_nulls_with,
+                join_to_timespine=join_to_timespine,
+                filter=measure_filter,
+            ),
         ),
+        # no metric-level filter
     )
 
     manifest = PydanticSemanticManifest(
-        semantic_models=[sm1, sm2],
-        metrics=[metric_to_flatten],
-        project_configuration=_project_config(),
+        semantic_models=[sm1, sm2], metrics=[metric_to_flatten], project_configuration=_project_config()
     )
 
     transformed = FlattenSimpleMetricsWithMeasureInputsRule.transform_model(manifest)
 
-    # Ensure both metrics are present
-    assert len(transformed.metrics) == 1
+    assert len(transformed.metrics) == 1, "Expected exactly one metric after transformation"
+    updated_simple = transformed.metrics[0]
 
-    # Find updated simple metric
-    updated_simple = next(m for m in transformed.metrics if m.name == "orders")
-    assert updated_simple.type == MetricType.SIMPLE
-    # The rule should populate aggregation params from the measure in sm2
+    # Aggregation params and expr are copied from the measure
     assert updated_simple.type_params.metric_aggregation_params is not None
-    agg_params = updated_simple.type_params.metric_aggregation_params
-    assert agg_params.semantic_model == "sm2"
-    assert agg_params.agg == AggregationType.PERCENTILE
-    assert agg_params.agg_time_dimension == "event_time"
+    assert updated_simple.type_params.metric_aggregation_params.semantic_model == "sm2"
+    assert updated_simple.type_params.metric_aggregation_params.agg_time_dimension == "event_time"
     assert updated_simple.type_params.expr == "amount"
-    # join_to_timespine should be set to True and fill_nulls_with to 7 by
-    # pulling from the measure
-    assert updated_simple.type_params.join_to_timespine is True
-    assert updated_simple.type_params.fill_nulls_with == 7
+
+    # Non-filter measure input fields applied appropriately
+    if fill_nulls_with is not None:
+        assert updated_simple.type_params.fill_nulls_with == fill_nulls_with
+    else:
+        assert updated_simple.type_params.fill_nulls_with is None
+
+    if join_to_timespine:
+        assert updated_simple.type_params.join_to_timespine is True
+    else:
+        assert updated_simple.type_params.join_to_timespine is False
+
+    # Measure filter should be surfaced on the metric
+    assert updated_simple.filter is not None
+    assert sorted([wf.where_sql_template for wf in updated_simple.filter.where_filters]) == sorted(
+        ["ds >= '2020-01-01'"]
+    )
+
+
+@pytest.mark.parametrize(
+    "has_measure_filter,has_metric_filter",
+    [
+        (True, False),  # only measure filter
+        (False, True),  # only metric filter
+        (True, True),  # both
+        (False, False),  # neither
+    ],
+)
+def test_filter_merging_between_metric_and_measure_input(has_measure_filter: bool, has_metric_filter: bool) -> None:
+    """Verifies filters from measure input and metric are merged as expected."""
+    sm = _make_semantic_model_with_measure(
+        name="sm",
+        time_dimension="ds",
+        measures=[
+            PydanticMeasure(
+                name=DEFAULT_MEASURE_NAME,
+                agg=AggregationType.SUM,
+                agg_time_dimension="ds",
+            )
+        ],
+    )
+
+    measure_filter = (
+        PydanticWhereFilterIntersection(where_filters=[PydanticWhereFilter(where_sql_template="amount > 0")])
+        if has_measure_filter
+        else None
+    )
+    metric_filter = (
+        PydanticWhereFilterIntersection(where_filters=[PydanticWhereFilter(where_sql_template="e = 'x'")])
+        if has_metric_filter
+        else None
+    )
+
+    metric = PydanticMetric(
+        name=DEFAULT_MEASURE_NAME,
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            measure=PydanticMetricInputMeasure(
+                name=DEFAULT_MEASURE_NAME,
+                filter=measure_filter,
+            ),
+        ),
+        filter=metric_filter,
+    )
+
+    manifest = PydanticSemanticManifest(semantic_models=[sm], metrics=[metric], project_configuration=_project_config())
+
+    transformed = FlattenSimpleMetricsWithMeasureInputsRule.transform_model(manifest)
+    assert len(transformed.metrics) == 1, "Expected exactly one metric after transformation"
+    out = transformed.metrics[0]
+
+    if has_measure_filter or has_metric_filter:
+        assert out.filter is not None
+        expected_order = []
+        if has_metric_filter:
+            expected_order.append("e = 'x'")
+        if has_measure_filter:
+            expected_order.append("amount > 0")
+        assert sorted([wf.where_sql_template for wf in out.filter.where_filters]) == sorted(expected_order)
+    else:
+        assert out.filter is None
+
+
+@pytest.mark.parametrize(
+    "measure_expr,expected_expr",
+    [
+        ("amount", "amount"),  # measure has expr
+        (None, "orders"),  # measure has no expr, falls back to name
+    ],
+)
+def test_expr_population_from_measure_or_name(measure_expr: Optional[str], expected_expr: str) -> None:
+    """Verifies expr is taken from measure.expr if available; otherwise from measure.name."""
+    sm = _make_semantic_model_with_measure(
+        name="sm",
+        time_dimension="ds",
+        measures=[
+            PydanticMeasure(
+                name=DEFAULT_MEASURE_NAME,
+                agg=AggregationType.SUM,
+                agg_time_dimension="ds",
+                expr=measure_expr,
+            )
+        ],
+    )
+
+    measure_filter = PydanticWhereFilterIntersection(
+        where_filters=[PydanticWhereFilter(where_sql_template="ds >= '2020-01-01'")]
+    )
+
+    metric = PydanticMetric(
+        name=DEFAULT_MEASURE_NAME,
+        type=MetricType.SIMPLE,
+        type_params=PydanticMetricTypeParams(
+            measure=PydanticMetricInputMeasure(
+                name=DEFAULT_MEASURE_NAME,
+                filter=measure_filter,
+            ),
+        ),
+    )
+
+    manifest = PydanticSemanticManifest(semantic_models=[sm], metrics=[metric], project_configuration=_project_config())
+
+    transformed = FlattenSimpleMetricsWithMeasureInputsRule.transform_model(manifest)
+    assert len(transformed.metrics) == 1, "Expected exactly one metric after transformation"
+    out = transformed.metrics[0]
+
+    assert out.type_params.expr == expected_expr


### PR DESCRIPTION
Towards #387

### Description

Paul ran into a bunch of edge cases in metricflow where the expr and filter values were not quite what he expected for the metrics that transformations added to DSI should have created.

He put up a quick patch [here](https://github.com/dbt-labs/metricflow/pull/1882) for metricflow that corrected the issues after running all, but after looking at [copying that patch directly](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/439) up to dsi, we decided that properly fixing the behaviors in each transformation was worth the extra time.

This PR makes those fixes to each transformation and makes sure things still work.  I have not yet but will soon also patch this to MF and test there to see that no tests are broken.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
