### PR TITLE
Fix created metric naming convention for negative fill_with_nulls values

### DIFF
--- a/.changes/unreleased/Fixes-20251007-212326.yaml
+++ b/.changes/unreleased/Fixes-20251007-212326.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fixes naming of created metrics with negative fill_nulls_with value to be legal.
+time: 2025-10-07T21:23:26.419795-07:00
+custom:
+    Author: theyostalservice
+    Issue: "387"

--- a/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
+++ b/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
@@ -203,7 +203,7 @@ class MeasureFeaturesToMetricNameMapper:
         """Generate a new metric name for the measure configuration."""
         name_parts = [measure_name]
         if fill_nulls_with is not None:
-            fill_nulls_name_part = str(fill_nulls_with) if fill_nulls_with >= 0 else f"neg{abs(fill_nulls_with)}"
+            fill_nulls_name_part = str(fill_nulls_with) if fill_nulls_with >= 0 else f"neg_{abs(fill_nulls_with)}"
             name_parts.append(f"fill_nulls_with_{fill_nulls_name_part}")
         if join_to_timespine:
             name_parts.append("join_to_timespine")

--- a/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
+++ b/dbt_semantic_interfaces/transformations/measure_to_metric_transformation_pieces/measure_features_to_metric_name.py
@@ -203,7 +203,8 @@ class MeasureFeaturesToMetricNameMapper:
         """Generate a new metric name for the measure configuration."""
         name_parts = [measure_name]
         if fill_nulls_with is not None:
-            name_parts.append(f"fill_nulls_with_{fill_nulls_with}")
+            fill_nulls_name_part = str(fill_nulls_with) if fill_nulls_with >= 0 else f"neg{abs(fill_nulls_with)}"
+            name_parts.append(f"fill_nulls_with_{fill_nulls_name_part}")
         if join_to_timespine:
             name_parts.append("join_to_timespine")
 

--- a/tests/transformations/test_replace_input_measures_with_simple_metrics_transformation_rule.py
+++ b/tests/transformations/test_replace_input_measures_with_simple_metrics_transformation_rule.py
@@ -355,7 +355,7 @@ def test_repeated_cumulative_measure_inputs_do_not_create_dulplicates_metrics() 
     [
         (True, None, "m1_join_to_timespine"),
         (False, 12, "m1_fill_nulls_with_12"),
-        (True, -10, "m1_fill_nulls_with_neg10_join_to_timespine"),
+        (True, -10, "m1_fill_nulls_with_neg_10_join_to_timespine"),
         (False, None, "m1"),
     ],
 )

--- a/tests/transformations/test_replace_input_measures_with_simple_metrics_transformation_rule.py
+++ b/tests/transformations/test_replace_input_measures_with_simple_metrics_transformation_rule.py
@@ -355,7 +355,7 @@ def test_repeated_cumulative_measure_inputs_do_not_create_dulplicates_metrics() 
     [
         (True, None, "m1_join_to_timespine"),
         (False, 12, "m1_fill_nulls_with_12"),
-        (True, 45, "m1_fill_nulls_with_45_join_to_timespine"),
+        (True, -10, "m1_fill_nulls_with_neg10_join_to_timespine"),
         (False, None, "m1"),
     ],
 )


### PR DESCRIPTION
Towards #387

### Description

@plypaul [caught a potential bug](https://github.com/dbt-labs/dbt-semantic-interfaces/pull/440#issuecomment-3379491047) - if we create a metric in a situation where fill_with_nulls has a negative value, the resulting name will have a dash, which isn't a legal name by our standards.  This addresses that.

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
