### PR TITLE
Fix FixProxyMetricsRule transformation to properly log the warning

### DIFF
--- a/dbt_semantic_interfaces/transformations/fix_proxy_metrics.py
+++ b/dbt_semantic_interfaces/transformations/fix_proxy_metrics.py
@@ -48,13 +48,21 @@ class FixProxyMetricsRule(ProtocolHint[SemanticManifestTransformRule[PydanticSem
                 # Likely the new spec where measures are removed
                 continue
 
-            if metric.type_params.expr is not None:
-                logger.warning("Metric should not have an expr set if it's proxy from measures")
             # Override the expr to the measure expr or name if it is not set.
             referenced_measure = all_measures.get(metric.type_params.measure.name)
 
             if referenced_measure is None:
                 logger.warning(f"Measure {metric.type_params.measure.name} not found")
                 continue
+
+            if metric.type_params.expr is not None and metric.type_params.expr not in [
+                referenced_measure.expr,
+                referenced_measure.name,
+            ]:
+                logger.warning(
+                    f"Metric {metric.name} should not have an expr set if it's proxy from measures, "
+                    "overriding with measure"
+                )
+
             metric.type_params.expr = referenced_measure.expr or referenced_measure.name
         return semantic_manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbt-semantic-interfaces"
-version = "0.10.3"
+version = "0.10.4"
 description = 'The shared semantic layer definitions that dbt-core and MetricFlow use'
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
Currently, we are throwing this log whenever the `metric.type_params.expr` is populated cause we assume that if it is populated it is potentially incorrect. This is true, however, we actually ran the `CreateProxyMeasureRule` prior to this, so all the proxy metrics would already have the expr populated in this case. It's a matter of whether it was populated correctly, so instead we would check that it should be matching the measure's designated expr.
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
