### PR TITLE
Avoid errors during validation when missing time dimensions

### DIFF
--- a/.changes/unreleased/Fixes-20260210-163340.yaml
+++ b/.changes/unreleased/Fixes-20260210-163340.yaml
@@ -1,0 +1,6 @@
+kind: Fixes
+body: Fix bad error message when validating time spines with no time dimensions.
+time: 2026-02-10T16:33:40.469369-08:00
+custom:
+    Author: theyostalservice
+    Issue: "467"

--- a/dbt_semantic_interfaces/validations/time_spines.py
+++ b/dbt_semantic_interfaces/validations/time_spines.py
@@ -64,6 +64,14 @@ class TimeSpineRule(SemanticManifestValidationRule[SemanticManifestT], Generic[S
             for dimension in semantic_model.dimensions
             if dimension.type_params
         }
+        if len(dimension_granularities) == 0:
+            issues.append(
+                ValidationWarning(
+                    message="No time dimensions configured. To avoid unexpected query errors, configuring a "
+                    "time spine at or below the smallest time dimension granularity is recommended."
+                )
+            )
+            return issues
         smallest_dim_granularity = min(dimension_granularities)
         smallest_time_spine_granularity = min(time_spines_by_granularity.keys())
         if smallest_dim_granularity < smallest_time_spine_granularity:

--- a/tests/validations/test_time_spines.py
+++ b/tests/validations/test_time_spines.py
@@ -35,6 +35,7 @@ from dbt_semantic_interfaces.type_enums import (
 from dbt_semantic_interfaces.validations.semantic_manifest_validator import (
     SemanticManifestValidator,
 )
+from dbt_semantic_interfaces.validations.time_spines import TimeSpineRule
 
 
 def test_valid_time_spines() -> None:  # noqa: D
@@ -335,3 +336,32 @@ def test_time_spines_with_invalid_names() -> None:  # noqa: D
         ),
     ]:
         assert msg in error_messages
+
+
+def test_warning_when_no_time_dimensions_configured() -> None:  # noqa: D
+    validator = SemanticManifestValidator[PydanticSemanticManifest]([TimeSpineRule()])
+    semantic_manifest = PydanticSemanticManifest(
+        semantic_models=[
+            semantic_model_with_guaranteed_meta(
+                name="sm",
+                dimensions=[],
+                measures=[],
+                entities=[PydanticEntity(name="entity", type=EntityType.PRIMARY)],
+            ),
+        ],
+        metrics=[],
+        project_configuration=PydanticProjectConfiguration(
+            time_spine_table_configurations=[],
+            time_spines=[
+                PydanticTimeSpine(
+                    node_relation=PydanticNodeRelation(alias="time_spine", schema_name="schema"),
+                    primary_column=PydanticTimeSpinePrimaryColumn(name="ds", time_granularity=TimeGranularity.DAY),
+                    custom_granularities=[],
+                ),
+            ],
+        ),
+    )
+    issues = validator.validate_semantic_manifest(semantic_manifest)
+    assert not issues.has_blocking_issues
+    assert len(issues.warnings) == 1
+    assert issues.warnings[0].message.startswith("No time dimensions configured. To avoid unexpected query errors,")


### PR DESCRIPTION
Resolves [JIRA](https://dbtlabs.atlassian.net/jira/software/c/projects/DI/boards/1602?selectedIssue=DI-3283)

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description

We had some users on Fusion run into strange problems because Fusion didn't enforce some of the same validations enforced in dbt-core.  See inline PR comments as pointers to the expected behaviors for our parsers (dbt-core or fusion, for instance).

The error we saw seems to be inflicted by the call to min() when we have no granularities.  The error is as follows:
```
error: dbt1005: An error occurred while running model validation to ensure that time spines are valid - ValueError: min() iterable argument is empty
```

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)