### PR TITLE
Add compiled_sql to NodeRelation for ephemeral model support

### DIFF
--- a/.changes/unreleased/Features-20260326-000000.yaml
+++ b/.changes/unreleased/Features-20260326-000000.yaml
@@ -1,0 +1,5 @@
+kind: Features
+body: Add compiled_sql to NodeRelation protocol and PydanticNodeRelation to support ephemeral models in Semantic Layer definitions.
+time: 2026-03-26T00:00:00.000000-07:00
+custom:
+  Author: b-per

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 # IDE
 .idea/
 .vscode/
+
+# Git worktrees
+.worktrees/

--- a/dbt_semantic_interfaces/implementations/node_relation.py
+++ b/dbt_semantic_interfaces/implementations/node_relation.py
@@ -17,6 +17,7 @@ class PydanticNodeRelation(HashableBaseModel, ProtocolHint[NodeRelation]):
     schema_name: str
     database: Optional[str] = None
     relation_name: str = ""
+    compiled_sql: Optional[str] = None
 
     @override
     def _implements_protocol(self) -> NodeRelation:  # noqa: D

--- a/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
+++ b/dbt_semantic_interfaces/parsing/generated_json_schemas/default_explicit_schema.json
@@ -665,6 +665,9 @@
                 "alias": {
                     "type": "string"
                 },
+                "compiled_sql": {
+                    "type": "string"
+                },
                 "database": {
                     "type": "string"
                 },

--- a/dbt_semantic_interfaces/parsing/schemas.py
+++ b/dbt_semantic_interfaces/parsing/schemas.py
@@ -379,6 +379,7 @@ node_relation_schema = {
         "schema_name": {"type": "string"},
         "database": {"type": "string"},
         "relation_name": {"type": "string"},
+        "compiled_sql": {"type": "string"},
     },
     "additionalProperties": False,
     "required": ["alias", "schema_name"],

--- a/dbt_semantic_interfaces/protocols/node_relation.py
+++ b/dbt_semantic_interfaces/protocols/node_relation.py
@@ -26,3 +26,9 @@ class NodeRelation(Protocol):
     @abstractmethod
     def relation_name(self) -> str:  # noqa: D
         pass
+
+    @property
+    @abstractmethod
+    def compiled_sql(self) -> Optional[str]:
+        """The compiled SQL for ephemeral models. When set, this is used as the source instead of relation_name."""
+        pass

--- a/tests/implementations/test_node_relation.py
+++ b/tests/implementations/test_node_relation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dbt_semantic_interfaces.implementations.node_relation import PydanticNodeRelation
+
+
+def test_node_relation_compiled_sql_defaults_to_none() -> None:
+    """compiled_sql is None by default for non-ephemeral models."""
+    node_relation = PydanticNodeRelation(schema_name="my_schema", alias="my_table")
+    assert node_relation.compiled_sql is None
+
+
+def test_node_relation_with_compiled_sql() -> None:
+    """compiled_sql is preserved when set (ephemeral model)."""
+    compiled_sql = "SELECT id, name FROM raw.source_table WHERE active = true"
+    node_relation = PydanticNodeRelation(
+        schema_name="my_schema",
+        alias="my_table",
+        compiled_sql=compiled_sql,
+    )
+    assert node_relation.compiled_sql == compiled_sql
+    assert node_relation.relation_name == "my_schema.my_table"
+
+
+def test_node_relation_from_string_has_no_compiled_sql() -> None:
+    """from_string produces a node relation without compiled_sql."""
+    node_relation = PydanticNodeRelation.from_string("my_schema.my_table")
+    assert node_relation.compiled_sql is None
+
+
+def test_node_relation_with_database_and_compiled_sql() -> None:
+    """compiled_sql works alongside a fully qualified relation (database.schema.table)."""
+    compiled_sql = "SELECT 1 AS id"
+    node_relation = PydanticNodeRelation(
+        database="my_db",
+        schema_name="my_schema",
+        alias="my_table",
+        compiled_sql=compiled_sql,
+    )
+    assert node_relation.compiled_sql == compiled_sql
+    assert node_relation.relation_name == "my_db.my_schema.my_table"

--- a/tests/parsing/test_semantic_model_parsing.py
+++ b/tests/parsing/test_semantic_model_parsing.py
@@ -92,6 +92,29 @@ def test_semantic_model_node_relation_parsing() -> None:
     assert len(build_result.semantic_manifest.semantic_models) == 1
     semantic_model = build_result.semantic_manifest.semantic_models[0]
     assert semantic_model.node_relation.relation_name == "some_schema.source_table"
+    assert semantic_model.node_relation.compiled_sql is None
+
+
+def test_semantic_model_node_relation_with_compiled_sql() -> None:
+    """Test parsing a semantic model with compiled_sql set on node_relation (ephemeral model)."""
+    yaml_contents = textwrap.dedent(
+        """\
+        semantic_model:
+          name: ephemeral_test
+          node_relation:
+            alias: source_table
+            schema_name: some_schema
+            compiled_sql: "SELECT id, name FROM raw.source_table WHERE active = true"
+        """
+    )
+    file = YamlConfigFile(filepath="inline_for_test", contents=yaml_contents)
+
+    build_result = parse_yaml_files_to_semantic_manifest(files=[file, EXAMPLE_PROJECT_CONFIGURATION_YAML_CONFIG_FILE])
+
+    assert len(build_result.semantic_manifest.semantic_models) == 1
+    semantic_model = build_result.semantic_manifest.semantic_models[0]
+    assert semantic_model.node_relation.compiled_sql == "SELECT id, name FROM raw.source_table WHERE active = true"
+    assert semantic_model.node_relation.relation_name == "some_schema.source_table"
 
 
 def test_base_semantic_model_entity_parsing() -> None:


### PR DESCRIPTION
## Summary

- Adds optional `compiled_sql` field to the `NodeRelation` protocol and `PydanticNodeRelation` implementation
- Updates JSON schema and `schemas.py` to allow `compiled_sql` in YAML parsing
- When set, `compiled_sql` carries the compiled SQL for ephemeral dbt models instead of relying on `relation_name`

This is the upstream companion to dbt-labs/metricflow#1993, which already consumes this field via `getattr` as a workaround until this PR lands. Once merged and published, the `getattr` workaround in metricflow can be replaced with a direct attribute access.

## Test plan

- [x] `tests/implementations/test_node_relation.py` — new unit tests for `compiled_sql` default, setting, and `from_string` behavior
- [x] `tests/parsing/test_semantic_model_parsing.py::test_semantic_model_node_relation_with_compiled_sql` — new parsing test for ephemeral model YAML
- [x] `tests/parsing/test_semantic_model_parsing.py::test_semantic_model_node_relation_parsing` — updated to also assert `compiled_sql is None` for non-ephemeral models