### PR TITLE
add future annotations for 3.14 compat

### DIFF
--- a/.changes/unreleased/Under the Hood-20260413-201639.yaml
+++ b/.changes/unreleased/Under the Hood-20260413-201639.yaml
@@ -1,0 +1,6 @@
+kind: Under the Hood
+body: Add annotations import to allow python 3.14 compatibility
+time: 2026-04-13T20:16:39.48598+05:30
+custom:
+    Author: ash2shukla
+    Issue: "12098"

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -44,4 +44,5 @@ runs:
     shell: bash
     run: |
       pip3 install "click<8.3.0"
+      pip3 install "virtualenv<21"
       pip3 install hatch

--- a/dbt_semantic_interfaces/implementations/element_config.py
+++ b/dbt_semantic_interfaces/implementations/element_config.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any, Dict
 
 from typing_extensions import override

--- a/dbt_semantic_interfaces/implementations/element_config.py
+++ b/dbt_semantic_interfaces/implementations/element_config.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from typing import Any, Dict
 
 from typing_extensions import override

--- a/dbt_semantic_interfaces/implementations/semantic_manifest.py
+++ b/dbt_semantic_interfaces/implementations/semantic_manifest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Dict, List, Tuple
 
 from typing_extensions import override


### PR DESCRIPTION
Resolves #12098

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.md for more information.
-->

### Description
As part of work to support 3.14 in dbt-core this PR adds annotations compatibility for PEP 593 in semantic layer for relevant modules. 

### Checklist

- [x] I have read [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md) and understand what's expected of me
- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] This PR includes tests, or tests are not required/relevant for this PR
- [x] I have run `changie new` to [create a changelog entry](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md#adding-a-changelog-entry)
