### PR TITLE
Fix changelog-existence workflow link to point to own CONTRIBUTING.md

### DIFF
--- a/.github/workflows/changelog-existence.yml
+++ b/.github/workflows/changelog-existence.yml
@@ -35,6 +35,6 @@ jobs:
   changelog:
     uses: dbt-labs/actions/.github/workflows/changelog-existence.yml@main
     with:
-      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/metricflow/blob/main/CONTRIBUTING.md).'
+      changelog_comment: 'Thank you for your pull request! We could not find a changelog entry for this change. For details on how to document a change, see [the contributing guide](https://github.com/dbt-labs/dbt-semantic-interfaces/blob/main/CONTRIBUTING.md).'
       skip_label: 'Skip Changelog'
     secrets: inherit


### PR DESCRIPTION
## Summary

The changelog-existence workflow's comment message links to MetricFlow's CONTRIBUTING.md (`dbt-labs/metricflow`) instead of this repo's own CONTRIBUTING.md (`dbt-labs/dbt-semantic-interfaces`). This fixes the URL to point to the correct repository.

## Test plan

- [x] Changes are cosmetic/config only — no behavior change
- [x] Verified patterns exist before fixing